### PR TITLE
feat: add responsive layout to dashboard stats

### DIFF
--- a/frontend/app/dashboard/page.jsx
+++ b/frontend/app/dashboard/page.jsx
@@ -139,7 +139,7 @@ return (
         </div>
         <Suspense
           fallback={
-            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
               {Array.from({ length: 6 }).map((_, i) => (
                 <div key={i} className="card animate-pulse">
                   <div className="h-3 w-20 bg-gray-700 rounded mb-3" />

--- a/frontend/components/dashboard/StatWidgets.jsx
+++ b/frontend/components/dashboard/StatWidgets.jsx
@@ -114,7 +114,7 @@ export default function StatWidgets({ address }) {
 
   if (loading) {
     return (
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
         {Array.from({ length: 6 }).map((_, i) => (
           <SkeletonCard key={i} />
         ))}
@@ -133,7 +133,7 @@ export default function StatWidgets({ address }) {
   // Empty state — user has no escrows yet
   if (!stats || stats.total === 0) {
     return (
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
         <StatWidget label="Total Escrows" value={0} icon="📦" />
         <StatWidget label="Active" value={0} icon="🔒" color="text-indigo-400" />
         <StatWidget label="Completed" value={0} icon="✅" color="text-emerald-400" />
@@ -145,7 +145,7 @@ export default function StatWidgets({ address }) {
   }
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
       <StatWidget label="Total Escrows" value={stats.total} icon="📦" />
       <StatWidget label="Active" value={stats.active} icon="🔒" color="text-indigo-400" />
       <StatWidget label="Completed" value={stats.completed} icon="✅" color="text-emerald-400" />

--- a/frontend/components/ui/StatCard.jsx
+++ b/frontend/components/ui/StatCard.jsx
@@ -2,6 +2,7 @@
  * StatCard Component
  *
  * Small card displaying a single metric with label, value, and optional icon.
+ * Responsive design: stacks vertically on mobile, grid layout on tablet/desktop.
  *
  * @param {object} props
  * @param {string} props.label
@@ -12,12 +13,12 @@
 
 export default function StatCard({ label, value, icon, trend: _trend }) {
   return (
-    <div className="card flex flex-col gap-2">
+    <div className="card flex flex-col gap-2 w-full sm:w-auto">
       <div className="flex items-center justify-between">
         <p className="text-xs text-gray-500 uppercase tracking-wider">{label}</p>
         {icon && <span className="text-lg">{icon}</span>}
       </div>
-      <p className="text-2xl font-bold text-white">{value}</p>
+      <p className="text-2xl font-bold text-white break-all">{value}</p>
       {/* TODO (contributor — easy): add trend arrow and percentage */}
     </div>
   );


### PR DESCRIPTION
- Make StatCard responsive with w-full on mobile
- Update grid layout: 1 column mobile, 2 small tablet, 3 tablet, 6 desktop
- Add break-all for long values on small screens
- Ensure cards stack vertically on mobile (375px width)
- Maintain 2x2 grid on tablet devices
- Prevent horizontal overflow on mobile viewports

Closes #443

## Description

<!-- What does this PR change and why? -->

## Related Issue

Closes #<!-- issue number -->

## Type of Change

- [ ] 🦀 Smart contract (Rust/Soroban)
- [ ] 🖥️ Backend (Node.js)
- [ ] 🎨 Frontend (Next.js/React)
- [ ] 📚 Documentation
- [ ] 🧪 Tests
- [ ] 🐛 Bug fix

## Checklist

- [ ] Branch is up to date with `main`
- [ ] Contract: `cargo fmt` + `cargo clippy -- -D warnings` pass
- [ ] Backend: `npm run lint` passes
- [ ] Frontend: `npm run lint` passes
- [ ] Tests added for new functionality
- [ ] PR description clearly explains the change
- [ ] Linked the issue with `Closes #N`
