### PR TITLE
feat: implement distributed tracing with OpenTelemetry + Jaeger

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -55,3 +55,11 @@ USDC_ISSUER=
 SLOW_REQUEST_THRESHOLD_MS=500
 SLOW_QUERY_THRESHOLD_MS=200
 METRICS_TOKEN=
+
+# ── Distributed Tracing (OpenTelemetry + Jaeger) ──────────────────────────────
+# Set to "false" to disable tracing (e.g. in unit tests)
+TRACING_ENABLED=true
+# OTLP HTTP endpoint — Jaeger all-in-one listens on port 4318
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+OTEL_SERVICE_NAME=stellar-trust-escrow
+OTEL_ENVIRONMENT=development

--- a/backend/lib/prismaTracing.js
+++ b/backend/lib/prismaTracing.js
@@ -1,0 +1,57 @@
+/**
+ * Prisma Distributed Tracing
+ *
+ * Attaches a Prisma middleware that creates an OTel child span for every
+ * database query, recording model, operation, and duration.
+ *
+ * Works alongside prismaMetrics.js — both middlewares can be attached.
+ *
+ * @module lib/prismaTracing
+ */
+
+/* eslint-disable no-undef */
+import { getTracer } from './tracing.js';
+import { SpanStatusCode } from '@opentelemetry/api';
+
+const SLOW_QUERY_THRESHOLD_MS = parseInt(process.env.SLOW_QUERY_THRESHOLD_MS || '200');
+
+/**
+ * @param {import('@prisma/client').PrismaClient} prisma
+ */
+export function attachPrismaTracing(prisma) {
+  prisma.$use(async (params, next) => {
+    const tracer = getTracer('prisma');
+    const spanName = `db.${params.model ?? 'unknown'}.${params.action ?? 'unknown'}`;
+
+    return tracer.startActiveSpan(
+      spanName,
+      {
+        attributes: {
+          'db.system': 'postgresql',
+          'db.operation': params.action ?? 'unknown',
+          'db.sql.table': params.model ?? 'unknown',
+        },
+      },
+      async (span) => {
+        const start = Date.now();
+        try {
+          const result = await next(params);
+          const durationMs = Date.now() - start;
+
+          span.setAttributes({
+            'db.duration_ms': durationMs,
+            'db.slow_query': durationMs > SLOW_QUERY_THRESHOLD_MS,
+          });
+          span.setStatus({ code: SpanStatusCode.OK });
+          return result;
+        } catch (err) {
+          span.recordException(err);
+          span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+          throw err;
+        } finally {
+          span.end();
+        }
+      },
+    );
+  });
+}

