### PR TITLE
feat: #115 add comprehensive API response compression

### DIFF
--- a/backend/lib/metrics.js
+++ b/backend/lib/metrics.js
@@ -130,4 +130,28 @@ export const errorsTotal = new client.Counter({
   registers: [register],
 });
 
+// ── Compression Metrics ───────────────────────────────────────────────────────
+
+export const compressedResponsesTotal = new client.Counter({
+  name: 'http_compressed_responses_total',
+  help: 'Total number of compressed HTTP responses',
+  labelNames: ['algorithm', 'route'],
+  registers: [register],
+});
+
+export const compressionBytesTotal = new client.Counter({
+  name: 'http_compression_bytes_total',
+  help: 'Total bytes before and after compression',
+  labelNames: ['direction', 'algorithm'], // direction: original | compressed
+  registers: [register],
+});
+
+export const compressionRatio = new client.Histogram({
+  name: 'http_compression_ratio',
+  help: 'Ratio of compressed size to original size (lower is better)',
+  labelNames: ['algorithm', 'route'],
+  buckets: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
+  registers: [register],
+});
+
 export { register };

--- a/backend/middleware/compression.js
+++ b/backend/middleware/compression.js
@@ -1,0 +1,159 @@
+/**
+ * Compression Middleware
+ *
+ * Applies gzip and brotli compression to API responses.
+ *
+ * Strategy:
+ *  - Brotli is preferred when the client advertises `br` in Accept-Encoding
+ *    (better ratio, ~20-26% smaller than gzip on JSON payloads).
+ *  - Falls back to gzip for all other clients.
+ *  - Skips compression for small responses (< COMPRESSION_THRESHOLD bytes)
+ *    to avoid CPU overhead with no meaningful size benefit.
+ *  - Compression level is tunable via env vars so staging/prod can trade
+ *    CPU for ratio independently.
+ *
+ * Env vars:
+ *  COMPRESSION_LEVEL      gzip level 1-9  (default: 6)
+ *  BROTLI_QUALITY         brotli quality 0-11 (default: 4)
+ *  COMPRESSION_THRESHOLD  min bytes to compress (default: 1024)
+ */
+
+/* eslint-disable no-undef */
+import zlib from 'zlib';
+import compression from 'compression';
+import { compressionRatio, compressedResponsesTotal, compressionBytesTotal } from '../lib/metrics.js';
+
+const GZIP_LEVEL = parseInt(process.env.COMPRESSION_LEVEL || '6');
+const BROTLI_QUALITY = parseInt(process.env.BROTLI_QUALITY || '4');
+const THRESHOLD = parseInt(process.env.COMPRESSION_THRESHOLD || '1024');
+
+/**
+ * Decide whether to compress this response.
+ * Skips: /metrics endpoint, already-compressed content types, small payloads.
+ */
+function shouldCompress(req, res) {
+  // Never compress the Prometheus scrape endpoint
+  if (req.path === '/metrics') return false;
+
+  const contentType = res.getHeader('Content-Type') || '';
+  // Skip already-compressed formats
+  if (/image|audio|video|zip|gzip|br|compress/.test(contentType)) return false;
+
+  return compression.filter(req, res);
+}
+
+/**
+ * Wraps res.write / res.end to track original vs compressed byte counts
+ * and emit Prometheus metrics on finish.
+ */
+function wrapResponseForMetrics(req, res) {
+  let originalBytes = 0;
+  let compressedBytes = 0;
+
+  const origWrite = res.write.bind(res);
+  const origEnd = res.end.bind(res);
+
+  res.write = function (chunk, ...args) {
+    if (chunk) originalBytes += Buffer.byteLength(chunk);
+    return origWrite(chunk, ...args);
+  };
+
+  res.end = function (chunk, ...args) {
+    if (chunk) originalBytes += Buffer.byteLength(chunk);
+    return origEnd(chunk, ...args);
+  };
+
+  res.on('finish', () => {
+    const encoding = res.getHeader('Content-Encoding');
+    if (!encoding) return; // not compressed
+
+    // Content-Length reflects compressed size after compression middleware runs
+    const cl = res.getHeader('Content-Length');
+    compressedBytes = cl ? parseInt(cl) : originalBytes;
+
+    const algorithm = encoding === 'br' ? 'brotli' : encoding; // 'gzip' | 'deflate' | 'brotli'
+    const route = req.route ? (req.baseUrl || '') + req.route.path : req.path;
+
+    compressedResponsesTotal.inc({ algorithm, route });
+    compressionBytesTotal.inc({ direction: 'original', algorithm }, originalBytes);
+    compressionBytesTotal.inc({ direction: 'compressed', algorithm }, compressedBytes);
+
+    if (originalBytes > 0) {
+      compressionRatio.observe({ algorithm, route }, compressedBytes / originalBytes);
+    }
+  });
+}
+
+/**
+ * Brotli compression middleware (manual, since `compression` package only
+ * handles gzip/deflate natively).
+ */
+function brotliMiddleware(req, res, next) {
+  const acceptEncoding = req.headers['accept-encoding'] || '';
+  if (!acceptEncoding.includes('br')) return next();
+
+  const contentLength = parseInt(res.getHeader('Content-Length') || '0');
+  if (contentLength > 0 && contentLength < THRESHOLD) return next();
+
+  const origWrite = res.write.bind(res);
+  const origEnd = res.end.bind(res);
+
+  const brotli = zlib.createBrotliCompress({
+    params: { [zlib.constants.BROTLI_PARAM_QUALITY]: BROTLI_QUALITY },
+  });
+
+  let headersSent = false;
+
+  function patchHeaders() {
+    if (headersSent) return;
+    headersSent = true;
+    res.setHeader('Content-Encoding', 'br');
+    res.removeHeader('Content-Length'); // length changes after compression
+    res.setHeader('Vary', 'Accept-Encoding');
+  }
+
+  res.write = function (chunk, encoding, callback) {
+    patchHeaders();
+    return brotli.write(chunk, encoding, callback);
+  };
+
+  res.end = function (chunk, encoding, callback) {
+    patchHeaders();
+    if (chunk) brotli.write(chunk, encoding);
+    brotli.end();
+
+    brotli.on('data', (compressed) => origWrite(compressed));
+    brotli.on('end', () => origEnd(null, null, callback));
+    brotli.on('error', (err) => {
+      console.error('[Compression] Brotli error:', err.message);
+      origEnd(chunk, encoding, callback);
+    });
+  };
+
+  next();
+}
+
+/**
+ * Gzip middleware via the `compression` package.
+ */
+const gzipMiddleware = compression({
+  level: GZIP_LEVEL,
+  threshold: THRESHOLD,
+  filter: shouldCompress,
+});
+
+/**
+ * Combined compression middleware.
+ * Brotli is attempted first; if the client doesn't support it, gzip takes over.
+ */
+export default function compressionMiddleware(req, res, next) {
+  wrapResponseForMetrics(req, res);
+
+  const acceptEncoding = req.headers['accept-encoding'] || '';
+  if (acceptEncoding.includes('br')) {
+    return brotliMiddleware(req, res, next);
+  }
+  return gzipMiddleware(req, res, next);
+}
+
+export { GZIP_LEVEL, BROTLI_QUALITY, THRESHOLD };

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 import 'dotenv/config';
-import compression from 'compression';
+import compressionMiddleware from './middleware/compression.js';
 import cors from 'cors';
 import express from 'express';
 import helmet from 'helmet';
