### PR TITLE
#436 Add Wallet Address Validation 

### DIFF
--- a/frontend/app/escrow/create/page.jsx
+++ b/frontend/app/escrow/create/page.jsx
@@ -25,6 +25,8 @@ import { useSearchParams } from 'next/navigation';
 import Button from '../../../components/ui/Button';
 import ErrorAlert from '../../../components/ui/ErrorAlert';
 import TemplateSelector from '../../../components/escrow/TemplateSelector';
+import StellarAddressInput from '../../../components/ui/StellarAddressInput';
+import { isValidStellarAddress } from '../../../lib/validation';
 import templatesData from '../../../data/templates.json';
 
 const STEPS = [
@@ -211,7 +213,11 @@ export default function CreateEscrowPage() {
           Back
         </Button>
         {currentStep < 4 ? (
-          <Button variant="primary" onClick={() => setCurrentStep((step) => step + 1)}>
+          <Button
+            variant="primary"
+            onClick={() => setCurrentStep((step) => step + 1)}
+            disabled={currentStep === 1 && !isValidStellarAddress(formData.freelancerAddress)}
+          >
             Next →
           </Button>
         ) : (
@@ -234,20 +240,14 @@ function StepCounterparty({ formData, setFormData }) {
     <div className="space-y-4">
       <h2 className="text-lg font-semibold text-white">Counterparty & Funds</h2>
 
-      <div>
-        <label className="block text-sm text-gray-400 mb-1">Freelancer Stellar Address</label>
-        <input
-          type="text"
-          placeholder="GABCD1234..."
-          className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2.5
-                     text-white placeholder-gray-500 focus:outline-none focus:border-indigo-500"
-          value={formData.freelancerAddress}
-          onChange={(event) =>
-            setFormData((data) => ({ ...data, freelancerAddress: event.target.value }))
-          }
-        />
-        {/* TODO (contributor): add validation error display */}
-      </div>
+      <StellarAddressInput
+        id="freelancer-address"
+        label="Freelancer Stellar Address"
+        placeholder="GABCD1234..."
+        value={formData.freelancerAddress}
+        onChange={(val) => setFormData((data) => ({ ...data, freelancerAddress: val }))}
+        required
+      />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div>

--- a/frontend/components/ui/StellarAddressInput.jsx
+++ b/frontend/components/ui/StellarAddressInput.jsx
@@ -1,0 +1,57 @@
+import { isValidStellarAddress } from '../../lib/validation';
+
+/**
+ * Controlled address input with inline Stellar validation.
+ *
+ * Props:
+ *   value      {string}   controlled value
+ *   onChange   {function} called with the trimmed string on every keystroke
+ *   label      {string}   field label
+ *   placeholder {string}
+ *   id         {string}   for label/input association
+ *   required   {boolean}
+ */
+export default function StellarAddressInput({
+  value,
+  onChange,
+  label = 'Stellar Address',
+  placeholder = 'GABCD…',
+  id = 'stellar-address',
+  required = false,
+}) {
+  const touched = value.length > 0;
+  const isValid = isValidStellarAddress(value);
+  const showError = touched && !isValid;
+
+  function handleChange(e) {
+    onChange(e.target.value.trim());
+  }
+
+  return (
+    <div>
+      {label && (
+        <label htmlFor={id} className="block text-sm text-gray-400 mb-1">
+          {label}
+          {required && <span className="text-red-400 ml-1">*</span>}
+        </label>
+      )}
+      <input
+        id={id}
+        type="text"
+        placeholder={placeholder}
+        value={value}
+        onChange={handleChange}
+        aria-invalid={showError}
+        aria-describedby={showError ? `${id}-error` : undefined}
+        className={`w-full bg-gray-800 border rounded-lg px-4 py-2.5 text-white
+          placeholder-gray-500 focus:outline-none transition-colors
+          ${showError ? 'border-red-500 focus:border-red-400' : 'border-gray-700 focus:border-indigo-500'}`}
+      />
+      {showError && (
+        <p id={`${id}-error`} className="mt-1 text-xs text-red-400" role="alert">
+          Invalid Stellar address. Must be 56 characters starting with G.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/validation.js
+++ b/frontend/lib/validation.js
@@ -1,0 +1,14 @@
+/** Matches a valid Stellar public (G-address): G + 55 Base32 chars (A-Z, 2-7). */
+const STELLAR_ADDRESS_RE = /^G[A-Z2-7]{55}$/;
+
+/**
+ * Returns true if the given string is a valid Stellar G-address.
+ * Trims whitespace before checking so copy-paste errors are handled gracefully.
+ *
+ * @param {string} address
+ * @returns {boolean}
+ */
+export function isValidStellarAddress(address) {
+  if (typeof address !== 'string') return false;
+  return STELLAR_ADDRESS_RE.test(address.trim());
+}

--- a/frontend/tests/components/ui/StellarAddressInput.test.jsx
+++ b/frontend/tests/components/ui/StellarAddressInput.test.jsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import StellarAddressInput from '../../../components/ui/StellarAddressInput';
+
+const VALID = 'GA7YNBW5CBTJZ3ZZOWX3ZNBKD6OE7A7IHUQVWMY62W2ZBG2SGZVOOPVH';
+
+function renderInput(value, onChange = jest.fn()) {
+  return render(
+    <StellarAddressInput value={value} onChange={onChange} id="test-addr" />,
+  );
+}
+
+describe('StellarAddressInput', () => {
+  it('Test 1: shows error for a 55-character string', () => {
+    renderInput(VALID.slice(0, 55));
+    expect(screen.getByRole('alert')).toHaveTextContent('Invalid Stellar address');
+  });
+
+  it('Test 2: shows error for a 56-character string starting with S', () => {
+    renderInput('S' + VALID.slice(1));
+    expect(screen.getByRole('alert')).toHaveTextContent('Invalid Stellar address');
+  });
+
+  it('Test 3: shows no error and marks input valid for a correct G-address', () => {
+    renderInput(VALID);
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('shows no error when the field is empty (not yet touched)', () => {
+    renderInput('');
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('trims whitespace and calls onChange with trimmed value', () => {
+    const onChange = jest.fn();
+    renderInput('', onChange);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: `  ${VALID}  ` } });
+    expect(onChange).toHaveBeenCalledWith(VALID);
+  });
+
+  it('marks input aria-invalid when value is invalid', () => {
+    renderInput('INVALID');
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+  });
+});

--- a/frontend/tests/lib/validation.test.js
+++ b/frontend/tests/lib/validation.test.js
@@ -1,0 +1,40 @@
+import { isValidStellarAddress } from '../../lib/validation';
+
+describe('isValidStellarAddress', () => {
+  const VALID = 'GA7YNBW5CBTJZ3ZZOWX3ZNBKD6OE7A7IHUQVWMY62W2ZBG2SGZVOOPVH';
+
+  it('Test 1: rejects a 55-character string', () => {
+    const short = VALID.slice(0, 55); // 55 chars
+    expect(isValidStellarAddress(short)).toBe(false);
+  });
+
+  it('Test 2: rejects a 56-character string starting with S (secret key)', () => {
+    const secretKey = 'S' + VALID.slice(1); // same length, starts with S
+    expect(isValidStellarAddress(secretKey)).toBe(false);
+  });
+
+  it('Test 3: accepts a valid G-address and returns true', () => {
+    expect(isValidStellarAddress(VALID)).toBe(true);
+  });
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(isValidStellarAddress(`  ${VALID}  `)).toBe(true);
+  });
+
+  it('rejects a 57-character string', () => {
+    expect(isValidStellarAddress(VALID + 'A')).toBe(false);
+  });
+
+  it('rejects lowercase characters', () => {
+    expect(isValidStellarAddress(VALID.toLowerCase())).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(isValidStellarAddress('')).toBe(false);
+  });
+
+  it('rejects non-string input', () => {
+    expect(isValidStellarAddress(null)).toBe(false);
+    expect(isValidStellarAddress(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

<!-- What does this PR change and why? -->

closes #436 
 

Adds a reusable Stellar G-address validation utility, a controlled `StellarAddressInput` component with real-time error feedback, and integrates it into the Create Escrow form.

## New Files

| File | Purpose |
|---|---|
| `frontend/lib/validation.js` | `isValidStellarAddress(address)` utility |
| `frontend/components/ui/StellarAddressInput.jsx` | Reusable controlled input with inline validation |
| `frontend/tests/lib/validation.test.js` | Unit tests for the utility |
| `frontend/tests/components/ui/StellarAddressInput.test.jsx` | Component tests |

## Modified Files

- `frontend/app/escrow/create/page.jsx` — replaced raw address `<input>` in `StepCounterparty` with `<StellarAddressInput>`; "Next →" button disabled until address is valid

## Implementation Details

**Validation rule:** `/^G[A-Z2-7]{55}$/` — exactly 56 chars, starts with `G`, only uppercase Base32 characters (A–Z, 2–7).

**Whitespace trimming:** `onChange` trims the value before passing it up, silently handling copy-paste padding.

**UX:** Error message only appears after the user has typed something (not on empty/untouched fields). Clears immediately once the address becomes valid. Input border turns red on error, indigo on focus when valid. `aria-invalid` and `aria-describedby` set for screen reader accessibility.

**`StellarAddressInput` props:** `value`, `onChange`, `label`, `placeholder`, `id`, `required` — drop-in for any address field.

## Tests (14 passing ✅)

**Utility (`validation.test.js`):**
- Test 1: 55-char string → `false`
- Test 2: 56-char string starting with `S` → `false`
- Test 3: valid `GA7YNB…` address → `true`
- Whitespace trimming, 57-char, lowercase, empty string, non-string inputs

**Component (`StellarAddressInput.test.jsx`):**
- Test 1: 55-char input shows error alert
- Test 2: S-prefixed input shows error alert
- Test 3: valid address shows no error, `aria-invalid` not set
- Empty field shows no error (untouched state)
- `onChange` called with trimmed value
- `aria-invalid="true"` set on invalid input

- [ ] 🦀 Smart contract (Rust/Soroban)
- [ ] 🖥️ Backend (Node.js)
- [ ] 🎨 Frontend (Next.js/React)
- [ ] 📚 Documentation
- [ ] 🧪 Tests
- [ ] 🐛 Bug fix

## Checklist

- [ ] Branch is up to date with `main`
- [ ] Contract: `cargo fmt` + `cargo clippy -- -D warnings` pass
- [ ] Backend: `npm run lint` passes
- [ ] Frontend: `npm run lint` passes
- [ ] Tests added for new functionality
- [ ] PR description clearly explains the change
- [ ] Linked the issue with `Closes #N`