--- a/backend/lib/tracing.js
+++ b/backend/lib/tracing.js
@@ -1,0 +1,148 @@
+/**
+ * OpenTelemetry Distributed Tracing
+ *
+ * Initialises the OTel SDK with:
+ *  - OTLP/HTTP exporter → Jaeger (or any OTLP-compatible backend)
+ *  - Auto-instrumentation for HTTP, Express, and fetch
+ *  - W3C TraceContext + Baggage propagators
+ *
+ * MUST be imported before any other module in server.js so that
+ * auto-instrumentation patches are applied at startup.
+ *
+ * Environment variables:
+ *  OTEL_EXPORTER_OTLP_ENDPOINT  — default: http://localhost:4318
+ *  OTEL_SERVICE_NAME            — default: stellar-trust-escrow
+ *  OTEL_ENVIRONMENT             — default: development
+ *  TRACING_ENABLED              — set to "false" to disable (e.g. in tests)
+ *
+ * @module lib/tracing
+ */
+
+/* eslint-disable no-undef */
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { Resource } from '@opentelemetry/resources';
+import { SEMRESATTRS_SERVICE_NAME, SEMRESATTRS_DEPLOYMENT_ENVIRONMENT } from '@opentelemetry/semantic-conventions';
+import { W3CTraceContextPropagator, CompositePropagator, W3CBaggagePropagator } from '@opentelemetry/core';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { trace, context, SpanStatusCode, propagation } from '@opentelemetry/api';
+
+const SERVICE_NAME = process.env.OTEL_SERVICE_NAME || 'stellar-trust-escrow';
+const ENVIRONMENT = process.env.OTEL_ENVIRONMENT || process.env.NODE_ENV || 'development';
+const OTLP_ENDPOINT = process.env.OTEL_EXPORTER_OTLP_ENDPOINT || 'http://localhost:4318';
+const TRACING_ENABLED = process.env.TRACING_ENABLED !== 'false';
+
+let sdk = null;
+
+/**
+ * Initialise and start the OTel SDK.
+ * Safe to call multiple times — subsequent calls are no-ops.
+ */
+export function initTracing() {
+  if (!TRACING_ENABLED || sdk) return;
+
+  const exporter = new OTLPTraceExporter({
+    url: `${OTLP_ENDPOINT}/v1/traces`,
+    headers: {},
+  });
+
+  sdk = new NodeSDK({
+    resource: new Resource({
+      [SEMRESATTRS_SERVICE_NAME]: SERVICE_NAME,
+      [SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: ENVIRONMENT,
+    }),
+    traceExporter: exporter,
+    spanProcessor: new BatchSpanProcessor(exporter, {
+      maxQueueSize: 512,
+      scheduledDelayMillis: 2000,
+    }),
+    textMapPropagator: new CompositePropagator({
+      propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
+    }),
+    instrumentations: [
+      getNodeAutoInstrumentations({
+        '@opentelemetry/instrumentation-fs': { enabled: false }, // too noisy
+        '@opentelemetry/instrumentation-http': { enabled: true },
+        '@opentelemetry/instrumentation-express': { enabled: true },
+      }),
+    ],
+  });
+
+  sdk.start();
+  console.log(`[Tracing] OpenTelemetry started → ${OTLP_ENDPOINT} (service: ${SERVICE_NAME})`);
+
+  process.on('SIGTERM', () => shutdownTracing());
+  process.on('SIGINT', () => shutdownTracing());
+}
+
+/** Flush and shut down the SDK gracefully. */
+export async function shutdownTracing() {
+  if (!sdk) return;
+  try {
+    await sdk.shutdown();
+    console.log('[Tracing] SDK shut down cleanly');
+  } catch (err) {
+    console.error('[Tracing] Error during shutdown:', err.message);
+  }
+}
+
+/**
+ * Returns the tracer for a given instrumentation scope.
+ * @param {string} [name] - scope name, defaults to service name
+ */
+export function getTracer(name = SERVICE_NAME) {
+  return trace.getTracer(name, '1.0.0');
+}
+
+/**
+ * Wraps an async function in a named span.
+ * Automatically records exceptions and sets error status.
+ *
+ * @param {string} spanName
+ * @param {object} [attributes] - initial span attributes
+ * @param {Function} fn - async function receiving the active span
+ * @returns {Promise<*>}
+ *
+ * @example
+ * const result = await withSpan('stellarService.submitTransaction', { 'tx.hash': hash }, async (span) => {
+ *   // ... do work
+ *   return result;
+ * });
+ */
+export async function withSpan(spanName, attributes = {}, fn) {
+  if (!TRACING_ENABLED) return fn({ setAttribute: () => {}, setStatus: () => {}, recordException: () => {} });
+
+  const tracer = getTracer();
+  return tracer.startActiveSpan(spanName, { attributes }, async (span) => {
+    try {
+      const result = await fn(span);
+      span.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (err) {
+      span.recordException(err);
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/**
+ * Injects the current trace context into a headers object (for outbound HTTP).
+ * @param {object} headers - mutable headers map
+ */
+export function injectTraceContext(headers) {
+  propagation.inject(context.active(), headers);
+}
+
+/**
+ * Extracts trace context from incoming headers and returns an OTel Context.
+ * @param {object} headers
+ */
+export function extractTraceContext(headers) {
+  return propagation.extract(context.active(), headers);
+}
+
+export { SpanStatusCode, trace, context };

--- a/backend/middleware/tracingMiddleware.js
+++ b/backend/middleware/tracingMiddleware.js
@@ -1,0 +1,73 @@
+/**
+ * Tracing Middleware
+ *
+ * Enriches the active OTel span (created by auto-instrumentation) with
+ * HTTP-level attributes and propagates trace context on responses.
+ *
+ * Also attaches `req.span` so controllers/services can add custom attributes.
+ *
+ * @module middleware/tracingMiddleware
+ */
+
+/* eslint-disable no-undef */
+import { trace, SpanStatusCode } from '@opentelemetry/api';
+
+/**
+ * Normalize Express route path — replaces dynamic segments with placeholders
+ * to keep span name cardinality low.
+ */
+function normalizeRoute(req) {
+  if (req.route?.path) {
+    return (req.baseUrl || '') + req.route.path;
+  }
+  return req.path
+    .replace(/\/[0-9]+/g, '/:id')
+    .replace(/\/G[A-Z2-7]{55}/g, '/:address')
+    .replace(/\/[0-9a-f]{64}/gi, '/:hash');
+}
+
+export default function tracingMiddleware(req, res, next) {
+  // Skip tracing for internal endpoints
+  if (req.path === '/metrics' || req.path === '/health') return next();
+
+  const span = trace.getActiveSpan();
+  if (!span) return next();
+
+  // Attach span to request so downstream code can enrich it
+  req.span = span;
+
+  // Add HTTP semantic attributes
+  span.setAttributes({
+    'http.method': req.method,
+    'http.url': req.originalUrl,
+    'http.user_agent': req.headers['user-agent'] || '',
+    'http.request_id': req.headers['x-request-id'] || '',
+    'net.peer.ip': req.ip || req.socket?.remoteAddress || '',
+  });
+
+  // Propagate trace context to response headers for client-side correlation
+  const spanContext = span.spanContext();
+  if (spanContext.traceId) {
+    res.setHeader('X-Trace-Id', spanContext.traceId);
+    res.setHeader('X-Span-Id', spanContext.spanId);
+  }
+
+  res.on('finish', () => {
+    const route = normalizeRoute(req);
+    span.setAttributes({
+      'http.route': route,
+      'http.status_code': res.statusCode,
+    });
+
+    // Update span name to normalized route for better grouping in Jaeger
+    span.updateName(`${req.method} ${route}`);
+
+    if (res.statusCode >= 500) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: `HTTP ${res.statusCode}` });
+    } else if (res.statusCode >= 400) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: `HTTP ${res.statusCode}` });
+    }
+  });
+
+  next();
+}

--- a/backend/monitoring/docker-compose.yml
+++ b/backend/monitoring/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.8'
 
