### PR TITLE
feat: add empty state to escrow explorer

### DIFF
--- a/frontend/app/explorer/page.jsx
+++ b/frontend/app/explorer/page.jsx
@@ -7,13 +7,14 @@
 
 'use client';
 
-
+import { useState, useRef, useEffect, useCallback, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Search, SlidersHorizontal, X, ChevronLeft, ChevronRight, Loader2 } from 'lucide-react';
 import EscrowCard from '../../components/escrow/EscrowCard';
 import SearchFilters from '../../components/explorer/SearchFilters';
 import Button from '../../components/ui/Button';
 import Badge from '../../components/ui/Badge';
+import EmptyState from '../../components/ui/EmptyState';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
 
@@ -342,18 +343,17 @@ function ExplorerContent() {
               <p className="text-gray-500 text-sm">{error}</p>
             </div>
           ) : escrows.length === 0 ? (
-            <div className="text-center py-16 text-gray-500">
-              <p className="text-lg mb-2">No escrows found</p>
-              <p className="text-sm">Try adjusting your search or filters.</p>
-              {activeFilterCount > 0 && (
-                <button
-                  onClick={handleReset}
-                  className="mt-4 text-indigo-400 hover:text-indigo-300 text-sm transition-colors"
-                >
-                  Clear all filters
-                </button>
-              )}
-            </div>
+            <EmptyState
+              title="No escrows found"
+              description={
+                activeFilterCount > 0
+                  ? 'No escrows match your current filters. Try adjusting or clearing them.'
+                  : 'There are no escrows to display yet. Create one to get started.'
+              }
+              actionLabel={activeFilterCount > 0 ? 'Clear all filters' : 'Create Escrow'}
+              onAction={activeFilterCount > 0 ? handleReset : undefined}
+              actionHref={activeFilterCount > 0 ? undefined : '/escrow/create'}
+            />
           ) : (
             <div
               className={`grid gap-4 ${showFilters ? 'md:grid-cols-2' : 'md:grid-cols-2 lg:grid-cols-3'}`}
@@ -439,6 +439,7 @@ function ExplorerContent() {
 }
 
 
+export default function ExplorerPage() {
   return (
     <Suspense
       fallback={
@@ -449,7 +450,6 @@ function ExplorerContent() {
       }
     >
       <ExplorerContent />
-</Suspense>
-    </ErrorBoundary>
+    </Suspense>
   );
 }

--- a/frontend/components/ui/EmptyState.jsx
+++ b/frontend/components/ui/EmptyState.jsx
@@ -1,0 +1,98 @@
+/**
+ * EmptyState Component
+ *
+ * Displays a centered SVG illustration, a title, a supporting message,
+ * and an optional call-to-action when a list or page has no content.
+ *
+ * @param {object}   props
+ * @param {string}   [props.title='No escrows found']
+ * @param {string}   [props.description]
+ * @param {string}   [props.actionLabel]   — label for the CTA button
+ * @param {string}   [props.actionHref]    — renders CTA as a link if provided
+ * @param {Function} [props.onAction]      — renders CTA as a button if provided
+ * @param {string}   [props.className]
+ */
+
+import Link from 'next/link';
+
+export default function EmptyState({
+  title = 'No escrows found',
+  description,
+  actionLabel,
+  actionHref,
+  onAction,
+  className = '',
+}) {
+  const hasAction = actionLabel && (actionHref || onAction);
+
+  return (
+    <div
+      className={`flex flex-col items-center justify-center py-20 text-center ${className}`}
+      data-testid="empty-state"
+    >
+      {/* SVG illustration */}
+      <svg
+        aria-hidden="true"
+        width="120"
+        height="120"
+        viewBox="0 0 120 120"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        className="mb-6 opacity-40"
+      >
+        {/* Outer circle */}
+        <circle cx="60" cy="60" r="56" stroke="#4F46E5" strokeWidth="2" strokeDasharray="6 4" />
+
+        {/* Document body */}
+        <rect x="35" y="28" width="50" height="64" rx="5" fill="#1E1B4B" stroke="#4F46E5" strokeWidth="1.5" />
+
+        {/* Document fold */}
+        <path d="M70 28 L85 43" stroke="#4F46E5" strokeWidth="1.5" />
+        <path d="M70 28 L70 43 L85 43" fill="#312E81" stroke="#4F46E5" strokeWidth="1.5" strokeLinejoin="round" />
+
+        {/* Lines on document */}
+        <rect x="43" y="52" width="34" height="3" rx="1.5" fill="#4F46E5" opacity="0.5" />
+        <rect x="43" y="61" width="26" height="3" rx="1.5" fill="#4F46E5" opacity="0.4" />
+        <rect x="43" y="70" width="30" height="3" rx="1.5" fill="#4F46E5" opacity="0.3" />
+
+        {/* Magnifying glass */}
+        <circle cx="78" cy="83" r="12" fill="#0F172A" stroke="#6366F1" strokeWidth="2" />
+        <circle cx="78" cy="83" r="7" stroke="#818CF8" strokeWidth="1.5" />
+        <line x1="83" y1="88" x2="90" y2="95" stroke="#818CF8" strokeWidth="2.5" strokeLinecap="round" />
+
+        {/* X inside magnifying glass */}
+        <line x1="75" y1="80" x2="81" y2="86" stroke="#6366F1" strokeWidth="1.5" strokeLinecap="round" />
+        <line x1="81" y1="80" x2="75" y2="86" stroke="#6366F1" strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+
+      {/* Title */}
+      <h3 className="text-lg font-semibold text-white mb-2">{title}</h3>
+
+      {/* Supporting message */}
+      {description && (
+        <p className="text-sm text-gray-400 max-w-xs mb-6">{description}</p>
+      )}
+
+      {/* Call-to-action */}
+      {hasAction && (
+        actionHref ? (
+          <Link
+            href={actionHref}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-indigo-600
+                       hover:bg-indigo-500 text-white text-sm font-medium transition-colors"
+          >
+            {actionLabel}
+          </Link>
+        ) : (
+          <button
+            onClick={onAction}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-indigo-600
+                       hover:bg-indigo-500 text-white text-sm font-medium transition-colors"
+          >
+            {actionLabel}
+          </button>
+        )
+      )}
+    </div>
+  );
+}

--- a/frontend/tests/components/ui/EmptyState.test.jsx
+++ b/frontend/tests/components/ui/EmptyState.test.jsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import EmptyState from '../../../components/ui/EmptyState';
+
+describe('EmptyState', () => {
+  it('renders the default title when no title prop is given', () => {
+    render(<EmptyState />);
+    expect(screen.getByText('No escrows found')).toBeInTheDocument();
+  });
+
+  it('renders a custom title', () => {
+    render(<EmptyState title="Nothing here yet" />);
+    expect(screen.getByText('Nothing here yet')).toBeInTheDocument();
+  });
+
+  it('renders the description when provided', () => {
+    render(<EmptyState description="Try adjusting your filters." />);
+    expect(screen.getByText('Try adjusting your filters.')).toBeInTheDocument();
+  });
+
+  it('does not render a description element when omitted', () => {
+    render(<EmptyState />);
+    // No <p> with description text should be present
+    expect(screen.queryByText(/Try adjusting/)).not.toBeInTheDocument();
+  });
+
+  it('renders the SVG illustration', () => {
+    render(<EmptyState />);
+    // The SVG is present (aria-hidden so we find by test-id wrapper)
+    expect(screen.getByTestId('empty-state').querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders a button CTA when onAction is provided', () => {
+    render(<EmptyState actionLabel="Clear filters" onAction={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Clear filters' })).toBeInTheDocument();
+  });
+
+  it('calls onAction when the CTA button is clicked', () => {
+    const onAction = jest.fn();
+    render(<EmptyState actionLabel="Clear filters" onAction={onAction} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a link CTA when actionHref is provided', () => {
+    render(<EmptyState actionLabel="Create Escrow" actionHref="/escrow/create" />);
+    const link = screen.getByRole('link', { name: 'Create Escrow' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/escrow/create');
+  });
+
+  it('does not render a CTA when neither onAction nor actionHref is given', () => {
+    render(<EmptyState actionLabel="Create Escrow" />);
+    expect(screen.queryByRole('button', { name: 'Create Escrow' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Create Escrow' })).not.toBeInTheDocument();
+  });
+
+  it('is centered with the correct container', () => {
+    render(<EmptyState />);
+    const container = screen.getByTestId('empty-state');
+    expect(container).toHaveClass('flex', 'flex-col', 'items-center', 'justify-center', 'text-center');
+  });
+});

--- a/frontend/tests/pages/explorer.test.jsx
+++ b/frontend/tests/pages/explorer.test.jsx
@@ -1,6 +1,13 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ExplorerPage from '../../app/explorer/page';
 
+// EscrowCard uses useI18n which requires I18nProvider — mock it for tests.
+jest.mock('../../components/escrow/EscrowCard', () =>
+  function EscrowCard({ escrow }) {
+    return <div data-testid="escrow-card">Escrow #{escrow.id}</div>;
+  }
+);
+
 const mockEscrows = [
   { id: 1, status: 'Active', totalAmount: '1000', clientAddress: '0x1A2B' },
   { id: 2, status: 'Active', totalAmount: '2000', clientAddress: '0x3C4D' },


### PR DESCRIPTION
## New component — frontend/components/ui/EmptyState.jsx

Created a reusable EmptyState component with:

- **SVG illustration** — inline dark-themed graphic showing a document with a magnifying-glass overlay, so no external image dependencies and no layout shift while data loads (illustration is always the same fixed size via explicit width/height attributes)
- **Title** — defaults to "No escrows found"; fully overridable via `title` prop
- **Description** — optional supporting message rendered below the title
- **Call-to-action** — optional; renders as a `<Link>` when `actionHref` is provided, or a `<button>` when `onAction` is provided; omitted entirely when neither is set
- `data-testid="empty-state"` on the root element for test targeting

Props: `title`, `description`, `actionLabel`, `actionHref`, `onAction`, `className`

## Explorer page — frontend/app/explorer/page.jsx

Replaced the inline empty-state `<div>` (plain text only) with the new `<EmptyState>` component. Two distinct states are now handled:

- **Filters active** (`activeFilterCount > 0`): description explains no escrows match current filters; CTA button calls `handleReset` to clear them in-place (no navigation)
- **No filters active**: description invites the user to create the first escrow; CTA is a link to `/escrow/create`

Also fixed two pre-existing bugs that prevented the page from compiling:
  - Added missing `import { useState, useRef, useEffect, useCallback, Suspense } from 'react'` (the ExplorerContent component used all five hooks but none were imported)
  - Added the missing `export default function ExplorerPage()` wrapper around the dangling `return (<Suspense>…</Suspense>)` and removed the unmatched `</ErrorBoundary>` closing tag

## Tests

### frontend/tests/components/ui/EmptyState.test.jsx (new, 10 tests)
- Default title renders as "No escrows found"
- Custom title prop
- Description renders when provided; absent when omitted
- SVG illustration present in the DOM
- Button CTA rendered and calls onAction on click
- Link CTA rendered with correct href when actionHref is provided
- No CTA rendered when actionLabel has no handler or href
- Container has centering classes (flex, items-center, text-center)

### frontend/tests/pages/explorer.test.jsx (updated)
- Added `jest.mock` for EscrowCard (which requires I18nProvider) so all 9 explorer tests pass in the jsdom environment without a provider wrapper — this was the cause of 8 pre-existing test failures

## Acceptance criteria checklist
- [x] Empty state displays when no escrows exist
- [x] Illustration is centered and properly sized (fixed 120×120 SVG)
- [x] Message is clear and actionable (two context-aware descriptions)
- [x] Call-to-action button works (clears filters or links to /escrow/create)
- [x] No layout shift when data loads (SVG has fixed dimensions)


resolves #439 