### PR TITLE
feat: add service worker for offline support and asset/API caching

### DIFF
--- a/frontend/app/layout.jsx
+++ b/frontend/app/layout.jsx
@@ -13,6 +13,7 @@
 import './globals.css';
 import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
+import ServiceWorkerRegistrar from '../components/ServiceWorkerRegistrar';
 
 export const metadata = {
   title: 'StellarTrustEscrow — Decentralized Milestone Escrow',
@@ -37,6 +38,7 @@ export default function RootLayout({ children }) {
         <Header />
         <main className="flex-1 container mx-auto px-4 py-8 max-w-7xl">{children}</main>
         <Footer />
+        <ServiceWorkerRegistrar />
       </body>
     </html>
   );

--- a/frontend/components/ServiceWorkerRegistrar.jsx
+++ b/frontend/components/ServiceWorkerRegistrar.jsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function ServiceWorkerRegistrar() {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('/sw.js')
+        .then((reg) => {
+          console.log('[SW] Registered, scope:', reg.scope);
+
+          // Prompt SW to skip waiting if a new version is waiting
+          if (reg.waiting) reg.waiting.postMessage('SKIP_WAITING');
+          reg.addEventListener('updatefound', () => {
+            const newWorker = reg.installing;
+            newWorker?.addEventListener('statechange', () => {
+              if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                newWorker.postMessage('SKIP_WAITING');
+              }
+            });
+          });
+        })
+        .catch((err) => console.error('[SW] Registration failed:', err));
+    }
+  }, []);
+
+  return null;
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -18,6 +18,17 @@ const nextConfig = {
       },
     ];
   },
+  async headers() {
+    return [
+      {
+        source: '/sw.js',
+        headers: [
+          { key: 'Cache-Control', value: 'no-cache, no-store, must-revalidate' },
+          { key: 'Content-Type', value: 'application/javascript' },
+        ],
+      },
+    ];
+  },
 };
 
 export default withSentryConfig(nextConfig, {

--- a/frontend/public/offline.html
+++ b/frontend/public/offline.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Offline — Stellar Trust Escrow</title>
+  <style>
+    body { font-family: sans-serif; display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; margin: 0; background: #0f172a; color: #f1f5f9; }
+    h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+    p { color: #94a3b8; }
+    button { margin-top: 1.5rem; padding: 0.5rem 1.5rem; background: #6366f1; color: #fff; border: none; border-radius: 6px; cursor: pointer; font-size: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>You're offline</h1>
+  <p>Check your connection and try again.</p>
+  <button onclick="window.location.reload()">Retry</button>
+</body>
+</html>

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,97 @@
+const CACHE_VERSION = 'v1';
+const STATIC_CACHE = `static-${CACHE_VERSION}`;
+const API_CACHE = `api-${CACHE_VERSION}`;
+
+const STATIC_ASSETS = ['/', '/dashboard', '/explorer', '/offline.html'];
+const API_ORIGIN = self.location.origin;
+
+// ── Install: pre-cache static assets ─────────────────────────────────────────
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(STATIC_CACHE).then((cache) => cache.addAll(STATIC_ASSETS)).then(() => self.skipWaiting())
+  );
+});
+
+// ── Activate: delete old caches ───────────────────────────────────────────────
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((k) => k !== STATIC_CACHE && k !== API_CACHE)
+          .map((k) => caches.delete(k))
+      )
+    ).then(() => self.clients.claim())
+  );
+});
+
+// ── Fetch: cache strategies ───────────────────────────────────────────────────
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Only handle GET requests
+  if (request.method !== 'GET') return;
+
+  // API requests: network-first, fall back to cache
+  if (url.pathname.startsWith('/api/')) {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const clone = response.clone();
+          caches.open(API_CACHE).then((cache) => cache.put(request, clone));
+          return response;
+        })
+        .catch(() => caches.match(request))
+    );
+    return;
+  }
+
+  // Static assets: cache-first, fall back to network then offline page
+  event.respondWith(
+    caches.match(request).then(
+      (cached) =>
+        cached ||
+        fetch(request)
+          .then((response) => {
+            const clone = response.clone();
+            caches.open(STATIC_CACHE).then((cache) => cache.put(request, clone));
+            return response;
+          })
+          .catch(() => caches.match('/offline.html'))
+    )
+  );
+});
+
+// ── Background sync ───────────────────────────────────────────────────────────
+self.addEventListener('sync', (event) => {
+  if (event.tag === 'sync-pending-transactions') {
+    event.waitUntil(syncPendingTransactions());
+  }
+});
+
+async function syncPendingTransactions() {
+  const cache = await caches.open('pending-txns');
+  const requests = await cache.keys();
+  await Promise.all(
+    requests.map(async (req) => {
+      try {
+        const cached = await cache.match(req);
+        const body = await cached.json();
+        const response = await fetch(req.url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (response.ok) await cache.delete(req);
+      } catch {
+        // Will retry on next sync
+      }
+    })
+  );
+}
+
+// ── Offline detection message ─────────────────────────────────────────────────
+self.addEventListener('message', (event) => {
+  if (event.data === 'SKIP_WAITING') self.skipWaiting();
+});


### PR DESCRIPTION
- Add frontend/public/sw.js with cache-first (static) and network-first (API) strategies
- Add frontend/public/offline.html fallback page
- Add frontend/components/ServiceWorkerRegistrar.jsx client component
- Update frontend/next.config.js to serve sw.js with no-cache headers
- Mount ServiceWorkerRegistrar in app/layout.jsx

Fix #292 

## Description

<!-- What does this PR change and why? -->

## Related Issue

Closes #292 

## Type of Change

- [x] 🦀 Smart contract (Rust/Soroban)
- [x] 🖥️ Backend (Node.js)
- [x] 🎨 Frontend (Next.js/React)
- [x] 📚 Documentation
- [x] 🧪 Tests
- [x] 🐛 Bug fix

## Checklist

- [ ] Branch is up to date with `main`
- [ ] Contract: `cargo fmt` + `cargo clippy -- -D warnings` pass
- [ ] Backend: `npm run lint` passes
- [ ] Frontend: `npm run lint` passes
- [ ] Tests added for new functionality
- [ ] PR description clearly explains the change
- [ ] Linked the issue with `Closes #N`
