### PR TITLE
#279 Implement API Request Batching

### DIFF
--- a/backend/api/controllers/batchController.js
+++ b/backend/api/controllers/batchController.js
@@ -1,0 +1,64 @@
+import supertest from 'supertest';
+
+const MAX_BATCH_SIZE = parseInt(process.env.MAX_BATCH_SIZE || '20', 10);
+const ALLOWED_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
+
+async function dispatchRequest(app, { method = 'GET', url, body, headers = {} }, parentReq) {
+  const upperMethod = method.toUpperCase();
+  if (!ALLOWED_METHODS.has(upperMethod)) {
+    return { status: 400, data: { error: `Method not allowed: ${method}` }, headers: {} };
+  }
+
+  // Propagate parent auth unless the sub-request overrides it
+  const authHeader = parentReq.headers['authorization'];
+  if (authHeader && !headers['authorization'] && !headers['Authorization']) {
+    headers = { ...headers, authorization: authHeader };
+  }
+
+  try {
+    const agent = supertest(app)[upperMethod.toLowerCase()](url);
+
+    for (const [key, value] of Object.entries(headers)) {
+      agent.set(key, value);
+    }
+
+    if (body && (upperMethod === 'POST' || upperMethod === 'PUT' || upperMethod === 'PATCH')) {
+      agent.send(body);
+    }
+
+    const response = await agent;
+    return {
+      status: response.status,
+      data: response.body,
+      headers: response.headers,
+    };
+  } catch (err) {
+    return { status: 500, data: { error: err.message }, headers: {} };
+  }
+}
+
+export async function handleBatch(req, res) {
+  const requests = req.body;
+
+  if (!Array.isArray(requests)) {
+    return res.status(400).json({ error: 'Request body must be an array.' });
+  }
+
+  if (requests.length > MAX_BATCH_SIZE) {
+    return res.status(413).json({
+      error: `Batch size ${requests.length} exceeds maximum allowed (${MAX_BATCH_SIZE}).`,
+    });
+  }
+
+  const results = await Promise.allSettled(
+    requests.map((item) => dispatchRequest(req.app, item, req)),
+  );
+
+  const responses = results.map((result) =>
+    result.status === 'fulfilled'
+      ? result.value
+      : { status: 500, data: { error: result.reason?.message || 'Internal error' }, headers: {} },
+  );
+
+  return res.status(200).json(responses);
+}

--- a/backend/api/routes/batchRoutes.js
+++ b/backend/api/routes/batchRoutes.js
@@ -1,0 +1,13 @@
+import express from 'express';
+import { handleBatch } from '../controllers/batchController.js';
+
+const router = express.Router();
+
+/**
+ * @route  POST /api/batch
+ * @desc   Execute multiple API requests in a single call.
+ * @body   Array of { method, url, body?, headers? }
+ */
+router.post('/', handleBatch);
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -28,6 +28,7 @@ import auditRoutes from './api/routes/auditRoutes.js';
 import authRoutes from './api/routes/authRoutes.js';
 import complianceRoutes from './api/routes/complianceRoutes.js';
 import incidentRoutes from './api/routes/incidentRoutes.js';
+import batchRoutes from './api/routes/batchRoutes.js';
 import authMiddleware from './api/middleware/auth.js';
 import tenantMiddleware from './api/middleware/tenant.js';
 import auditMiddleware from './api/middleware/audit.js';
@@ -178,6 +179,7 @@ app.use('/api/audit', auditRoutes);
 app.use('/api/compliance', complianceRoutes);
 app.use('/api/incidents', incidentRoutes);
 app.use('/api/admin', adminRoutes);
+app.use('/api/batch', batchRoutes);
 app.use('/docs', docsRouter);
 
 // ── Example: Deprecated API Version ───────────────────────────────────────────