-# Local observability stack: Prometheus + Grafana
+# Local observability stack: Prometheus + Grafana + Jaeger
 # Run: docker compose -f backend/monitoring/docker-compose.yml up -d
 
 services:
@@ -28,6 +28,20 @@ services:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
     depends_on:
       - prometheus
+    restart: unless-stopped
+
+  # Jaeger all-in-one: trace storage + UI + OTLP collector
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    container_name: ste_jaeger
+    ports:
+      - '16686:16686'   # Jaeger UI
+      - '4317:4317'     # OTLP gRPC receiver
+      - '4318:4318'     # OTLP HTTP receiver (used by the backend)
+      - '14269:14269'   # Admin/health
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+      - SPAN_STORAGE_TYPE=memory
     restart: unless-stopped
 
 volumes:

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,14 @@
     "db:seed": "node database/seed.js"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.51.0",
+    "@opentelemetry/core": "^1.26.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.53.0",
+    "@opentelemetry/resources": "^1.26.0",
+    "@opentelemetry/sdk-node": "^0.53.0",
+    "@opentelemetry/sdk-trace-base": "^1.26.0",
+    "@opentelemetry/semantic-conventions": "^1.27.0",
     "@prisma/client": "^5.0.0",
     "@stellar/stellar-sdk": "^12.0.0",
     "compression": "^1.7.4",

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,4 +1,8 @@
 /* eslint-disable no-undef */
+import { initTracing } from './lib/tracing.js';
+// Tracing MUST be initialised before any other imports so auto-instrumentation patches apply
+initTracing();
+
 import 'dotenv/config';
 import compression from 'compression';
 import cors from 'cors';
@@ -19,15 +23,18 @@ import userRoutes from './api/routes/userRoutes.js';
 import auditRoutes from './api/routes/auditRoutes.js';
 import cache from './lib/cache.js';
 import { attachPrismaMetrics } from './lib/prismaMetrics.js';
+import { attachPrismaTracing } from './lib/prismaTracing.js';
 import prisma from './lib/prisma.js';
 import { errorsTotal } from './lib/metrics.js';
 import metricsMiddleware from './middleware/metricsMiddleware.js';
 import responseTime from './middleware/responseTime.js';
+import tracingMiddleware from './middleware/tracingMiddleware.js';
 import emailService from './services/emailService.js';
 import { startIndexer } from './services/eventIndexer.js';
 
-// Attach Prisma query instrumentation
+// Attach Prisma query instrumentation (metrics + traces)
 attachPrismaMetrics(prisma);
+attachPrismaTracing(prisma);
 
 const app = express();
 const PORT = process.env.PORT || 4000;
@@ -36,6 +43,7 @@ app.use(helmet());
 app.use(compression());
 app.use(metricsMiddleware);
 app.use(responseTime);
