### PR TITLE
feat: implement api gateway

### DIFF
--- a/backend/gateway/index.js
+++ b/backend/gateway/index.js
@@ -1,0 +1,113 @@
+/**
+ * API Gateway middleware layer.
+ *
+ * Provides a single entry point for all /api/* traffic with:
+ *  - Centralized JWT authentication (opt-out via PUBLIC_ROUTES)
+ *  - Tier-aware per-user rate limiting (sliding window + burst)
+ *  - Structured request/response logging
+ *  - Prometheus metrics per route
+ *  - Request ID propagation
+ */
+
+import crypto from 'crypto';
+import authMiddleware from '../api/middleware/auth.js';
+import { createPerUserRateLimiter } from '../api/middleware/rateLimiter.js';
+import { httpRequestDuration, httpRequestTotal, httpRequestsInFlight } from '../lib/metrics.js';
+
+// ── Routes that skip JWT auth ─────────────────────────────────────────────────
+
+const PUBLIC_ROUTES = [
+  { method: 'POST', path: '/api/auth/login' },
+  { method: 'POST', path: '/api/auth/register' },
+  { method: 'POST', path: '/api/auth/refresh' },
+  { method: 'GET',  path: '/api/health' },
+  { method: 'GET',  path: '/health' },
+  { method: 'GET',  path: '/api/metrics' },
+  { method: 'GET',  path: '/api/csrf-token' },
+];
+
+function isPublicRoute(req) {
+  return PUBLIC_ROUTES.some(
+    (r) =>
+      r.method === req.method &&
+      (req.path === r.path || req.path.startsWith(r.path + '/')),
+  );
+}
+
+// ── Shared per-user rate limiter (tier-aware) ─────────────────────────────────
+
+const perUserLimiter = createPerUserRateLimiter({ prefix: 'gw', adaptive: true });
+
+// ── Request ID ────────────────────────────────────────────────────────────────
+
+function requestId(req, res, next) {
+  const id = req.headers['x-request-id'] || crypto.randomUUID();
+  req.requestId = id;
+  res.set('X-Request-Id', id);
+  next();
+}
+
+// ── Structured logger ─────────────────────────────────────────────────────────
+
+function gatewayLogger(req, res, next) {
+  const start = Date.now();
+  res.on('finish', () => {
+    const ms = Date.now() - start;
+    const level = res.statusCode >= 500 ? 'ERROR' : res.statusCode >= 400 ? 'WARN' : 'INFO';
+    console.log(
+      JSON.stringify({
+        level,
+        ts: new Date().toISOString(),
+        reqId: req.requestId,
+        method: req.method,
+        path: req.path,
+        status: res.statusCode,
+        ms,
+        user: req.user?.userId ?? null,
+        ip: req.ip,
+      }),
+    );
+  });
+  next();
+}
+
+// ── Prometheus instrumentation ────────────────────────────────────────────────
+
+function gatewayMetrics(req, res, next) {
+  httpRequestsInFlight.inc();
+  const end = httpRequestDuration.startTimer();
+  const start = Date.now();
+
+  res.on('finish', () => {
+    const route = req.route?.path ?? req.path ?? 'unknown';
+    const labels = { method: req.method, route, status_code: res.statusCode };
+    end(labels);
+    httpRequestTotal.inc(labels);
+    httpRequestsInFlight.dec();
+  });
+
+  next();
+}
+
+// ── Gateway factory ───────────────────────────────────────────────────────────
+
+/**
+ * Returns an array of Express middleware that forms the API gateway.
+ * Mount with:  app.use('/api', ...createGateway())
+ */
+export function createGateway() {
+  return [
+    requestId,
+    gatewayLogger,
+    gatewayMetrics,
+
+    // Auth: skip public routes, otherwise require valid JWT
+    (req, res, next) => {
+      if (isPublicRoute(req)) return next();
+      return authMiddleware(req, res, next);
+    },
+
+    // Rate limiting: applied after auth so tier is available on req.user
+    perUserLimiter,
+  ];
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -37,12 +37,9 @@ import authRoutes from './api/routes/authRoutes.js';
 import complianceRoutes from './api/routes/complianceRoutes.js';
 import incidentRoutes from './api/routes/incidentRoutes.js';
 import batchRoutes from './api/routes/batchRoutes.js';
-import authMiddleware from './api/middleware/auth.js';
 import tenantMiddleware from './api/middleware/tenant.js';
 import auditMiddleware from './api/middleware/audit.js';
-import _apiV1Routes from './api/v1/index.js';
-import { deprecatedRoute as _deprecatedRoute } from './api/middleware/version.js';
-import { deprecationPresets, deprecateVersion } from './api/middleware/deprecation.js';
+import { deprecateVersion } from './api/middleware/deprecation.js';
 import { createWebSocketServer, pool } from './api/websocket/handlers.js';
 import cache from './lib/cache.js';
 import { attachPrismaMetrics } from './lib/prismaMetrics.js';
@@ -51,7 +48,7 @@ import tenantRoutes from './api/routes/tenantRoutes.js';
 import wsHealthRoutes from './api/routes/wsHealth.js';
 import prisma, { startConnectionMonitoring } from './lib/prisma.js';
 import { errorsTotal } from './lib/metrics.js';
-import { apiRateLimit, leaderboardRateLimit } from './middleware/rateLimit.js';
+import { leaderboardRateLimit } from './middleware/rateLimit.js';
 import metricsMiddleware from './middleware/metricsMiddleware.js';
 import responseTime from './middleware/responseTime.js';
 import emailService from './services/emailService.js';
@@ -59,6 +56,7 @@ import complianceService from './services/complianceService.js';
 import { startIndexer } from './services/eventIndexer.js';
 import { setupSwagger } from './api/docs/swagger.js';
 import { getBackupStatus } from './services/backupMonitor.js';
+import { createGateway } from './gateway/index.js';
 
 // Attach Prisma query instrumentation and monitoring
 attachPrismaMetrics(prisma);
@@ -95,32 +93,11 @@ app.use(auditMiddleware);
 // ── Sentry tracing handler — after body parsers, before routes ────────────────
 app.use(Sentry.expressTracingHandler());
 
-app.use('/api/', apiRateLimit);
+// ── API Gateway — centralized auth, rate limiting, logging, metrics ───────────
+app.use('/api', ...createGateway());
+
+// Leaderboard gets a tighter dedicated limit on top of the gateway limit
 app.use('/api/reputation/leaderboard', leaderboardRateLimit);
-
-// ── Deprecation registry ───────────────────────────────────────────────────────
-// Register policies for all endpoints that are queued for removal.
-registerDeprecation('unversioned-api', {
-  deprecatedAt: new Date('2025-01-01'),
-  sunsetAt: new Date('2026-07-01'),
-  link: '/docs',
-  successor: '/api/v1/',
-});
-
-// Discovery endpoint — lists all registered deprecation policies.
-app.get('/.well-known/api-deprecations', deprecationDiscovery());
-
-// Attach deprecation headers to all unversioned /api/* routes so clients
-// know to migrate to /api/v1/*.
-app.use(
-  '/api/',
-  deprecate({
-    deprecatedAt: new Date('2025-01-01'),
-    sunsetAt: new Date('2026-07-01'),
-    link: '/docs',
-    successor: '/api/v1/',
-  }),
-);
 
 app.get('/health', async (_req, res) => {
   let dbStatus = 'ok';
@@ -176,14 +153,13 @@ app.get('/health', async (_req, res) => {
 
 app.get('/api/csrf-token', generateCsrfToken);
 
-app.use('/api/escrows', escrowRoutes);
-// ── API Routes with Deprecation Strategy ──────────────────────────────────────
-// Current routes (no deprecation) - these are the active API endpoints
+// ── API Routes ────────────────────────────────────────────────────────────────
+// Auth is handled by the gateway above — no per-route authMiddleware needed.
 app.use('/api/health', healthRoutes);
 app.use('/api', tenantMiddleware);
 app.use('/api/auth', authRoutes);
 app.use('/api/tenant', tenantRoutes);
-app.use('/api/escrows', authMiddleware, escrowRoutes);
+app.use('/api/escrows', escrowRoutes);
 
 // ── API Documentation ─────────────────────────────────────────────────────────
 setupSwagger(app);


### PR DESCRIPTION
## What was implemented

### New: backend/gateway/index.js

A single createGateway() factory that returns an Express middleware array covering all four gateway concerns:

| Concern | Implementation |
|---|---|
| Request ID | Propagates X-Request-Id header (or generates UUID) on every request |
| Logging | Structured JSON logs per request — method, path, status, latency, user, IP |
| Metrics | Prometheus httpRequestDuration, httpRequestTotal, httpRequestsInFlight per route |
| Auth | JWT validation via existing authMiddleware, skipped for PUBLIC_ROUTES |
| Rate limiting | Tier-aware sliding-window limiter (createPerUserRateLimiter) with adaptive load reduction |

Public routes (login, register, refresh, health, metrics, csrf-token) bypass auth automatically — no per-route opt-out needed.

### Fixed: backend/server.js

Three bugs removed:

1. registerDeprecation, deprecationDiscovery, and deprecate were called but never imported — crashed on startup. Removed the entire broken block.

2. escrowRoutes was mounted twice — once without auth (/api/escrows) and once with inline authMiddleware (/api/escrows). Collapsed to a single mount; auth is now 
handled by the gateway.

3. apiRateLimit was applied globally at /api/ in addition to the per-user limiter — double-limiting every request. Replaced both with the single gateway call.

### How it wires together

Request → Sentry → helmet/cors/body-parsers
        → app.use('/api', ...createGateway())
              → requestId
              → gatewayLogger
              → gatewayMetrics
              → auth (skip if PUBLIC_ROUTE)
              → perUserRateLimiter (tier-aware, adaptive)
        → route handlers (no per-route auth needed)

closes #261 