--- a/backend/tests/batch.test.js
+++ b/backend/tests/batch.test.js
@@ -1,0 +1,98 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import supertest from 'supertest';
+import express from 'express';
+
+// ── Minimal Express app for testing ──────────────────────────────────────────
+// We build a self-contained app so tests don't need a DB or Sentry.
+
+function buildTestApp() {
+  const app = express();
+  app.use(express.json());
+
+  // Public route — always succeeds
+  app.get('/api/health', (_req, res) => res.status(200).json({ status: 'ok' }));
+
+  // Public route — always 404
+  app.get('/api/not-found', (_req, res) => res.status(404).json({ error: 'Not found' }));
+
+  // Protected route — requires Authorization header
+  app.get('/api/escrows/abc123', (req, res) => {
+    if (!req.headers['authorization']) {
+      return res.status(401).json({ error: 'Access denied. No token provided.' });
+    }
+    return res.status(200).json({ id: 'abc123', status: 'active' });
+  });
+
+  // Batch route (must come after the routes it will dispatch to)
+  app.post('/api/batch', async (req, res) => {
+    const { handleBatch } = await import('../api/controllers/batchController.js');
+    return handleBatch(req, res);
+  });
+
+  return app;
+}
+
+describe('POST /api/batch', () => {
+  let app;
+  let request;
+
+  beforeEach(() => {
+    app = buildTestApp();
+    request = supertest(app);
+  });
+
+  it('Test 1 (Mixed Results): returns correct status codes for each sub-request', async () => {
+    const res = await request.post('/api/batch').send([
+      { method: 'GET', url: '/api/health' },
+      { method: 'GET', url: '/api/health' },
+      { method: 'GET', url: '/api/not-found' },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(3);
+    expect(res.body[0].status).toBe(200);
+    expect(res.body[1].status).toBe(200);
+    expect(res.body[2].status).toBe(404);
+  });
+
+  it('Test 2 (Auth Propagation): propagates parent Authorization header to protected sub-requests', async () => {
+    const token = 'Bearer test-token-xyz';
+
+    const res = await request
+      .post('/api/batch')
+      .set('Authorization', token)
+      .send([{ method: 'GET', url: '/api/escrows/abc123' }]);
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].status).toBe(200);
+    expect(res.body[0].data).toMatchObject({ id: 'abc123' });
+  });
+
+  it('Test 2b (Auth Propagation): returns 401 when no auth header is present on protected sub-request', async () => {
+    const res = await request
+      .post('/api/batch')
+      .send([{ method: 'GET', url: '/api/escrows/abc123' }]);
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].status).toBe(401);
+  });
+
+  it('Test 3 (Limit Enforcement): returns 413 when batch exceeds MAX_BATCH_SIZE', async () => {
+    const oversizedBatch = Array.from({ length: 21 }, () => ({
+      method: 'GET',
+      url: '/api/health',
+    }));
+
+    const res = await request.post('/api/batch').send(oversizedBatch);
+
+    expect(res.status).toBe(413);
+    expect(res.body.error).toMatch(/exceeds maximum/i);
+  });
+
+  it('returns 400 when body is not an array', async () => {
+    const res = await request.post('/api/batch').send({ method: 'GET', url: '/api/health' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/array/i);
+  });
+});


### PR DESCRIPTION
closes #279 

## Description

 #108 — Adds a `POST /api/batch` endpoint that accepts multiple API requests in a single HTTP call, executes them in parallel, and returns a consolidated ordered response array.

## New Files

- `backend/api/controllers/batchController.js` — core dispatch logic
- `backend/api/routes/batchRoutes.js` — route definition
- `backend/tests/batch.test.js` — test suite

## Implementation Details

**Dispatch strategy:** Uses `supertest` to route sub-requests internally through the same Express `app` instance — no actual network calls to localhost, no `eval()`.

**Parallelism:** `Promise.allSettled()` ensures a single failing sub-request never blocks the others.

**Auth propagation:** The parent request's `Authorization` header is automatically forwarded to every sub-request unless the sub-request explicitly provides its own.

**Security:** `MAX_BATCH_SIZE` (default: 20, configurable via `MAX_BATCH_SIZE` env var) — returns `413 Payload Too Large` if exceeded.

**Response format:**
json
[
 { "status": 200, "data": { ... }, "headers": { ... } },
 { "status": 404, "data": { "error": "Not found" }, "headers": { ... } }
]

## Tests (5 passing ✅)

- **Test 1 (Mixed Results):** 2 successful + 1 failing sub-request — verifies each item carries the correct individual status code
- **Test 2 (Auth Propagation):** parent `Authorization` header reaches a protected sub-route; absent header correctly yields `401`
- **Test 3 (Limit Enforcement):** 21-item batch returns `413` with descriptive error message
- Invalid body shape (non-array) returns `400`



## Type of Change

- [ ] 🦀 Smart contract (Rust/Soroban)
- [ ] 🖥️ Backend (Node.js)
- [ ] 🎨 Frontend (Next.js/React)
- [ ] 📚 Documentation
- [ ] 🧪 Tests
- [ ] 🐛 Bug fix

## Checklist

- [ ] Branch is up to date with `main`
- [ ] Contract: `cargo fmt` + `cargo clippy -- -D warnings` pass
- [ ] Backend: `npm run lint` passes
- [ ] Frontend: `npm run lint` passes
- [ ] Tests added for new functionality
- [ ] PR description clearly explains the change
- [ ] Linked the issue with `Closes #N`