+app.use(tracingMiddleware);
 app.use(
   cors({
     origin: process.env.ALLOWED_ORIGINS?.split(',') || 'http://localhost:3000',

--- a/backend/services/auditService.js
+++ b/backend/services/auditService.js
@@ -9,6 +9,7 @@
 
 import { stringify } from 'csv-stringify/sync';
 import prisma from '../lib/prisma.js';
+import { withSpan } from '../lib/tracing.js';
 
 // ── Categories & Actions ──────────────────────────────────────────────────────
 
@@ -71,16 +72,21 @@ export const AuditAction = {
  */
 export async function log(entry) {
   try {
-    await prisma.auditLog.create({
-      data: {
-        category: entry.category,
-        action: entry.action,
-        actor: entry.actor,
-        resourceId: entry.resourceId ?? null,
-        metadata: entry.metadata ?? undefined,
-        statusCode: entry.statusCode ?? null,
-        ipAddress: entry.ipAddress ?? null,
-      },
+    await withSpan('auditService.log', {
+      'audit.category': entry.category,
+      'audit.action': entry.action,
+    }, async () => {
+      await prisma.auditLog.create({
+        data: {
+          category: entry.category,
+          action: entry.action,
+          actor: entry.actor,
+          resourceId: entry.resourceId ?? null,
+          metadata: entry.metadata ?? undefined,
+          statusCode: entry.statusCode ?? null,
+          ipAddress: entry.ipAddress ?? null,
+        },
+      });
     });
   } catch (err) {
     console.error('[AuditService] Failed to write audit log:', err.message);

--- a/backend/services/emailService.js
+++ b/backend/services/emailService.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url';
 import disputeRaisedTemplate from '../templates/emails/disputeRaised.js';
 import escrowStatusChangedTemplate from '../templates/emails/escrowStatusChanged.js';
 import milestoneCompletedTemplate from '../templates/emails/milestoneCompleted.js';
+import { withSpan } from '../lib/tracing.js';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -157,58 +158,61 @@ function pruneSentTimestamps() {
 }
 
 async function sendWithProvider(message) {
-  if (config.provider === 'console' || !config.sendgridApiKey) {
-    console.log('[EmailService] Console delivery', {
-      to: message.to.email,
-      subject: message.subject,
-      eventType: message.eventType,
-    });
-    return {
-      provider: 'console',
-      messageId: `console-${crypto.randomUUID()}`,
-    };
-  }
-
-  if (config.provider !== 'sendgrid') {
-    throw new Error(`Unsupported email provider: ${config.provider}`);
-  }
-
-  const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${config.sendgridApiKey}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      personalizations: [
-        {
-          to: [{ email: message.to.email, name: message.to.name }],
-          subject: message.subject,
-        },
-      ],
-      from: {
-        email: config.fromEmail,
-        name: config.fromName,
-      },
-      content: [
-        { type: 'text/plain', value: message.text },
-        { type: 'text/html', value: message.html },
-      ],
-      custom_args: {
+  return withSpan('emailService.sendWithProvider', {
+    'email.event_type': message.eventType,
+    'email.provider': config.provider,
+  }, async (span) => {
+    if (config.provider === 'console' || !config.sendgridApiKey) {
+      console.log('[EmailService] Console delivery', {
+        to: message.to.email,
+        subject: message.subject,
         eventType: message.eventType,
+      });
+      const messageId = `console-${crypto.randomUUID()}`;
+      span.setAttribute('email.message_id', messageId);
+      return { provider: 'console', messageId };
+    }
+
+    if (config.provider !== 'sendgrid') {
+      throw new Error(`Unsupported email provider: ${config.provider}`);
+    }
+
+    const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${config.sendgridApiKey}`,
+        'Content-Type': 'application/json',
       },
-    }),
+      body: JSON.stringify({
+        personalizations: [
+          {
+            to: [{ email: message.to.email, name: message.to.name }],
+            subject: message.subject,
+          },
+        ],
+        from: {
+          email: config.fromEmail,
+          name: config.fromName,
+        },
+        content: [
+          { type: 'text/plain', value: message.text },
+          { type: 'text/html', value: message.html },
+        ],
+        custom_args: {
+          eventType: message.eventType,
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`SendGrid request failed: ${response.status} ${errorText}`);
+    }
+
+    const messageId = response.headers.get('x-message-id') || `sendgrid-${crypto.randomUUID()}`;
+    span.setAttribute('email.message_id', messageId);
+    return { provider: 'sendgrid', messageId };
   });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`SendGrid request failed: ${response.status} ${errorText}`);
-  }
-
-  return {
-    provider: 'sendgrid',
-    messageId: response.headers.get('x-message-id') || `sendgrid-${crypto.randomUUID()}`,
-  };
 }
 
 async function processQueue() {
@@ -267,43 +271,44 @@ async function processQueue() {
 }
 
 async function enqueueEvent(eventType, payload) {
-  await loadState();
+  return withSpan('emailService.enqueueEvent', { 'email.event_type': eventType }, async (span) => {
+    await loadState();
 
-  const accepted = [];
-  const skipped = [];
+    const accepted = [];
+    const skipped = [];
 
-  for (const rawRecipient of payload.recipients || []) {
-    const email = assertEmail(rawRecipient.email);
-    const preference = await ensurePreference(email);
+    for (const rawRecipient of payload.recipients || []) {
+      const email = assertEmail(rawRecipient.email);
+      const preference = await ensurePreference(email);
 
-    if (preference.unsubscribedAt) {
-      skipped.push({ email, reason: 'unsubscribed' });
-      continue;
+      if (preference.unsubscribedAt) {
+        skipped.push({ email, reason: 'unsubscribed' });
+        continue;
+      }
+
+      const recipient = { ...rawRecipient, email };
+      const job = {
+        id: crypto.randomUUID(),
+        status: 'queued',
+        attempts: 0,
+        createdAt: nowIso(),
+        updatedAt: nowIso(),
+        availableAt: nowIso(),
+        message: buildMessage(eventType, payload, recipient, preference),
+      };
+
+      state.queue.push(job);
+      accepted.push({ id: job.id, email, eventType });
     }
 
-    const recipient = { ...rawRecipient, email };
-    const job = {
-      id: crypto.randomUUID(),
-      status: 'queued',
-      attempts: 0,
-      createdAt: nowIso(),
-      updatedAt: nowIso(),
-      availableAt: nowIso(),
-      message: buildMessage(eventType, payload, recipient, preference),
-    };
+    await persistState();
+    await processQueue();
 
-    state.queue.push(job);
-    accepted.push({ id: job.id, email, eventType });
-  }
+    span.setAttribute('email.queued_count', accepted.length);
+    span.setAttribute('email.skipped_count', skipped.length);
 
-  await persistState();
-  await processQueue();
-
-  return {
-    queued: accepted.length,
-    accepted,
-    skipped,
-  };
+    return { queued: accepted.length, accepted, skipped };
+  });
 }
 
 async function unsubscribe(email, token, reason = 'user_request') {

--- a/backend/services/eventIndexer.js
+++ b/backend/services/eventIndexer.js
@@ -29,6 +29,7 @@
 
 import prisma from '../lib/prisma.js';
 import { getContractEvents, getLatestLedger } from './stellarService.js';
+import { withSpan, getTracer } from '../lib/tracing.js';
 
 const CONTRACT_ID = process.env.ESCROW_CONTRACT_ID || '';
 const POLL_INTERVAL_MS = parseInt(process.env.INDEXER_POLL_INTERVAL_MS || '5000', 10);
@@ -377,14 +378,19 @@ const dispatchEvent = async (rawEvent) => {
     contractId: rawEvent.contractId,
   };
 
-  try {
-    await handler(rawEvent, meta);
-  } catch (err) {
-    // Unique constraint violation = already indexed, safe to skip
-    if (err.code === 'P2002') return;
-    console.error(`[Indexer] Failed to handle ${eventType}:`, err.message);
-    throw err;
-  }
+  await withSpan(`eventIndexer.dispatch.${eventType}`, {
+    'indexer.event_type': eventType,
+    'indexer.ledger': rawEvent.ledger,
+    'indexer.tx_hash': rawEvent.txHash ?? '',
+  }, async () => {
+    try {
+      await handler(rawEvent, meta);
+    } catch (err) {
+      if (err.code === 'P2002') return;
+      console.error(`[Indexer] Failed to handle ${eventType}:`, err.message);
+      throw err;
+    }
+  });
 };
 
 // ─── Core loop ────────────────────────────────────────────────────────────────
@@ -396,23 +402,28 @@ const dispatchEvent = async (rawEvent) => {
  * @returns {Promise<number>} the latest ledger sequence processed
  */
 const fetchAndProcessEvents = async (fromLedger) => {
-  if (!CONTRACT_ID) {
-    console.warn('[Indexer] ESCROW_CONTRACT_ID not set — skipping fetch');
-    return fromLedger;
-  }
+  return withSpan('eventIndexer.fetchAndProcessEvents', { 'indexer.from_ledger': fromLedger }, async (span) => {
+    if (!CONTRACT_ID) {
+      console.warn('[Indexer] ESCROW_CONTRACT_ID not set — skipping fetch');
+      return fromLedger;
+    }
 
-  const events = await getContractEvents(fromLedger, CONTRACT_ID);
-  const latestLedger = await getLatestLedger();
+    const events = await getContractEvents(fromLedger, CONTRACT_ID);
+    const latestLedger = await getLatestLedger();
 
-  for (const event of events) {
-    await dispatchEvent(event);
-  }
+    span.setAttribute('indexer.events_count', events.length);
+    span.setAttribute('indexer.latest_ledger', latestLedger);
 
-  if (events.length > 0) {
-    console.log(`[Indexer] Processed ${events.length} events up to ledger ${latestLedger}`);
-  }
+    for (const event of events) {
+      await dispatchEvent(event);
+    }
 
-  return latestLedger;
+    if (events.length > 0) {
+      console.log(`[Indexer] Processed ${events.length} events up to ledger ${latestLedger}`);
+    }
+
+    return latestLedger;
+  });
 };
 
 /**

--- a/backend/services/kycService.js
+++ b/backend/services/kycService.js
@@ -8,6 +8,7 @@
 
 import crypto from 'crypto';
 import prisma from '../lib/prisma.js';
+import { withSpan } from '../lib/tracing.js';
 
 const {
   SUMSUB_APP_TOKEN,
@@ -48,31 +49,43 @@ async function sumsubFetch(method, path, body) {
 
 /** Create or retrieve a Sumsub applicant for the given Stellar address. */
 async function getOrCreateApplicant(address) {
-  let record = await prisma.kycVerification.findUnique({ where: { address } });
+  return withSpan('kycService.getOrCreateApplicant', { 'kyc.address': address }, async (span) => {
+    let record = await prisma.kycVerification.findUnique({ where: { address } });
 
-  if (record?.applicantId) return record;
+    if (record?.applicantId) {
+      span.setAttribute('kyc.applicant_id', record.applicantId);
+      span.setAttribute('kyc.cache_hit', true);
+      return record;
+    }
 
-  const applicant = await sumsubFetch('POST', '/resources/applicants?levelName=' + LEVEL_NAME, {
-    externalUserId: address,
+    const applicant = await sumsubFetch('POST', '/resources/applicants?levelName=' + LEVEL_NAME, {
+      externalUserId: address,
+    });
+
+    span.setAttribute('kyc.applicant_id', applicant.id);
+    span.setAttribute('kyc.cache_hit', false);
+
+    record = await prisma.kycVerification.upsert({
+      where: { address },
+      update: { applicantId: applicant.id, status: 'Init' },
+      create: { address, applicantId: applicant.id, status: 'Init' },
+    });
+
+    return record;
   });
-
-  record = await prisma.kycVerification.upsert({
-    where: { address },
-    update: { applicantId: applicant.id, status: 'Init' },
-    create: { address, applicantId: applicant.id, status: 'Init' },
-  });
-
-  return record;
 }
 
 /** Generate a short-lived SDK access token for the frontend widget. */
 async function generateSdkToken(address) {
-  const record = await getOrCreateApplicant(address);
-  const data = await sumsubFetch(
-    'POST',
-    `/resources/accessTokens?userId=${record.applicantId}&levelName=${LEVEL_NAME}`,
-  );
-  return { token: data.token, applicantId: record.applicantId };
+  return withSpan('kycService.generateSdkToken', { 'kyc.address': address }, async (span) => {
+    const record = await getOrCreateApplicant(address);
+    const data = await sumsubFetch(
+      'POST',
+      `/resources/accessTokens?userId=${record.applicantId}&levelName=${LEVEL_NAME}`,
+    );
+    span.setAttribute('kyc.applicant_id', record.applicantId);
+    return { token: data.token, applicantId: record.applicantId };
+  });
 }
 
 /** Get current KYC status for an address (from DB, not Sumsub). */
@@ -95,32 +108,37 @@ async function listAll({ skip = 0, take = 20, status } = {}) {
  * Returns the updated record.
  */
 async function handleWebhook(payload) {
-  const { externalUserId, applicantId, type, reviewResult } = payload;
+  return withSpan('kycService.handleWebhook', { 'kyc.event_type': payload.type }, async (span) => {
+    const { externalUserId, applicantId, type, reviewResult } = payload;
 
-  const statusMap = {
-    applicantCreated: 'Init',
-    applicantPending: 'Processing',
-    applicantReviewed: reviewResult?.reviewAnswer === 'GREEN' ? 'Approved' : 'Declined',
-  };
+    const statusMap = {
+      applicantCreated: 'Init',
+      applicantPending: 'Processing',
+      applicantReviewed: reviewResult?.reviewAnswer === 'GREEN' ? 'Approved' : 'Declined',
+    };
 
-  const newStatus = statusMap[type];
-  if (!newStatus) return null; // unhandled event type
+    const newStatus = statusMap[type];
+    if (!newStatus) return null;
 
-  return prisma.kycVerification.upsert({
-    where: { address: externalUserId },
-    update: {
-      applicantId,
-      status: newStatus,
-      reviewResult: reviewResult?.reviewAnswer ?? null,
-      rejectLabels: reviewResult?.rejectLabels ?? [],
-    },
-    create: {
-      address: externalUserId,
-      applicantId,
-      status: newStatus,
-      reviewResult: reviewResult?.reviewAnswer ?? null,
-      rejectLabels: reviewResult?.rejectLabels ?? [],
-    },
+    span.setAttribute('kyc.new_status', newStatus);
+    span.setAttribute('kyc.applicant_id', applicantId);
+
+    return prisma.kycVerification.upsert({
+      where: { address: externalUserId },
+      update: {
+        applicantId,
+        status: newStatus,
+        reviewResult: reviewResult?.reviewAnswer ?? null,
+        rejectLabels: reviewResult?.rejectLabels ?? [],
+      },
+      create: {
+        address: externalUserId,
+        applicantId,
+        status: newStatus,
+        reviewResult: reviewResult?.reviewAnswer ?? null,
+        rejectLabels: reviewResult?.rejectLabels ?? [],
+      },
+    });
   });
 }
 

--- a/backend/services/paymentService.js
+++ b/backend/services/paymentService.js
@@ -10,6 +10,7 @@
 
 import Stripe from 'stripe';
 import prisma from '../lib/prisma.js';
+import { withSpan } from '../lib/tracing.js';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: '2024-04-10' });
 
@@ -38,40 +39,48 @@ async function getXlmUsdPrice() {
  * @returns {{ sessionId, url, paymentId }}
  */
 async function createCheckoutSession({ address, amountUsd, escrowId }) {
-  const amountCents = Math.round(amountUsd * 100);
+  return withSpan('paymentService.createCheckoutSession', {
+    'payment.amount_usd': amountUsd,
+    'payment.escrow_id': escrowId?.toString() ?? '',
+  }, async (span) => {
+    const amountCents = Math.round(amountUsd * 100);
 
-  const session = await stripe.checkout.sessions.create({
-    payment_method_types: ['card'],
-    mode: 'payment',
-    line_items: [
-      {
-        price_data: {
-          currency: 'usd',
-          unit_amount: amountCents,
-          product_data: {
-            name: 'Escrow Funding',
-            description: `Fund escrow on StellarTrustEscrow`,
+    const session = await stripe.checkout.sessions.create({
+      payment_method_types: ['card'],
+      mode: 'payment',
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            unit_amount: amountCents,
+            product_data: {
+              name: 'Escrow Funding',
+              description: `Fund escrow on StellarTrustEscrow`,
+            },
           },
+          quantity: 1,
         },
-        quantity: 1,
+      ],
+      metadata: { address, escrowId: escrowId?.toString() ?? '' },
+      success_url: `${process.env.FRONTEND_URL}/payment/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${process.env.FRONTEND_URL}/payment/cancel`,
+    });
+
+    span.setAttribute('payment.stripe_session_id', session.id);
+
+    const payment = await prisma.payment.create({
+      data: {
+        address,
+        escrowId: escrowId ? BigInt(escrowId) : null,
+        stripeSessionId: session.id,
+        amountFiat: amountCents,
+        status: 'Pending',
       },
-    ],
-    metadata: { address, escrowId: escrowId?.toString() ?? '' },
-    success_url: `${process.env.FRONTEND_URL}/payment/success?session_id={CHECKOUT_SESSION_ID}`,
-    cancel_url: `${process.env.FRONTEND_URL}/payment/cancel`,
-  });
+    });
 
-  const payment = await prisma.payment.create({
-    data: {
-      address,
-      escrowId: escrowId ? BigInt(escrowId) : null,
-      stripeSessionId: session.id,
-      amountFiat: amountCents,
-      status: 'Pending',
-    },
+    span.setAttribute('payment.id', payment.id);
+    return { sessionId: session.id, url: session.url, paymentId: payment.id };
   });
-
-  return { sessionId: session.id, url: session.url, paymentId: payment.id };
 }
 
 /**
@@ -96,19 +105,23 @@ async function getByAddress(address) {
  * @param {string} paymentId - internal Payment.id
  */
 async function refund(paymentId) {
-  const payment = await prisma.payment.findUniqueOrThrow({ where: { id: paymentId } });
+  return withSpan('paymentService.refund', { 'payment.id': paymentId }, async (span) => {
+    const payment = await prisma.payment.findUniqueOrThrow({ where: { id: paymentId } });
 
-  if (payment.status !== 'Completed') {
-    throw new Error(`Cannot refund payment in status: ${payment.status}`);
-  }
+    if (payment.status !== 'Completed') {
+      throw new Error(`Cannot refund payment in status: ${payment.status}`);
+    }
 
-  const stripeRefund = await stripe.refunds.create({
-    payment_intent: payment.stripePaymentIntent,
-  });
+    const stripeRefund = await stripe.refunds.create({
+      payment_intent: payment.stripePaymentIntent,
+    });
 
-  return prisma.payment.update({
-    where: { id: paymentId },
-    data: { status: 'Refunded', refundId: stripeRefund.id },
+    span.setAttribute('payment.refund_id', stripeRefund.id);
+
+    return prisma.payment.update({
+      where: { id: paymentId },
+      data: { status: 'Refunded', refundId: stripeRefund.id },
+    });
   });
 }
 
@@ -117,59 +130,63 @@ async function refund(paymentId) {
  * Returns the updated payment record or null for unhandled events.
  */
 async function handleWebhook(rawBody, signature) {
-  const event = stripe.webhooks.constructEvent(
-    rawBody,
-    signature,
-    process.env.STRIPE_WEBHOOK_SECRET,
-  );
+  return withSpan('paymentService.handleWebhook', {}, async (span) => {
+    const event = stripe.webhooks.constructEvent(
+      rawBody,
+      signature,
+      process.env.STRIPE_WEBHOOK_SECRET,
+    );
 
-  switch (event.type) {
-    case 'checkout.session.completed': {
-      const session = event.data.object;
-      // Compute crypto equivalent
-      let amountCrypto = null;
-      try {
-        const xlmPrice = await getXlmUsdPrice();
-        const usd = session.amount_total / 100;
-        amountCrypto = (usd / xlmPrice).toFixed(7) + ' XLM';
-      } catch {
-        // non-fatal — conversion is informational
-      }
+    span.setAttribute('payment.webhook_event_type', event.type);
 
-      return prisma.payment.update({
-        where: { stripeSessionId: session.id },
-        data: {
-          status: 'Completed',
-          stripePaymentIntent: session.payment_intent,
-          amountCrypto,
-        },
-      });
-    }
+    switch (event.type) {
+      case 'checkout.session.completed': {
+        const session = event.data.object;
+        span.setAttribute('payment.stripe_session_id', session.id);
+        let amountCrypto = null;
+        try {
+          const xlmPrice = await getXlmUsdPrice();
+          const usd = session.amount_total / 100;
+          amountCrypto = (usd / xlmPrice).toFixed(7) + ' XLM';
+        } catch {
+          // non-fatal — conversion is informational
+        }
 
-    case 'checkout.session.expired':
-    case 'payment_intent.payment_failed': {
-      const obj = event.data.object;
-      const where =
-        obj.object === 'checkout.session'
-          ? { stripeSessionId: obj.id }
-          : { stripePaymentIntent: obj.id };
-      return prisma.payment.updateMany({ where, data: { status: 'Failed' } });
-    }
-
-    case 'charge.refunded': {
-      const refundId = event.data.object.refunds?.data?.[0]?.id;
-      if (refundId) {
-        return prisma.payment.updateMany({
-          where: { refundId },
-          data: { status: 'Refunded' },
+        return prisma.payment.update({
+          where: { stripeSessionId: session.id },
+          data: {
+            status: 'Completed',
+            stripePaymentIntent: session.payment_intent,
+            amountCrypto,
+          },
         });
       }
-      return null;
-    }
 
-    default:
-      return null;
-  }
+      case 'checkout.session.expired':
+      case 'payment_intent.payment_failed': {
+        const obj = event.data.object;
+        const where =
+          obj.object === 'checkout.session'
+            ? { stripeSessionId: obj.id }
+            : { stripePaymentIntent: obj.id };
+        return prisma.payment.updateMany({ where, data: { status: 'Failed' } });
+      }
+
+      case 'charge.refunded': {
+        const refundId = event.data.object.refunds?.data?.[0]?.id;
+        if (refundId) {
+          return prisma.payment.updateMany({
+            where: { refundId },
+            data: { status: 'Refunded' },
+          });
+        }
+        return null;
+      }
+
+      default:
+        return null;
+    }
+  });
 }
 
 export default { createCheckoutSession, getBySessionId, getByAddress, refund, handleWebhook };

--- a/backend/services/stellarService.js
+++ b/backend/services/stellarService.js
@@ -9,6 +9,7 @@
  */
 
 import { SorobanRpc, Transaction, Networks } from '@stellar/stellar-sdk';
+import { withSpan } from '../lib/tracing.js';
 
 const RPC_URL = process.env.SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org';
 const NETWORK = process.env.STELLAR_NETWORK || 'testnet';
@@ -26,29 +27,33 @@ const getServer = () =>
  * @returns {Promise<{ hash: string, status: string, errorResultXdr?: string }>}
  */
 const submitTransaction = async (signedXdr) => {
-  const server = getServer();
-  const tx = new Transaction(signedXdr, NETWORK_PASSPHRASE);
-  const sendResult = await server.sendTransaction(tx);
+  return withSpan('stellarService.submitTransaction', { 'stellar.network': NETWORK }, async (span) => {
+    const server = getServer();
+    const tx = new Transaction(signedXdr, NETWORK_PASSPHRASE);
+    const sendResult = await server.sendTransaction(tx);
 
-  if (sendResult.status === 'ERROR') {
-    return { hash: sendResult.hash, status: 'FAILED', errorResultXdr: sendResult.errorResultXdr };
-  }
+    span.setAttribute('stellar.tx.hash', sendResult.hash);
 
-  // Poll until the transaction is no longer pending
-  const hash = sendResult.hash;
-  for (let i = 0; i < 30; i++) {
-    await new Promise((r) => setTimeout(r, 2000));
-    const result = await server.getTransaction(hash);
-    if (result.status !== 'NOT_FOUND') {
-      return {
-        hash,
-        status: result.status === 'SUCCESS' ? 'SUCCESS' : 'FAILED',
-        errorResultXdr: result.resultXdr,
-      };
+    if (sendResult.status === 'ERROR') {
+      span.setAttribute('stellar.tx.status', 'FAILED');
+      return { hash: sendResult.hash, status: 'FAILED', errorResultXdr: sendResult.errorResultXdr };
     }
-  }
 
-  return { hash, status: 'TIMEOUT' };
+    const hash = sendResult.hash;
+    for (let i = 0; i < 30; i++) {
+      await new Promise((r) => setTimeout(r, 2000));
+      const result = await server.getTransaction(hash);
+      if (result.status !== 'NOT_FOUND') {
+        const status = result.status === 'SUCCESS' ? 'SUCCESS' : 'FAILED';
+        span.setAttribute('stellar.tx.status', status);
+        span.setAttribute('stellar.tx.poll_attempts', i + 1);
+        return { hash, status, errorResultXdr: result.resultXdr };
+      }
+    }
+
+    span.setAttribute('stellar.tx.status', 'TIMEOUT');
+    return { hash, status: 'TIMEOUT' };
+  });
 };
 
 /**
@@ -59,12 +64,19 @@ const submitTransaction = async (signedXdr) => {
  * @returns {Promise<Array>} array of raw Soroban event objects
  */
 const getContractEvents = async (startLedger, contractId) => {
-  const server = getServer();
-  const response = await server.getEvents({
-    startLedger,
-    filters: [{ type: 'contract', contractIds: [contractId] }],
+  return withSpan('stellarService.getContractEvents', {
+    'stellar.start_ledger': startLedger,
+    'stellar.contract_id': contractId,
+  }, async (span) => {
+    const server = getServer();
+    const response = await server.getEvents({
+      startLedger,
+      filters: [{ type: 'contract', contractIds: [contractId] }],
+    });
+    const events = response.events ?? [];
+    span.setAttribute('stellar.events.count', events.length);
+    return events;
   });
-  return response.events ?? [];
 };
 
 /**
@@ -73,9 +85,12 @@ const getContractEvents = async (startLedger, contractId) => {
  * @returns {Promise<number>}
  */
 const getLatestLedger = async () => {
-  const server = getServer();
-  const health = await server.getLatestLedger();
-  return health.sequence;
+  return withSpan('stellarService.getLatestLedger', {}, async (span) => {
+    const server = getServer();
+    const health = await server.getLatestLedger();
+    span.setAttribute('stellar.latest_ledger', health.sequence);
+    return health.sequence;
+  });
 };
 
 export { submitTransaction, getContractEvents, getLatestLedger };


### PR DESCRIPTION
closes #250
 Add lib/tracing.js: OTel SDK bootstrap with OTLP/HTTP exporter, W3C TraceContext + Baggage propagators, auto-instrumentation for HTTP/Express, and withSpan() helper for manual instrumentation
- Add lib/prismaTracing.js: Prisma middleware wrapping every DB query in a child span with db.system, db.operation, duration attributes
- Add middleware/tracingMiddleware.js: enriches active span with HTTP semantic attributes, normalizes route names, propagates X-Trace-Id and X-Span-Id response headers, marks 4xx/5xx as errors
- Instrument all services with withSpan(): stellarService, paymentService, kycService, emailService, auditService, eventIndexer
- Update server.js: initTracing() called first before other imports, tracingMiddleware added to pipeline, attachPrismaTracing wired up
- Update monitoring/docker-compose.yml: add Jaeger all-in-one (UI :16686, OTLP HTTP :4318)
- Update package.json: add 7 OTel dependencies
- Update .env.example: document TRACING_ENABLED, OTEL_* env vars

## Description

<!-- What does this PR change and why? -->

## Related Issue

Closes #<!-- issue number -->

## Type of Change

- [ ] 🦀 Smart contract (Rust/Soroban)
- [ ] 🖥️ Backend (Node.js)
- [ ] 🎨 Frontend (Next.js/React)
- [ ] 📚 Documentation
- [ ] 🧪 Tests
- [ ] 🐛 Bug fix

## Checklist

- [ ] Branch is up to date with `main`
- [ ] Contract: `cargo fmt` + `cargo clippy -- -D warnings` pass
- [ ] Backend: `npm run lint` passes
- [ ] Frontend: `npm run lint` passes
- [ ] Tests added for new functionality
- [ ] PR description clearly explains the change
- [ ] Linked the issue with `Closes #N`
