### PR TITLE
feat: implement wallet connection status indicator (#173)

### DIFF
--- a/frontend/components/layout/Header.jsx
+++ b/frontend/components/layout/Header.jsx
@@ -4,13 +4,10 @@
  * Persistent top navigation bar. Includes:
  * - Logo / brand name
  * - Nav links (Dashboard, Explorer)
- * - Wallet connect / disconnect button
- * - Network indicator pill
+ * - WalletStatus indicator (connected/connecting/disconnected)
+ * - Network indicator pill (Testnet / Mainnet)
  *
  * TODO (contributor — medium, Issue #37):
- * - Implement useWallet() hook (Freighter integration)
- * - Show truncated address when connected
- * - Show network badge (Testnet / Mainnet)
  * - Add mobile hamburger menu
  * - Highlight active nav link
  */
@@ -19,31 +16,20 @@
 'use client';
 
 import Link from 'next/link';
-import Button from '../ui/Button';
-
-// TODO (contributor — Issue #37): replace with real wallet state
-const PLACEHOLDER_WALLET = {
-  isConnected: false,
-  address: null,
-  network: 'testnet',
-};
+import { useWallet } from '../../hooks/useWallet';
+import WalletStatus from '../ui/WalletStatus';
 
 export default function Header() {
-  const wallet = PLACEHOLDER_WALLET;
+  const wallet = useWallet();
 
-  const handleConnect = async () => {
-    // TODO (contributor — Issue #37):
-    // 1. Check if Freighter is installed (window.freighter)
-    // 2. Call freighter.requestAccess()
-    // 3. Get public key: freighter.getPublicKey()
-    // 4. Store in wallet context
-    console.log('TODO: connect Freighter — see Issue #37');
-  };
-
-  const handleDisconnect = () => {
-    // TODO (contributor — Issue #37)
-    console.log('TODO: disconnect wallet');
-  };
+  // Determine network label & style from wallet state
+  const networkLabel = wallet.network === 'mainnet' ? 'Mainnet' : 'Testnet';
+  const networkStyles =
+    wallet.network === 'mainnet'
+      ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20'
+      : 'bg-amber-500/10 text-amber-400 border-amber-500/20';
+  const networkDotStyles =
+    wallet.network === 'mainnet' ? 'bg-emerald-400' : 'bg-amber-400 animate-pulse';
 
   return (
     <header className="border-b border-gray-800 bg-gray-950/80 backdrop-blur-sm sticky top-0 z-50">
@@ -78,35 +64,17 @@ export default function Header() {
 
           {/* Right Side */}
           <div className="flex items-center gap-3">
-            {/* Network Badge */}
-            {/*
-              TODO (contributor — Issue #37):
-              Show real network from wallet context.
-              Style differently for mainnet (green) vs testnet (amber).
-            */}
-            <span className="hidden sm:flex items-center gap-1.5 text-xs bg-amber-500/10 text-amber-400 border border-amber-500/20 px-2.5 py-1 rounded-full">
-              <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
-              Testnet
+            {/* Network Badge — shows real network when wallet is connected */}
+            <span
+              id="network-badge"
+              className={`hidden sm:flex items-center gap-1.5 text-xs border px-2.5 py-1 rounded-full transition-colors duration-300 ${networkStyles}`}
+            >
+              <span className={`w-1.5 h-1.5 rounded-full ${networkDotStyles}`} />
+              {networkLabel}
             </span>
 
-            {/* Wallet Button */}
-            {wallet.isConnected ? (
-              <div className="flex items-center gap-2">
-                <Link
-                  href={`/profile/${wallet.address}`}
-                  className="text-sm font-mono text-indigo-400 hover:text-indigo-300 hidden sm:block"
-                >
-                  {wallet.address?.slice(0, 6)}...{wallet.address?.slice(-4)}
-                </Link>
-                <Button variant="secondary" size="sm" onClick={handleDisconnect}>
-                  Disconnect
-                </Button>
-              </div>
-            ) : (
-              <Button variant="primary" size="sm" onClick={handleConnect}>
-                Connect Wallet
-              </Button>
-            )}
+            {/* Wallet Status */}
+            <WalletStatus wallet={wallet} />
           </div>
         </div>
       </div>

--- a/frontend/components/ui/WalletStatus.jsx
+++ b/frontend/components/ui/WalletStatus.jsx
@@ -1,0 +1,189 @@
+'use client';
+
+/**
+ * WalletStatus Component
+ *
+ * Displays the current Freighter wallet connection state in the header:
+ *
+ * - Disconnected → "Connect Wallet" button
+ * - Connecting   → spinner + "Connecting…" button
+ * - Connected    → status badge (green dot) + truncated address with tooltip
+ *                  showing the full address on hover + "Disconnect" button
+ *
+ * Props match the object returned by useWallet():
+ *
+ * @param {{ isConnected, isConnecting, isFreighterInstalled, address, network, connect, disconnect, error }} wallet
+ */
+
+import { useState } from 'react';
+import Button from './Button';
+import Spinner from './Spinner';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Truncate a Stellar address to first 6 + last 4 chars.
+ * e.g. GABCDEF...XY12
+ */
+function truncateAddress(address) {
+  if (!address) return '';
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+// ── Status Dot ────────────────────────────────────────────────────────────────
+
+function StatusDot({ status }) {
+  const styles = {
+    connected:    'bg-emerald-400 shadow-[0_0_6px_1px_rgba(52,211,153,0.7)]',
+    disconnected: 'bg-gray-500',
+    connecting:   'bg-amber-400 animate-pulse',
+  };
+  return (
+    <span
+      className={`inline-block w-2 h-2 rounded-full shrink-0 transition-colors duration-300 ${styles[status]}`}
+      aria-label={`Wallet ${status}`}
+    />
+  );
+}
+
+// ── Address Tooltip ───────────────────────────────────────────────────────────
+
+function AddressWithTooltip({ address }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch { /* ignore */ }
+  };
+
+  return (
+    <div className="relative group">
+      <button
+        id="wallet-address-display"
+        onClick={handleCopy}
+        className="font-mono text-sm text-indigo-400 hover:text-indigo-300 transition-colors focus:outline-none focus:ring-1 focus:ring-indigo-500 rounded px-1"
+        aria-label="Copy wallet address"
+        title="Click to copy"
+      >
+        {truncateAddress(address)}
+      </button>
+
+      {/* Tooltip */}
+      <div
+        role="tooltip"
+        className="absolute left-1/2 -translate-x-1/2 top-full mt-2 z-50
+                   invisible opacity-0 group-hover:visible group-hover:opacity-100
+                   transition-all duration-150 pointer-events-none"
+      >
+        <div className="bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 shadow-xl whitespace-nowrap">
+          <p className="text-xs text-gray-400 mb-1">Full address</p>
+          <p className="font-mono text-xs text-white break-all">{address}</p>
+          <p className="text-xs text-gray-500 mt-1">{copied ? '✅ Copied!' : 'Click to copy'}</p>
+          {/* Arrow */}
+          <span className="absolute -top-1.5 left-1/2 -translate-x-1/2 w-3 h-3 rotate-45 bg-gray-800 border-l border-t border-gray-700" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Not Installed Banner ──────────────────────────────────────────────────────
+
+function FreighterNotInstalled() {
+  return (
+    <a
+      href="https://freighter.app"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-xs text-amber-400 border border-amber-500/30 bg-amber-500/10
+                 px-3 py-1.5 rounded-lg hover:bg-amber-500/20 transition-colors"
+    >
+      Install Freighter ↗
+    </a>
+  );
+}
+
+// ── Main Component ────────────────────────────────────────────────────────────
+
+export default function WalletStatus({ wallet }) {
+  const {
+    isConnected,
+    isConnecting,
+    isFreighterInstalled,
+    address,
+    connect,
+    disconnect,
+    error,
+  } = wallet;
+
+  // Not installed — prompt installation
+  if (!isFreighterInstalled) {
+    return (
+      <div className="flex items-center gap-2">
+        <StatusDot status="disconnected" />
+        <FreighterNotInstalled />
+      </div>
+    );
+  }
+
+  // Connecting (loading state)
+  if (isConnecting) {
+    return (
+      <div className="flex items-center gap-2">
+        <StatusDot status="connecting" />
+        <button
+          disabled
+          id="wallet-connecting-btn"
+          className="inline-flex items-center gap-2 text-sm bg-gray-800 border border-gray-700
+                     text-gray-400 px-3 py-1.5 rounded-lg opacity-80 cursor-not-allowed"
+        >
+          <Spinner className="w-3.5 h-3.5" />
+          Connecting…
+        </button>
+      </div>
+    );
+  }
+
+  // Connected
+  if (isConnected && address) {
+    return (
+      <div className="flex items-center gap-2">
+        <StatusDot status="connected" />
+        <AddressWithTooltip address={address} />
+        <Button
+          id="wallet-disconnect-btn"
+          variant="secondary"
+          size="sm"
+          onClick={disconnect}
+        >
+          Disconnect
+        </Button>
+      </div>
+    );
+  }
+
+  // Disconnected (default)
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <div className="flex items-center gap-2">
+        <StatusDot status="disconnected" />
+        <Button
+          id="wallet-connect-btn"
+          variant="primary"
+          size="sm"
+          onClick={connect}
+        >
+          Connect Wallet
+        </Button>
+      </div>
+      {error && (
+        <p className="text-xs text-red-400 max-w-[200px] text-right truncate" title={error}>
+          ⚠️ {error}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
- Add WalletStatus.jsx component covering all states:
  - Not installed: Freighter install prompt link
  - Disconnected: 'Connect Wallet' button + error display
  - Connecting: spinner + disabled 'Connecting…' button
  - Connected: green animated status dot + truncated address (first 6...last 4 chars) with full-address tooltip on hover and click-to-copy functionality + Disconnect button
- Update Header.jsx:
  - Wire in useWallet() hook (replaces PLACEHOLDER_WALLET)
  - Render <WalletStatus> in place of hardcoded connect button
  - Network badge now reflects real connected network (mainnet = green, testnet = amber animated dot)

Closes #173