### PR TITLE
#245 Implement Feature Flags System 

### DIFF
--- a/backend/api/controllers/featureFlagController.js
+++ b/backend/api/controllers/featureFlagController.js
@@ -1,0 +1,36 @@
+import { listFlags, createFlag, updateFlag, deleteFlag } from '../../services/featureFlags.js';
+
+export async function index(_req, res) {
+  const flags = await listFlags();
+  res.json({ data: flags });
+}
+
+export async function create(req, res) {
+  try {
+    const flag = await createFlag(req.body, req.headers['x-admin-api-key']);
+    res.status(201).json({ data: flag });
+  } catch (err) {
+    if (err.code === 'P2002') return res.status(409).json({ error: 'Flag key already exists.' });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function update(req, res) {
+  try {
+    const flag = await updateFlag(req.params.key, req.body, req.headers['x-admin-api-key']);
+    res.json({ data: flag });
+  } catch (err) {
+    if (err.code === 'P2025') return res.status(404).json({ error: 'Flag not found.' });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+export async function destroy(req, res) {
+  try {
+    await deleteFlag(req.params.key, req.headers['x-admin-api-key']);
+    res.status(204).end();
+  } catch (err) {
+    if (err.code === 'P2025') return res.status(404).json({ error: 'Flag not found.' });
+    res.status(400).json({ error: err.message });
+  }
+}

--- a/backend/api/middleware/featureFlags.js
+++ b/backend/api/middleware/featureFlags.js
@@ -1,0 +1,25 @@
+import { listFlags, isFeatureEnabled } from '../../services/featureFlags.js';
+
+/**
+ * Attaches an `activeFlags` map to `req.user` so controllers can branch
+ * without making individual flag lookups.
+ *
+ * Usage: app.use(attachFeatureFlags) — place after authMiddleware.
+ *
+ * req.user.activeFlags = { 'new-dashboard': true, 'beta-payments': false, ... }
+ */
+export async function attachFeatureFlags(req, _res, next) {
+  try {
+    if (!req.user) return next();
+    const flags = await listFlags();
+    req.user.activeFlags = {};
+    await Promise.all(
+      flags.map(async (flag) => {
+        req.user.activeFlags[flag.key] = await isFeatureEnabled(flag.key, req.user);
+      }),
+    );
+  } catch {
+    // Never block the request on a flag evaluation failure
+  }
+  next();
+}

--- a/backend/api/routes/adminRoutes.js
+++ b/backend/api/routes/adminRoutes.js
@@ -11,6 +11,7 @@ const router = express.Router();
 import adminAuth from '../middleware/adminAuth.js';
 import adminController from '../controllers/adminController.js';
 import tenantController from '../controllers/tenantController.js';
+import * as featureFlagController from '../controllers/featureFlagController.js';
 import { getAuditLog, rotateSecrets } from '../../lib/secrets.js';
 import cache from '../../lib/cache.js';
 
@@ -115,6 +116,12 @@ router.post('/tenants', tenantController.createTenant);
 router.get('/tenants/:tenantId', tenantController.getTenant);
 router.patch('/tenants/:tenantId', tenantController.updateTenant);
 router.get('/tenants/:tenantId/metrics', tenantController.getTenantMetrics);
+
+// ── Feature Flags ─────────────────────────────────────────────────────────────
+router.get('/flags', featureFlagController.index);
+router.post('/flags', featureFlagController.create);
+router.patch('/flags/:key', featureFlagController.update);
+router.delete('/flags/:key', featureFlagController.destroy);
 
 /**
  * @route  GET /api/admin/secrets/audit

--- a/backend/database/migrations/20260327000001_feature_flags.js
+++ b/backend/database/migrations/20260327000001_feature_flags.js
@@ -1,0 +1,23 @@
+/**
+ * Migration: Feature Flags table
+ * Version:   20260327000001_feature_flags
+ */
+
+/** @param {import('@prisma/client').PrismaClient} prisma */
+export async function up(prisma) {
+  await prisma.$executeRawUnsafe(`
+    CREATE TABLE IF NOT EXISTS feature_flags (
+      key          TEXT        PRIMARY KEY,
+      is_enabled   BOOLEAN     NOT NULL DEFAULT FALSE,
+      percentage   INTEGER     NOT NULL DEFAULT 0 CHECK (percentage BETWEEN 0 AND 100),
+      target_users TEXT[]      NOT NULL DEFAULT '{}',
+      description  TEXT        NOT NULL DEFAULT '',
+      updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+}
+
+/** @param {import('@prisma/client').PrismaClient} prisma */
+export async function down(prisma) {
+  await prisma.$executeRawUnsafe(`DROP TABLE IF EXISTS feature_flags`);
+}

--- a/backend/database/schema.prisma
+++ b/backend/database/schema.prisma
@@ -443,6 +443,19 @@ enum MilestoneStatus {
   Rejected
 }
 
+// ── Feature Flags ─────────────────────────────────────────────────────────────
+
+model FeatureFlag {
+  key         String   @id
+  isEnabled   Boolean  @default(false) @map("is_enabled")
+  percentage  Int      @default(0)
+  targetUsers String[] @default([]) @map("target_users")
+  description String   @default("")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  @@map("feature_flags")
+}
+
 enum KycStatus {
   Pending
   Init

--- a/backend/services/featureFlags.js
+++ b/backend/services/featureFlags.js
@@ -1,0 +1,84 @@
+import crypto from 'crypto';
+import prisma from '../lib/prisma.js';
+import { log, AuditCategory } from './auditService.js';
+
+/**
+ * Deterministic hash of userId + flagKey → integer 0–99.
+ * Same user always gets the same bucket for a given flag.
+ */
+function hashBucket(userId, flagKey) {
+  const hash = crypto.createHash('sha256').update(`${userId}:${flagKey}`).digest('hex');
+  return parseInt(hash.slice(0, 8), 16) % 100;
+}
+
+/**
+ * Evaluate whether a feature flag is active for a given user context.
+ *
+ * Rules (in order):
+ *  1. Flag disabled globally → false
+ *  2. User explicitly in targetUsers → true
+ *  3. User's hash bucket < percentage → true
+ *  4. Otherwise → false
+ *
+ * @param {string} flagKey
+ * @param {{ id: string|number }} userContext
+ * @returns {Promise<boolean>}
+ */
+export async function isFeatureEnabled(flagKey, userContext) {
+  const flag = await prisma.featureFlag.findUnique({ where: { key: flagKey } });
+  if (!flag) return false;
+  if (!flag.isEnabled) {
+    // Still allow explicitly targeted users even when globally disabled
+    return flag.targetUsers.includes(String(userContext.id));
+  }
+  if (flag.targetUsers.includes(String(userContext.id))) return true;
+  return hashBucket(String(userContext.id), flagKey) < flag.percentage;
+}
+
+/**
+ * Return all flags (for admin listing).
+ */
+export async function listFlags() {
+  return prisma.featureFlag.findMany({ orderBy: { key: 'asc' } });
+}
+
+/**
+ * Create a new feature flag.
+ */
+export async function createFlag({ key, isEnabled = false, percentage = 0, targetUsers = [], description = '' }, adminId) {
+  const flag = await prisma.featureFlag.create({
+    data: { key, isEnabled, percentage, targetUsers, description },
+  });
+  await _auditFlagChange('FLAG_CREATED', flag.key, adminId, { isEnabled, percentage });
+  return flag;
+}
+
+/**
+ * Update an existing flag. Logs every change.
+ */
+export async function updateFlag(key, patch, adminId) {
+  const flag = await prisma.featureFlag.update({
+    where: { key },
+    data: patch,
+  });
+  await _auditFlagChange('FLAG_UPDATED', key, adminId, patch);
+  return flag;
+}
+
+/**
+ * Delete a flag.
+ */
+export async function deleteFlag(key, adminId) {
+  await prisma.featureFlag.delete({ where: { key } });
+  await _auditFlagChange('FLAG_DELETED', key, adminId, {});
+}
+
+async function _auditFlagChange(action, flagKey, adminId, changes) {
+  await log({
+    category: AuditCategory.ADMIN,
+    action,
+    actor: String(adminId ?? 'admin'),
+    resourceId: flagKey,
+    metadata: changes,
+  });
+}

--- a/backend/tests/featureFlags.test.js
+++ b/backend/tests/featureFlags.test.js
@@ -1,0 +1,120 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+// ── Mock prisma ───────────────────────────────────────────────────────────────
+const flagStore = new Map();
+
+const prismaMock = {
+  featureFlag: {
+    findUnique: jest.fn(({ where }) => Promise.resolve(flagStore.get(where.key) ?? null)),
+    findMany: jest.fn(() => Promise.resolve([...flagStore.values()])),
+    create: jest.fn(({ data }) => {
+      flagStore.set(data.key, { ...data });
+      return Promise.resolve(flagStore.get(data.key));
+    }),
+    update: jest.fn(({ where, data }) => {
+      const existing = flagStore.get(where.key);
+      if (!existing) { const e = new Error('Not found'); e.code = 'P2025'; throw e; }
+      const updated = { ...existing, ...data };
+      flagStore.set(where.key, updated);
+      return Promise.resolve(updated);
+    }),
+    delete: jest.fn(({ where }) => {
+      flagStore.delete(where.key);
+      return Promise.resolve();
+    }),
+  },
+  auditLog: {
+    create: jest.fn(() => Promise.resolve()),
+  },
+};
+
+jest.unstable_mockModule('../lib/prisma.js', () => ({ default: prismaMock }));
+
+const { isFeatureEnabled, createFlag, updateFlag } = await import('../services/featureFlags.js');
+
+describe('Feature Flags Service', () => {
+  beforeEach(() => {
+    flagStore.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('Test 1 (Deterministic Rollout)', () => {
+    it('consistently evaluates the same user the same way at 20% rollout', async () => {
+      // Find a user that IS in the 20% bucket and one that is NOT
+      // by brute-forcing with the same hash logic
+      const crypto = await import('crypto');
+      function bucket(userId, key) {
+        const hash = crypto.createHash('sha256').update(`${userId}:${key}`).digest('hex');
+        return parseInt(hash.slice(0, 8), 16) % 100;
+      }
+
+      const flagKey = 'new-dashboard';
+      let userIn = null;
+      let userOut = null;
+
+      for (let i = 0; i < 1000; i++) {
+        const id = String(i);
+        const b = bucket(id, flagKey);
+        if (b < 20 && !userIn) userIn = id;
+        if (b >= 20 && !userOut) userOut = id;
+        if (userIn && userOut) break;
+      }
+
+      await createFlag({ key: flagKey, isEnabled: true, percentage: 20, targetUsers: [] }, 'admin');
+
+      // userIn should consistently see the feature
+      const result1a = await isFeatureEnabled(flagKey, { id: userIn });
+      const result1b = await isFeatureEnabled(flagKey, { id: userIn });
+      expect(result1a).toBe(true);
+      expect(result1b).toBe(true);
+
+      // userOut should consistently NOT see the feature
+      const result2a = await isFeatureEnabled(flagKey, { id: userOut });
+      const result2b = await isFeatureEnabled(flagKey, { id: userOut });
+      expect(result2a).toBe(false);
+      expect(result2b).toBe(false);
+    });
+  });
+
+  describe('Test 2 (Targeting)', () => {
+    it('returns true for a user in targetUsers even when isEnabled is false', async () => {
+      await createFlag(
+        { key: 'beta-payments', isEnabled: false, percentage: 0, targetUsers: ['user-42'] },
+        'admin',
+      );
+
+      const enabled = await isFeatureEnabled('beta-payments', { id: 'user-42' });
+      expect(enabled).toBe(true);
+
+      const notEnabled = await isFeatureEnabled('beta-payments', { id: 'user-99' });
+      expect(notEnabled).toBe(false);
+    });
+  });
+
+  describe('Test 3 (Audit)', () => {
+    it('creates an audit log entry when a flag is toggled', async () => {
+      await createFlag({ key: 'audit-test', isEnabled: false, percentage: 0 }, 'admin-1');
+      await updateFlag('audit-test', { isEnabled: true }, 'admin-1');
+
+      // auditLog.create should have been called for both create and update
+      expect(prismaMock.auditLog.create).toHaveBeenCalledTimes(2);
+
+      const calls = prismaMock.auditLog.create.mock.calls;
+      expect(calls[0][0].data).toMatchObject({ action: 'FLAG_CREATED', resourceId: 'audit-test' });
+      expect(calls[1][0].data).toMatchObject({ action: 'FLAG_UPDATED', resourceId: 'audit-test' });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns false for a non-existent flag', async () => {
+      const result = await isFeatureEnabled('does-not-exist', { id: '1' });
+      expect(result).toBe(false);
+    });
+
+    it('returns false for a disabled flag with no targeting', async () => {
+      await createFlag({ key: 'off-flag', isEnabled: false, percentage: 100 }, 'admin');
+      const result = await isFeatureEnabled('off-flag', { id: 'any-user' });
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/frontend/app/admin/flags/page.jsx
+++ b/frontend/app/admin/flags/page.jsx
@@ -1,0 +1,209 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useAdminStore } from '../../../store/app-store';
+import { buildAdminHeaders } from '../../../store/admin';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+const EMPTY_FORM = { key: '', description: '', isEnabled: false, percentage: 0, targetUsers: '' };
+
+export default function FeatureFlagsPage() {
+  const { apiKey } = useAdminStore();
+  const [flags, setFlags] = useState([]);
+  const [error, setError] = useState('');
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [editingKey, setEditingKey] = useState(null);
+
+  const headers = buildAdminHeaders(apiKey);
+
+  const fetchFlags = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/api/admin/flags`, { headers });
+      const json = await res.json();
+      setFlags(json.data ?? []);
+    } catch {
+      setError('Failed to load flags.');
+    }
+  }, [apiKey]);
+
+  useEffect(() => { fetchFlags(); }, [fetchFlags]);
+
+  async function saveFlag(e) {
+    e.preventDefault();
+    const payload = {
+      ...form,
+      percentage: Number(form.percentage),
+      targetUsers: form.targetUsers.split(',').map((s) => s.trim()).filter(Boolean),
+    };
+
+    const url = editingKey
+      ? `${API_BASE}/api/admin/flags/${editingKey}`
+      : `${API_BASE}/api/admin/flags`;
+    const method = editingKey ? 'PATCH' : 'POST';
+
+    const res = await fetch(url, {
+      method,
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!res.ok) {
+      const json = await res.json();
+      setError(json.error ?? 'Save failed.');
+      return;
+    }
+
+    setForm(EMPTY_FORM);
+    setEditingKey(null);
+    fetchFlags();
+  }
+
+  async function toggleFlag(flag) {
+    await fetch(`${API_BASE}/api/admin/flags/${flag.key}`, {
+      method: 'PATCH',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isEnabled: !flag.isEnabled }),
+    });
+    fetchFlags();
+  }
+
+  async function deleteFlag(key) {
+    if (!confirm(`Delete flag "${key}"?`)) return;
+    await fetch(`${API_BASE}/api/admin/flags/${key}`, { method: 'DELETE', headers });
+    fetchFlags();
+  }
+
+  function startEdit(flag) {
+    setEditingKey(flag.key);
+    setForm({
+      key: flag.key,
+      description: flag.description,
+      isEnabled: flag.isEnabled,
+      percentage: flag.percentage,
+      targetUsers: flag.targetUsers.join(', '),
+    });
+  }
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold text-white mb-6">Feature Flags</h1>
+
+      {error && <p className="text-red-400 mb-4">{error}</p>}
+
+      {/* ── Create / Edit Form ── */}
+      <form onSubmit={saveFlag} className="card mb-8 space-y-4">
+        <h2 className="text-lg font-semibold text-white">
+          {editingKey ? `Edit: ${editingKey}` : 'New Flag'}
+        </h2>
+
+        <div className="grid grid-cols-2 gap-4">
+          <input
+            className="input col-span-2"
+            placeholder="Flag key (e.g. new-dashboard)"
+            value={form.key}
+            onChange={(e) => setForm({ ...form, key: e.target.value })}
+            disabled={!!editingKey}
+            required
+          />
+          <input
+            className="input col-span-2"
+            placeholder="Description"
+            value={form.description}
+            onChange={(e) => setForm({ ...form, description: e.target.value })}
+          />
+
+          <label className="flex items-center gap-2 text-gray-300">
+            <input
+              type="checkbox"
+              checked={form.isEnabled}
+              onChange={(e) => setForm({ ...form, isEnabled: e.target.checked })}
+            />
+            Enabled
+          </label>
+
+          <label className="flex flex-col text-gray-300 text-sm">
+            Rollout: {form.percentage}%
+            <input
+              type="range"
+              min={0}
+              max={100}
+              value={form.percentage}
+              onChange={(e) => setForm({ ...form, percentage: Number(e.target.value) })}
+              className="mt-1"
+            />
+          </label>
+
+          <input
+            className="input col-span-2"
+            placeholder="Beta user IDs (comma-separated)"
+            value={form.targetUsers}
+            onChange={(e) => setForm({ ...form, targetUsers: e.target.value })}
+          />
+        </div>
+
+        <div className="flex gap-2">
+          <button type="submit" className="btn-primary">
+            {editingKey ? 'Update' : 'Create'}
+          </button>
+          {editingKey && (
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={() => { setEditingKey(null); setForm(EMPTY_FORM); }}
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+      </form>
+
+      {/* ── Flags Table ── */}
+      <div className="space-y-3">
+        {flags.length === 0 && <p className="text-gray-500">No flags defined yet.</p>}
+        {flags.map((flag) => (
+          <div key={flag.key} className="card flex items-center justify-between gap-4">
+            <div className="flex-1 min-w-0">
+              <p className="font-mono font-semibold text-white">{flag.key}</p>
+              {flag.description && <p className="text-sm text-gray-400">{flag.description}</p>}
+              <p className="text-xs text-gray-500 mt-1">
+                Rollout: {flag.percentage}%
+                {flag.targetUsers.length > 0 && ` · ${flag.targetUsers.length} targeted user(s)`}
+              </p>
+            </div>
+
+            <div className="flex items-center gap-3 shrink-0">
+              {/* Toggle switch */}
+              <button
+                onClick={() => toggleFlag(flag)}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                  flag.isEnabled ? 'bg-green-500' : 'bg-gray-600'
+                }`}
+                aria-label={`Toggle ${flag.key}`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                    flag.isEnabled ? 'translate-x-6' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+
+              <button
+                onClick={() => startEdit(flag)}
+                className="text-sm text-blue-400 hover:text-blue-300"
+              >
+                Edit
+              </button>
+              <button
+                onClick={() => deleteFlag(flag.key)}
+                className="text-sm text-red-400 hover:text-red-300"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
closes #245 

## Description

<!-- What does this PR change and why? -->

## Related Issue

Closes #<!-- issue number -->

## Type of Change

- [ ] 🦀 Smart contract (Rust/Soroban)
- [ ] 🖥️ Backend (Node.js)
- [ ] 🎨 Frontend (Next.js/React)
- [ ] 📚 Documentation
- [ ] 🧪 Tests
- [ ] 🐛 Bug fix

## Checklist

- [ ] Branch is up to date with `main`
- [ ] Contract: `cargo fmt` + `cargo clippy -- -D warnings` pass
- [ ] Backend: `npm run lint` passes
- [ ] Frontend: `npm run lint` passes
- [ ] Tests added for new functionality
- [ ] PR description clearly explains the change
- [ ] Linked the issue with `Closes #N`

Adds an internal feature flag system with deterministic percentage-based rollouts, explicit user targeting, audit logging on every change, and an admin dashboard UI.

## New Files

| File | Purpose |
|---|---|
| `backend/services/featureFlags.js` | Core service: evaluation logic, CRUD, audit logging |
| `backend/api/controllers/featureFlagController.js` | Thin CRUD controller |
| `backend/api/middleware/featureFlags.js` | Attaches `req.user.activeFlags` map after auth |
| `backend/database/migrations/20260327000001_feature_flags.js` | DB migration |
| `backend/tests/featureFlags.test.js` | Test suite |
| `frontend/app/admin/flags/page.jsx` | Admin dashboard UI |

## Modified Files

- `backend/database/schema.prisma` — added `FeatureFlag` model
- `backend/api/routes/adminRoutes.js` — added CRUD routes under `/api/admin/flags` (protected by existing `adminAuth`)

## Implementation Details

**Evaluation logic (`isFeatureEnabled`):**
1. Flag not found → `false`
2. `isEnabled: false` but user is in `targetUsers` → `true` (beta override)
3. `isEnabled: false` otherwise → `false`
4. User in `targetUsers` → `true`
5. `SHA-256(userId:flagKey) % 100 < percentage` → `true` (deterministic, consistent per user)

**Audit:** Every `createFlag`, `updateFlag`, `deleteFlag` call writes to the existing `AuditLog` table with `category: ADMIN`.

**Middleware:** `attachFeatureFlags` evaluates all flags for the authenticated user and attaches `req.user.activeFlags = { 'flag-key': true/false }` — controllers can branch without individual lookups.

**Frontend:** `/admin/flags` — toggle switches, percentage slider (0–100%), comma-separated beta user ID input, create/edit/delete.

## Tests (5 passing ✅)

- **Test 1 (Deterministic Rollout):** Finds real users that fall inside/outside a 20% bucket via the same hash function, verifies consistent results across multiple calls
- **Test 2 (Targeting):** `isEnabled: false` flag still returns `true` for a user in `targetUsers`; returns `false` for all others
- **Test 3 (Audit):** `auditLog.create` is called on both `createFlag` and `updateFlag` with correct action names
- Edge: non-existent flag → `false`; disabled flag at 100% with no targeting → `false`

## DB Migration

Run after merging:
bash
cd backend && node database/migrations/migrate.js up