@@ -33,7 +33,7 @@ const app = express();
 const PORT = process.env.PORT || 4000;
 
 app.use(helmet());
-app.use(compression());
+app.use(compressionMiddleware);
 app.use(metricsMiddleware);
 app.use(responseTime);
 app.use(

--- a/backend/tests/compression.test.js
+++ b/backend/tests/compression.test.js
@@ -1,0 +1,147 @@
+/**
+ * Compression Middleware Tests
+ *
+ * Verifies that:
+ *  - Gzip is applied when client sends Accept-Encoding: gzip
+ *  - Brotli is applied when client sends Accept-Encoding: br
+ *  - No compression when client omits Accept-Encoding
+ *  - Small payloads below threshold are not compressed
+ *  - /metrics endpoint is never compressed
+ *  - Vary: Accept-Encoding header is set on compressed responses
+ */
+
+import { jest } from '@jest/globals';
+import zlib from 'zlib';
+import { promisify } from 'util';
+
+const gunzip = promisify(zlib.gunzip);
+const brotliDecompress = promisify(zlib.brotliDecompress);
+
+// ── Mock metrics so the middleware can be imported without a real registry ────
+jest.unstable_mockModule('../lib/metrics.js', () => ({
+  compressedResponsesTotal: { inc: jest.fn() },
+  compressionBytesTotal: { inc: jest.fn() },
+  compressionRatio: { observe: jest.fn() },
+  httpRequestDuration: { observe: jest.fn() },
+  httpRequestTotal: { inc: jest.fn() },
+  httpRequestsInFlight: { inc: jest.fn(), dec: jest.fn() },
+  errorsTotal: { inc: jest.fn() },
+  register: { metrics: jest.fn().mockResolvedValue('') },
+}));
+
+const { default: compressionMiddleware, THRESHOLD } = await import('../middleware/compression.js');
+
+// ── Minimal Express-like test harness ─────────────────────────────────────────
+
+import express from 'express';
+import supertest from 'supertest';
+
+/** Build a minimal app with a single JSON route returning `size` bytes. */
+function buildApp(payloadSize = 4096) {
+  const app = express();
+  app.use(compressionMiddleware);
+
+  app.get('/data', (_req, res) => {
+    // Generate a compressible JSON payload of roughly `payloadSize` bytes
+    const data = { items: Array.from({ length: payloadSize / 20 }, (_, i) => ({ id: i, value: 'x'.repeat(10) }) ) };
+    res.json(data);
+  });
+
+  app.get('/metrics', (_req, res) => {
+    res.type('text/plain').send('# prometheus metrics');
+  });
+
+  app.get('/tiny', (_req, res) => {
+    res.json({ ok: true }); // well below threshold
+  });
+
+  return app;
+}
+
+describe('Compression middleware', () => {
+  const app = buildApp(8192);
+
+  it('compresses with gzip when Accept-Encoding: gzip', async () => {
+    const res = await supertest(app)
+      .get('/data')
+      .set('Accept-Encoding', 'gzip');
+
+    expect(res.headers['content-encoding']).toBe('gzip');
+    expect(res.headers['vary']).toMatch(/Accept-Encoding/i);
+
+    // Verify the body is valid gzip and decompresses to JSON
+    const decompressed = await gunzip(res.body);
+    const parsed = JSON.parse(decompressed.toString());
+    expect(parsed).toHaveProperty('items');
+  });
+
+  it('compresses with brotli when Accept-Encoding: br', async () => {
+    const res = await supertest(app)
+      .get('/data')
+      .set('Accept-Encoding', 'br')
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => callback(null, Buffer.concat(chunks)));
+      });
+
+    expect(res.headers['content-encoding']).toBe('br');
+    expect(res.headers['vary']).toMatch(/Accept-Encoding/i);
+
+    const decompressed = await brotliDecompress(res.body);
+    const parsed = JSON.parse(decompressed.toString());
+    expect(parsed).toHaveProperty('items');
+  });
+
+  it('prefers brotli over gzip when both are advertised', async () => {
+    const res = await supertest(app)
+      .get('/data')
+      .set('Accept-Encoding', 'gzip, deflate, br')
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => callback(null, Buffer.concat(chunks)));
+      });
+
+    expect(res.headers['content-encoding']).toBe('br');
+  });
+
+  it('does not compress when Accept-Encoding is absent', async () => {
+    const res = await supertest(app)
+      .get('/data')
+      .set('Accept-Encoding', '');
+
+    expect(res.headers['content-encoding']).toBeUndefined();
+  });
+
+  it('does not compress the /metrics endpoint', async () => {
+    const res = await supertest(app)
+      .get('/metrics')
+      .set('Accept-Encoding', 'gzip, br');
+
+    expect(res.headers['content-encoding']).toBeUndefined();
+  });
+
+  it('does not compress payloads below the threshold', async () => {
+    const res = await supertest(app)
+      .get('/tiny')
+      .set('Accept-Encoding', 'gzip');
+
+    // Small payload — compression should be skipped
+    expect(res.headers['content-encoding']).toBeUndefined();
+  });
+
+  it('compressed response is smaller than uncompressed', async () => {
+    const [compressed, plain] = await Promise.all([
+      supertest(app).get('/data').set('Accept-Encoding', 'gzip').buffer(true),
+      supertest(app).get('/data').set('Accept-Encoding', '').buffer(true),
+    ]);
+
+    const compressedSize = compressed.body.length;
+    const plainSize = plain.body.length || Buffer.byteLength(plain.text || '');
+
+    expect(compressedSize).toBeLessThan(plainSize);
+  });
+});


