### PR TITLE
feat: add back to top button

### DIFF
--- a/frontend/app/layout.jsx
+++ b/frontend/app/layout.jsx
@@ -25,6 +25,7 @@ import { ToastProvider } from '../contexts/ToastContext';
 import ServiceWorkerRegistrar from '../components/ServiceWorkerRegistrar';
 import ErrorBoundary from '../components/error/ErrorBoundary';
 import PerformanceMonitor from '../components/performance/PerformanceMonitor';
+import BackToTop from '../components/ui/BackToTop';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
 const jetbrainsMono = JetBrains_Mono({ subsets: ['latin'], variable: '--font-mono' });
@@ -83,6 +84,7 @@ export default function RootLayout({ children }) {
 
         {/* Core Web Vitals monitoring — renders nothing to DOM */}
         <PerformanceMonitor />
+        <BackToTop />
         <ServiceWorkerRegistrar />
       </body>
     </html>

--- a/frontend/components/ui/BackToTop.jsx
+++ b/frontend/components/ui/BackToTop.jsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { cn } from '../../lib/utils';
+
+/**
+ * BackToTop
+ *
+ * Renders a fixed bottom-right button that appears after the user scrolls
+ * past 300 px and smoothly scrolls back to the top on click.
+ */
+export default function BackToTop() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 300);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  return (
+    <button
+      type="button"
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      aria-label="Back to top"
+      className={cn(
+        'fixed bottom-6 right-6 z-50 p-3 rounded-full bg-indigo-600 hover:bg-indigo-500 text-white shadow-lg transition-opacity duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500',
+        visible ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none',
+      )}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="h-5 w-5"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          fillRule="evenodd"
+          d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z"
+          clipRule="evenodd"
+        />
+      </svg>
+    </button>
+  );
+}


### PR DESCRIPTION
Closes #433

- Add BackToTop component (components/ui/BackToTop.jsx)
  - Uses a scroll event listener (passive) to track window.scrollY
  - Button becomes visible after scrolling past 300px threshold
  - Hidden on initial load via opacity-0 / pointer-events-none
  - Smooth scroll to top on click via window.scrollTo({ behavior: 'smooth' })
  - Fixed position bottom-right (bottom-6 right-6), z-50
  - CSS opacity transition for show/hide animation
  - Accessible: aria-label='Back to top', aria-hidden on decorative SVG
  - Marked 'use client' for client-side scroll tracking

- Mount BackToTop globally in app/layout.jsx so it is available on all pages