### PR DESCRIPTION
closes #286
- Add middleware/compression.js with gzip and brotli support
- Brotli preferred when client advertises br in Accept-Encoding
- Configurable via COMPRESSION_LEVEL, BROTLI_QUALITY, COMPRESSION_THRESHOLD env vars
- Skip compression for /metrics endpoint and payloads below threshold
- Add Prometheus metrics: compressed_responses_total, compression_bytes_total, compression_ratio
- Update server.js to use new compressionMiddleware
- Add tests/compression.test.js with 7 test cases

## Description

<!-- What does this PR change and why? -->

## Related Issue

Closes #<!-- issue number -->

## Type of Change

- [ ] 🦀 Smart contract (Rust/Soroban)
- [ ] 🖥️ Backend (Node.js)
- [ ] 🎨 Frontend (Next.js/React)
- [ ] 📚 Documentation
- [ ] 🧪 Tests
- [ ] 🐛 Bug fix

## Checklist

- [ ] Branch is up to date with `main`
- [ ] Contract: `cargo fmt` + `cargo clippy -- -D warnings` pass
- [ ] Backend: `npm run lint` passes
- [ ] Frontend: `npm run lint` passes
- [ ] Tests added for new functionality
- [ ] PR description clearly explains the change
- [ ] Linked the issue with `Closes #N`
