### PR TITLE
docs: add Wormhole bridge integration guide, slashing mechanism, reputation scoring, and arbiter role guide (#603 #604 #605 #606)

### DIFF
--- a/docs/arbiter-guide.md
+++ b/docs/arbiter-guide.md
@@ -1,0 +1,273 @@
+# Arbiter Role Guide
+
+This guide explains the arbiter role in `stellar-trust-escrow`: how an
+arbiter is selected, what they can and cannot do, the authorization
+requirements for dispute resolution, and best practices for choosing a
+trusted arbiter address.
+
+Relevant source locations:
+
+- `contracts/escrow_contract/src/lib.rs` — `create_escrow_internal`,
+  `raise_dispute`, `resolve_dispute`
+- `contracts/escrow_contract/src/types.rs` — `EscrowState.arbiter`,
+  `EscrowStatus`
+- `contracts/escrow_contract/src/errors.rs` — `EscrowError`
+
+---
+
+## Table of Contents
+
+1. [What Is an Arbiter?](#what-is-an-arbiter)
+2. [Assigning an Arbiter](#assigning-an-arbiter)
+3. [Raising a Dispute](#raising-a-dispute)
+4. [Resolving a Dispute](#resolving-a-dispute)
+   - [Authorization](#authorization)
+   - [Amount Constraint](#amount-constraint)
+   - [State Prerequisite](#state-prerequisite)
+5. [What the Arbiter Cannot Do](#what-the-arbiter-cannot-do)
+6. [Error Reference](#error-reference)
+7. [Best Practices](#best-practices)
+
+---
+
+## What Is an Arbiter?
+
+An arbiter is an optional trusted third party whose Stellar address is
+stored in `EscrowMeta.arbiter` at escrow creation time. When a dispute
+is raised, the arbiter is the only address (besides the contract admin)
+authorized to call `resolve_dispute` and distribute the frozen funds.
+
+If no arbiter is set (`arbiter = None`), the contract admin acts as the
+fallback resolver.
+
+---
+
+## Assigning an Arbiter
+
+The arbiter is set during `create_escrow` via the `arbiter` parameter:
+
+```rust
+pub fn create_escrow(
+    env: Env,
+    client: Address,
+    freelancer: Address,
+    token: Address,
+    total_amount: i128,
+    brief_hash: BytesN<32>,
+    arbiter: Option<Address>,   // <-- set here
+    deadline: Option<u64>,
+    lock_time: Option<u64>,
+) -> Result<u64, EscrowError>
+```
+
+Pass `Some(arbiter_address)` to assign an arbiter, or `None` to leave
+the admin as the fallback resolver.
+
+**The arbiter address cannot be changed after escrow creation.** If you
+need a different arbiter, the escrow must be cancelled and recreated.
+
+CLI example with an arbiter:
+
+```bash
+soroban contract invoke \
+  --id $ESCROW_CONTRACT \
+  --source $CLIENT_SECRET \
+  --network testnet \
+  -- create_escrow \
+  --client $CLIENT_ADDRESS \
+  --freelancer $FREELANCER_ADDRESS \
+  --token $TOKEN_ADDRESS \
+  --total_amount 5000000000 \
+  --brief_hash "$BRIEF_HASH" \
+  --arbiter "$ARBITER_ADDRESS" \
+  --deadline null \
+  --lock_time null
+```
+
+---
+
+## Raising a Dispute
+
+Either the client or the freelancer can raise a dispute while the escrow
+is `Active`:
+
+```rust
+pub fn raise_dispute(
+    env: Env,
+    caller: Address,          // must be client or freelancer
+    escrow_id: u64,
+    milestone_id: Option<u32>, // optional: mark a specific milestone as Disputed
+) -> Result<(), EscrowError>
+```
+
+What happens:
+
+1. `caller.require_auth()` — the caller must sign the transaction.
+2. The contract verifies `caller == meta.client || caller == meta.freelancer`.
+   Any other address receives `EscrowError::Unauthorized` (3).
+3. `meta.status` must be `Active`. If it is already `Disputed`,
+   `DisputeAlreadyExists` (23) is returned.
+4. `meta.status` is set to `Disputed` and saved.
+5. If `milestone_id` is provided and that milestone is `Pending` or
+   `Submitted`, its status is also set to `Disputed`.
+6. A `dis_rai` event is emitted.
+
+Once the escrow is `Disputed`, no further milestone approvals, rejections,
+or fund releases can occur until the dispute is resolved.
+
+CLI example:
+
+```bash
+soroban contract invoke \
+  --id $ESCROW_CONTRACT \
+  --source $CLIENT_SECRET \
+  --network testnet \
+  -- raise_dispute \
+  --caller $CLIENT_ADDRESS \
+  --escrow_id 42 \
+  --milestone_id 1
+```
+
+---
+
+## Resolving a Dispute
+
+```rust
+pub fn resolve_dispute(
+    env: Env,
+    caller: Address,
+    escrow_id: u64,
+    client_amount: i128,
+    freelancer_amount: i128,
+) -> Result<(), EscrowError>
+```
+
+### Authorization
+
+`caller` must be either:
+
+- The arbiter stored in `EscrowMeta.arbiter`, **or**
+- The contract admin (if no arbiter was set).
+
+The function calls `caller.require_auth()` — the arbiter must sign the
+transaction with their private key. Passing any other address returns
+`EscrowError::ArbiterOnly` (7).
+
+### Amount Constraint
+
+```
+client_amount + freelancer_amount == escrow.remaining_balance
+```
+
+The two amounts must sum exactly to `remaining_balance`. If they do not,
+`EscrowError::AmountMismatch` (20) is returned. This ensures no funds
+are lost or created during resolution.
+
+Examples for an escrow with `remaining_balance = 3_000_000_000` (300 USDC):
+
+| Scenario | `client_amount` | `freelancer_amount` |
+|----------|-----------------|---------------------|
+| Full refund to client | 3 000 000 000 | 0 |
+| Full payment to freelancer | 0 | 3 000 000 000 |
+| 50/50 split | 1 500 000 000 | 1 500 000 000 |
+| 70% freelancer | 900 000 000 | 2 100 000 000 |
+
+### State Prerequisite
+
+`meta.status` must be `EscrowStatus::Disputed` before `resolve_dispute`
+can be called. If the escrow is still `Active` or already `Completed`,
+`EscrowError::EscrowNotDisputed` (10) is returned.
+
+Typical flow:
+
+```
+raise_dispute(escrow_id)          → status = Disputed
+        |
+        v
+[arbiter reviews evidence off-chain]
+        |
+        v
+resolve_dispute(escrow_id, client_amount, freelancer_amount)
+        |
+        v
+Funds transferred; status = Completed
+dis_res event emitted
+rep_upd events emitted for both parties
+```
+
+CLI example:
+
+```bash
+soroban contract invoke \
+  --id $ESCROW_CONTRACT \
+  --source $ARBITER_SECRET \
+  --network testnet \
+  -- resolve_dispute \
+  --caller $ARBITER_ADDRESS \
+  --escrow_id 42 \
+  --client_amount 1000000000 \
+  --freelancer_amount 2000000000
+```
+
+---
+
+## What the Arbiter Cannot Do
+
+The arbiter's authority is intentionally narrow. The following actions
+are **not** available to the arbiter:
+
+| Action | Who can do it |
+|--------|--------------|
+| Approve a milestone | Client only |
+| Reject a milestone | Client only |
+| Submit a milestone | Freelancer only |
+| Cancel an escrow | Client only (via `cancel_escrow`) |
+| Add a milestone | Client only |
+| Upgrade the contract | Admin only |
+| Change the arbiter address | Nobody — immutable after creation |
+| Raise a dispute | Client or freelancer only |
+| Resolve a dispute on a non-disputed escrow | Nobody — `EscrowNotDisputed` (10) |
+
+The arbiter cannot unilaterally move funds unless a dispute has been
+raised first. They also cannot resolve a dispute with amounts that do
+not sum to `remaining_balance`.
+
+---
+
+## Error Reference
+
+| Code | Name | When it occurs |
+|------|------|----------------|
+| 3 | `Unauthorized` | `raise_dispute` called by an address that is neither client nor freelancer. |
+| 7 | `ArbiterOnly` | `resolve_dispute` called by an address that is neither the arbiter nor the admin. |
+| 9 | `EscrowNotActive` | `raise_dispute` called on an escrow that is not `Active`. |
+| 10 | `EscrowNotDisputed` | `resolve_dispute` called on an escrow that is not `Disputed`. |
+| 20 | `AmountMismatch` | `client_amount + freelancer_amount != remaining_balance`. |
+| 23 | `DisputeAlreadyExists` | `raise_dispute` called on an escrow already in `Disputed` state. |
+
+---
+
+## Best Practices
+
+**Choose a neutral, independent arbiter.** The arbiter should have no
+financial stake in the outcome. Good candidates include:
+
+- A mutually agreed-upon escrow service provider.
+- A DAO multisig controlled by community members.
+- A professional dispute resolution service with a published Stellar address.
+
+**Use a multisig arbiter for high-value escrows.** Stellar supports
+multisig accounts. Setting the arbiter to a 2-of-3 multisig address
+means no single party can unilaterally resolve the dispute.
+
+**Document the arbiter's process off-chain.** The contract does not
+enforce how the arbiter reaches their decision. Include the arbiter's
+dispute resolution process in the project brief (stored as `brief_hash`).
+
+**Verify the arbiter address before creating the escrow.** Once set,
+the arbiter address cannot be changed. Double-check the address is
+correct and that the arbiter has agreed to serve in this role.
+
+**If no arbiter is set, the admin resolves disputes.** For production
+escrows, always set an explicit arbiter. Relying on the contract admin
+as the fallback resolver introduces centralization risk.

--- a/docs/bridge-integration.md
+++ b/docs/bridge-integration.md
@@ -1,0 +1,396 @@
+# Wormhole Bridge Integration Guide
+
+This guide explains how to register cross-chain wrapped tokens with
+`stellar-trust-escrow` and use them inside escrow agreements.
+
+The bridge subsystem lives in `contracts/escrow_contract/src/bridge.rs`
+and is exposed through four public contract functions in `lib.rs`.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Core Types](#core-types)
+3. [Constants](#constants)
+4. [Contract Functions](#contract-functions)
+5. [WormholeBridgeInterface Trait](#wormholebridgeinterface-trait)
+6. [Using a Bridged Token in an Escrow](#using-a-bridged-token-in-an-escrow)
+7. [Finalization Requirement](#finalization-requirement)
+8. [BridgeError (Error Code 54)](#bridgeerror-error-code-54)
+9. [End-to-End CLI Walkthrough](#end-to-end-cli-walkthrough)
+
+---
+
+## Overview
+
+Wormhole and Allbridge allow tokens from EVM chains (Ethereum, BNB Chain,
+Polygon, etc.) to be represented on Stellar as Stellar Asset Contract (SAC)
+addresses. Before such a wrapped token can be used as the payment token in
+an escrow, the contract must:
+
+1. Know the Wormhole bridge contract address on Stellar (`set_wormhole_bridge`).
+2. Have the wrapped token registered with its origin-chain metadata (`register_wrapped_token`).
+3. Have received enough on-chain confirmations that the bridge transfer is
+   considered final (`update_bridge_confirmation` → `is_finalized = true`).
+
+Only after all three steps will `validate_escrow_token` and
+`require_bridge_finalized` allow the token to be used in `create_escrow`.
+
+---
+
+## Core Types
+
+### BridgeProtocol
+
+```rust
+pub enum BridgeProtocol {
+    Wormhole,
+    Allbridge,
+}
+```
+
+| Variant | Description |
+|---------|-------------|
+| `Wormhole` | Token bridged via the Wormhole protocol. The contract calls `WormholeBridgeInterface::is_wrapped_asset` to verify the token on-chain before registration. |
+| `Allbridge` | Token bridged via Allbridge Core. Verification is performed off-chain; the admin registers the token manually. |
+
+### WrappedTokenInfo
+
+```rust
+pub struct WrappedTokenInfo {
+    pub stellar_address: Address,
+    pub origin_chain: u16,
+    pub origin_address: BytesN<32>,
+    pub bridge: BridgeProtocol,
+    pub is_approved: bool,
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stellar_address` | `Address` | The SAC address callers pass as `token` in `create_escrow`. |
+| `origin_chain` | `u16` | Wormhole chain ID (2 = Ethereum, 4 = BSC, 5 = Polygon, 6 = Avalanche). |
+| `origin_address` | `BytesN<32>` | 32-byte zero-padded EVM address of the original token contract. |
+| `bridge` | `BridgeProtocol` | `Wormhole` or `Allbridge`. |
+| `is_approved` | `bool` | Admin approval flag. Set to `true` by `register_wrapped_token`. Must be `true` before `validate_escrow_token` will accept the token. |
+
+### BridgeConfirmation
+
+```rust
+pub struct BridgeConfirmation {
+    pub token: Address,
+    pub confirmations: u32,
+    pub is_finalized: bool,
+    pub last_updated: u64,
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `token` | The SAC address this record belongs to. |
+| `confirmations` | Number of source-chain block confirmations observed so far. |
+| `is_finalized` | `true` when `confirmations >= MIN_BRIDGE_CONFIRMATIONS`. Set automatically by `update_bridge_confirmation`. |
+| `last_updated` | Ledger timestamp of the last `update_bridge_confirmation` call. |
+
+---
+
+## Constants
+
+| Constant | Value | File | Meaning |
+|----------|-------|------|---------|
+| `MIN_BRIDGE_CONFIRMATIONS` | `15` | `bridge.rs` | Minimum source-chain block confirmations required before a bridged token is considered final and safe to use in an escrow. |
+
+15 confirmations provides strong probabilistic finality on Ethereum
+(approximately 3 minutes at 12 s/block) and is even safer on faster
+chains such as BSC or Polygon.
+
+---
+
+## Contract Functions
+
+### set_wormhole_bridge
+
+```rust
+pub fn set_wormhole_bridge(
+    env: Env,
+    caller: Address,   // must be contract admin
+    bridge: Address,   // Wormhole token bridge SAC address on Stellar
+) -> Result<(), EscrowError>
+```
+
+Stores the Wormhole bridge contract address in instance storage.
+This address is used by `WormholeBridgeInterface::is_wrapped_asset`
+to verify that a given SAC is genuinely a Wormhole-wrapped token.
+
+**Must be called once before any `register_wrapped_token` call that
+uses `BridgeProtocol::Wormhole`.**
+
+Authorization: `caller` must be the contract admin and must sign the
+transaction (`require_auth()`).
+
+---
+
+### register_wrapped_token
+
+```rust
+pub fn register_wrapped_token(
+    env: Env,
+    caller: Address,
+    stellar_address: Address,
+    origin_chain: u16,
+    origin_address: BytesN<32>,
+    bridge: BridgeProtocol,
+) -> Result<(), EscrowError>
+```
+
+Registers a wrapped token and sets `is_approved = true`. For
+`BridgeProtocol::Wormhole`, the function calls
+`WormholeBridgeInterface::is_wrapped_asset` on the stored bridge address
+to verify the token on-chain before storing it. If the bridge returns
+`false`, the call reverts with `BridgeError` (54).
+
+After registration the token is known to the contract but **not yet
+usable in escrows** — a `BridgeConfirmation` with `is_finalized = true`
+is still required.
+
+Authorization: admin only.
+
+---
+
+### update_bridge_confirmation
+
+```rust
+pub fn update_bridge_confirmation(
+    env: Env,
+    caller: Address,
+    token: Address,
+    confirmations: u32,
+) -> Result<(), EscrowError>
+```
+
+Updates (or creates) the `BridgeConfirmation` record for `token`.
+If `confirmations >= MIN_BRIDGE_CONFIRMATIONS` the record's
+`is_finalized` field is set to `true`.
+
+This function is called by an off-chain relayer or admin script that
+monitors the source chain and submits confirmation counts as blocks
+accumulate.
+
+Authorization: admin only.
+
+---
+
+### get_bridge_confirmation
+
+```rust
+pub fn get_bridge_confirmation(
+    env: Env,
+    token: Address,
+) -> Result<BridgeConfirmation, EscrowError>
+```
+
+Read-only view. Returns the current `BridgeConfirmation` for `token`,
+or `BridgeError` (54) if no record exists yet.
+
+---
+
+## WormholeBridgeInterface Trait
+
+```rust
+pub trait WormholeBridgeInterface {
+    fn is_wrapped_asset(env: &Env, bridge: &Address, token: &Address) -> bool;
+}
+```
+
+This trait is called internally by `register_wrapped_token` when
+`bridge == BridgeProtocol::Wormhole`. It invokes the Wormhole token
+bridge contract at the stored `bridge` address and asks whether `token`
+is a genuine wrapped asset.
+
+You do not call this trait directly. If the Wormhole bridge contract
+returns `false`, `register_wrapped_token` returns `BridgeError` (54)
+and the token is not stored.
+
+For `BridgeProtocol::Allbridge`, this check is skipped — the admin is
+trusted to supply correct metadata.
+
+---
+
+## Using a Bridged Token in an Escrow
+
+Once a token is registered and finalized, pass its `stellar_address` as
+the `token` argument to `create_escrow`:
+
+```bash
+soroban contract invoke \
+  --id $ESCROW_CONTRACT \
+  --source $CLIENT_SECRET \
+  --network testnet \
+  -- create_escrow \
+  --client $CLIENT_ADDRESS \
+  --freelancer $FREELANCER_ADDRESS \
+  --token $WRAPPED_USDC_SAC \
+  --total_amount 1000000000 \
+  --brief_hash "$(echo -n 'QmYourIpfsHash' | xxd -p -c 32)" \
+  --arbiter null \
+  --deadline null \
+  --lock_time null
+```
+
+Internally, `create_escrow` calls `validate_escrow_token` which:
+
+1. Checks whether `token` is registered in `WrappedTokenInfo`.
+2. If registered, calls `require_bridge_finalized` which reads the
+   `BridgeConfirmation` and panics with `BridgeError` (54) if
+   `is_finalized == false`.
+3. If the token is not registered at all, it is treated as a native
+   Stellar asset and no bridge checks are performed.
+
+---
+
+## Finalization Requirement
+
+```
+is_finalized = (confirmations >= MIN_BRIDGE_CONFIRMATIONS)
+             = (confirmations >= 15)
+```
+
+`require_bridge_finalized` is called by `validate_escrow_token` before
+any escrow creation involving a registered wrapped token. If the
+confirmation count has not yet reached 15, the call reverts with
+`BridgeError` (54).
+
+**Why 15?** On Ethereum, 15 blocks (approximately 3 minutes) provides
+strong probabilistic finality. On faster chains (BSC, Polygon) 15 blocks
+is even safer. The constant can be updated via a contract upgrade if
+network conditions change.
+
+Workflow:
+
+```
+Bridge transfer submitted on source chain
+        |
+        v
+Off-chain relayer monitors source chain
+        |
+        v
+update_bridge_confirmation(token, N) called for each new block
+        |
+        v
+When N >= 15: is_finalized = true
+        |
+        v
+create_escrow with this token now succeeds
+```
+
+---
+
+## BridgeError (Error Code 54)
+
+`BridgeError` is returned as `EscrowError` code **54**.
+
+| Cause | Resolution |
+|-------|-----------|
+| `get_bridge_confirmation` called for an unregistered token | Call `register_wrapped_token` first, then `update_bridge_confirmation`. |
+| `create_escrow` called before `is_finalized = true` | Wait for the relayer to submit enough confirmations, or call `update_bridge_confirmation` manually with the current count. |
+| `register_wrapped_token` with `BridgeProtocol::Wormhole` but `is_wrapped_asset` returns `false` | Verify `stellar_address` is the correct SAC for the Wormhole-wrapped token. Check that `set_wormhole_bridge` was called with the correct bridge address. |
+| `set_wormhole_bridge` not called before `register_wrapped_token` | Call `set_wormhole_bridge` with the Wormhole token bridge SAC address first. |
+
+---
+
+## End-to-End CLI Walkthrough
+
+The following example registers Wormhole-wrapped USDC (origin: Ethereum)
+and uses it in an escrow on Stellar testnet.
+
+**Step 1 — Set the Wormhole bridge address**
+
+```bash
+soroban contract invoke \
+  --id $ESCROW_CONTRACT \
+  --source $ADMIN_SECRET \
+  --network testnet \
+  -- set_wormhole_bridge \
+  --caller $ADMIN_ADDRESS \
+  --bridge $WORMHOLE_BRIDGE_SAC
+```
+
+**Step 2 — Register the wrapped token**
+
+```bash
+# Ethereum USDC: chain ID 2
+# Address 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 zero-padded to 32 bytes:
+ORIGIN_ADDR="000000000000000000000000A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+
+soroban contract invoke \
+  --id $ESCROW_CONTRACT \
+  --source $ADMIN_SECRET \
+  --network testnet \
+  -- register_wrapped_token \
+  --caller $ADMIN_ADDRESS \
+  --stellar_address $WRAPPED_USDC_SAC \
+  --origin_chain 2 \
+  --origin_address "$ORIGIN_ADDR" \
+  --bridge Wormhole
+```
+
+**Step 3 — Submit confirmation count (run by relayer after each source block)**
+
+```bash
+soroban contract invoke \
+  --id $ESCROW_CONTRACT \
+  --source $ADMIN_SECRET \
+  --network testnet \
+  -- update_bridge_confirmation \
+  --caller $ADMIN_ADDRESS \
+  --token $WRAPPED_USDC_SAC \
+  --confirmations 15
+```
+
+**Step 4 — Verify finalization**
+
+```bash
+soroban contract invoke \
+  --id $ESCROW_CONTRACT \
+  --network testnet \
+  -- get_bridge_confirmation \
+  --token $WRAPPED_USDC_SAC
+# Expected: { "token": "...", "confirmations": 15, "is_finalized": true, ... }
+```
+
+**Step 5 — Create an escrow using the wrapped token**
+
+```bash
+soroban contract invoke \
+  --id $ESCROW_CONTRACT \
+  --source $CLIENT_SECRET \
+  --network testnet \
+  -- create_escrow \
+  --client $CLIENT_ADDRESS \
+  --freelancer $FREELANCER_ADDRESS \
+  --token $WRAPPED_USDC_SAC \
+  --total_amount 1000000000 \
+  --brief_hash "$BRIEF_HASH" \
+  --arbiter null \
+  --deadline null \
+  --lock_time null
+```
+
+---
+
+## Common Wormhole Chain IDs
+
+| Chain | Wormhole ID |
+|-------|-------------|
+| Ethereum | 2 |
+| BNB Smart Chain | 4 |
+| Polygon | 5 |
+| Avalanche | 6 |
+| Fantom | 10 |
+| Celo | 14 |
+| Arbitrum | 23 |
+| Optimism | 24 |
+| Base | 30 |
+
+Full list: https://docs.wormhole.com/wormhole/reference/constants

--- a/docs/reputation-scoring.md
+++ b/docs/reputation-scoring.md
@@ -1,0 +1,244 @@
+# Reputation Scoring Algorithm
+
+This document explains the `ReputationRecord` data structure, every
+field's semantics and update rules, and the scoring algorithm implemented
+in `_update_reputation_internal`.
+
+Relevant source locations:
+
+- `contracts/escrow_contract/src/types.rs` — `ReputationRecord` struct
+- `contracts/escrow_contract/src/lib.rs` — `_update_reputation_internal`,
+  `update_reputation` (public), `get_reputation`
+- `contracts/escrow_contract/src/events.rs` — `emit_reputation_updated`
+
+---
+
+## Table of Contents
+
+1. [ReputationRecord Fields](#reputationrecord-fields)
+2. [When Reputation Is Updated](#when-reputation-is-updated)
+3. [Scoring Algorithm](#scoring-algorithm)
+4. [emit_reputation_updated Event](#emit_reputation_updated-event)
+5. [Default Record for New Addresses](#default-record-for-new-addresses)
+6. [Worked Examples](#worked-examples)
+7. [get_reputation Function](#get_reputation-function)
+
+---
+
+## ReputationRecord Fields
+
+```rust
+pub struct ReputationRecord {
+    pub address: Address,
+    pub total_score: u64,
+    pub completed_escrows: u32,
+    pub disputed_escrows: u32,
+    pub disputes_won: u32,
+    pub total_volume: i128,
+    pub slash_count: u32,
+    pub total_slashed: i128,
+    pub last_updated: u64,
+}
+```
+
+| Field | Unit | Increment rule | Decrement rule |
+|-------|------|----------------|----------------|
+| `address` | — | Set at record creation; never changes. | — |
+| `total_score` | points | +10 base on completion; +1 per 1 000 units of volume (capped at +10 bonus); +3 on winning a dispute. | −5 on disputed escrow; reduced on upheld slash. |
+| `completed_escrows` | count | +1 when an escrow reaches `Completed` status and this address was a party. | Never decremented. |
+| `disputed_escrows` | count | +1 when a dispute is raised on an escrow this address was party to. | Never decremented. |
+| `disputes_won` | count | +1 when `resolve_dispute` is called and this address is on the winning side. | Never decremented. |
+| `total_volume` | token base units (stroops) | Increased by the escrow's `total_amount` on successful completion. | Never decremented. |
+| `slash_count` | count | +1 when a slash against this address is upheld (finalized or resolved upheld). | Never decremented. |
+| `total_slashed` | token base units | Increased by `SlashRecord.amount` when a slash is upheld. | Never decremented. |
+| `last_updated` | ledger timestamp | Updated on every call to `_update_reputation_internal`. | — |
+
+---
+
+## When Reputation Is Updated
+
+`_update_reputation_internal` is called in three situations:
+
+| Trigger | `completed` | `disputed` | `volume` |
+|---------|-------------|------------|---------|
+| All milestones approved → escrow `Completed` | `true` | `false` | escrow `total_amount` |
+| `resolve_dispute` distributes funds | `false` | `true` | party's received amount |
+| Slash upheld by `finalize_slash` or `resolve_slash_dispute` | `false` | `false` | `0` (slash fields updated separately) |
+
+The public `update_reputation` function is a thin wrapper that calls
+`_update_reputation_internal` and is also available for admin use.
+
+---
+
+## Scoring Algorithm
+
+```
+_update_reputation_internal(address, completed, disputed, volume):
+
+  record = load_reputation(address)   // or default zero record
+
+  if completed:
+    volume_bonus = min(volume / 1_000, 10)   // capped at +10
+    record.total_score    += 10 + volume_bonus
+    record.completed_escrows += 1
+    record.total_volume   += volume
+
+  if disputed:
+    record.total_score    = saturating_sub(record.total_score, 5)
+    record.disputed_escrows += 1
+
+  record.last_updated = now
+  save_reputation(record)
+  emit_reputation_updated(address, record.total_score)
+```
+
+`saturating_sub` means the score never goes below 0.
+
+**Dispute win recovery** — when `resolve_dispute` determines a winner,
+`_update_reputation_internal` is called a second time for the winning
+party with a `disputes_won` increment and a +3 score recovery:
+
+```
+  if disputes_won_increment:
+    record.total_score  += 3
+    record.disputes_won += 1
+```
+
+**Slash penalty** — when a slash is upheld, the slashed address receives
+an additional score reduction proportional to the slash amount:
+
+```
+  slash_penalty = min(slash_amount / 1_000_000, 20)   // capped at −20
+  record.total_score = saturating_sub(record.total_score, slash_penalty)
+  record.slash_count    += 1
+  record.total_slashed  += slash_amount
+```
+
+---
+
+## emit_reputation_updated Event
+
+```rust
+pub fn emit_reputation_updated(env: &Env, address: &Address, new_score: u64)
+```
+
+Topic: `(symbol_short!("rep_upd"),)`
+Data: `(address, new_score)`
+
+Fired at the end of every `_update_reputation_internal` call.
+`new_score` is the value of `total_score` after all updates have been
+applied. The backend indexer listens for this event to keep the
+`reputation_records` table in sync.
+
+---
+
+## Default Record for New Addresses
+
+`get_reputation` never returns an error for an unknown address. If no
+record exists in persistent storage, it returns a synthesized default:
+
+```rust
+ReputationRecord {
+    address,
+    total_score: 0,
+    completed_escrows: 0,
+    disputed_escrows: 0,
+    disputes_won: 0,
+    total_volume: 0,
+    slash_count: 0,
+    total_slashed: 0,
+    last_updated: env.ledger().timestamp(),
+}
+```
+
+This default is **not written to storage** — it is constructed in memory
+on each call. The record is only persisted once `_update_reputation_internal`
+is called for that address for the first time.
+
+---
+
+## Worked Examples
+
+All amounts are in token base units (stroops, 7 decimal places).
+1 USDC = 10 000 000 stroops.
+
+### Example 1 — Clean completion
+
+Alice completes an escrow worth 500 USDC (5 000 000 000 stroops).
+
+```
+completed = true, disputed = false, volume = 5_000_000_000
+
+volume_bonus = min(5_000_000_000 / 1_000, 10) = 10   (capped)
+score_delta  = 10 + 10 = +20
+
+Result:
+  total_score       = 0 + 20 = 20
+  completed_escrows = 0 + 1  = 1
+  total_volume      = 0 + 5_000_000_000
+```
+
+### Example 2 — Disputed escrow, Alice loses
+
+Alice is on the losing side of a dispute.
+
+```
+completed = false, disputed = true, volume = 0
+
+score_delta = -5
+
+Result:
+  total_score      = 20 - 5 = 15
+  disputed_escrows = 0 + 1  = 1
+```
+
+### Example 3 — Dispute won
+
+Bob wins the same dispute.
+
+```
+disputes_won_increment = true
+
+score_delta = +3
+
+Result:
+  total_score  = 10 + 3 = 13   (Bob started at 10)
+  disputes_won = 0 + 1  = 1
+```
+
+### Example 4 — Slash upheld (0.5 USDC slashed)
+
+Alice is slashed 0.5 USDC (5 000 000 stroops).
+
+```
+slash_amount = 5_000_000
+slash_penalty = min(5_000_000 / 1_000_000, 20) = 5
+
+Result:
+  total_score   = 15 - 5 = 10
+  slash_count   = 0 + 1  = 1
+  total_slashed = 0 + 5_000_000
+```
+
+### Example 5 — Slash reversed
+
+No score change. `slash_count` and `total_slashed` are not incremented.
+
+---
+
+## get_reputation Function
+
+```rust
+pub fn get_reputation(
+    env: Env,
+    address: Address,
+) -> Result<ReputationRecord, EscrowError>
+```
+
+Returns the stored `ReputationRecord` for `address`, or the default
+zero-score record if none exists. Never returns an error for an unknown
+address — callers can safely call this for any Stellar address.
+
+The backend REST API exposes this via `GET /api/reputation/:address`
+and applies the same default-zero fallback for addresses not yet in the
+PostgreSQL `reputation_records` table.

--- a/docs/slashing-mechanism.md
+++ b/docs/slashing-mechanism.md
@@ -1,0 +1,255 @@
+# Slashing Mechanism
+
+This document explains how the slashing subsystem works in
+`stellar-trust-escrow`: when a slash is created, how the dispute window
+operates, and what happens to reputation on both outcomes.
+
+Relevant source locations:
+
+- `contracts/escrow_contract/src/lib.rs` — `finalize_slash` (L2441),
+  `dispute_slash` (L2480), `resolve_slash_dispute` (L2518),
+  `apply_slash` (L2662), `calculate_slash_amount` (L2657)
+- `contracts/escrow_contract/src/types.rs` — `SlashRecord` struct
+- Constants: `SLASH_DISPUTE_PERIOD` (L86), `SLASH_PERCENTAGE` (L87)
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Constants](#constants)
+3. [SlashRecord Type](#slashrecord-type)
+4. [Slash Lifecycle](#slash-lifecycle)
+   - [Creation via execute_cancellation](#creation-via-execute_cancellation)
+   - [calculate_slash_amount Formula](#calculate_slash_amount-formula)
+   - [Dispute Window](#dispute-window)
+   - [finalize_slash](#finalize_slash)
+   - [dispute_slash](#dispute_slash)
+   - [resolve_slash_dispute](#resolve_slash_dispute)
+5. [Reputation Effects](#reputation-effects)
+6. [Error Codes](#error-codes)
+
+---
+
+## Overview
+
+Slashing is a penalty mechanism applied when a party requests cancellation
+of an escrow and the cancellation is later deemed unjustified. A percentage
+of the escrow's remaining balance is transferred from the requester to the
+other party as a deterrent against bad-faith cancellation requests.
+
+The slashed party has a `SLASH_DISPUTE_PERIOD` window to challenge the
+slash. If they do not dispute within that window, `finalize_slash` can be
+called to execute the transfer. If they dispute, an admin calls
+`resolve_slash_dispute` to either uphold or reverse the slash.
+
+---
+
+## Constants
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `SLASH_DISPUTE_PERIOD` | `51_840` ledger seconds (~6 days) | How long the slashed party has to call `dispute_slash` before the slash can be finalized. |
+| `SLASH_PERCENTAGE` | `10` | Percentage of `remaining_balance` taken as the slash amount. |
+
+---
+
+## SlashRecord Type
+
+```rust
+pub struct SlashRecord {
+    pub escrow_id: u64,
+    pub slashed_user: Address,
+    pub recipient: Address,
+    pub amount: i128,
+    pub reason: String,
+    pub slashed_at: u64,
+    pub disputed: bool,
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `escrow_id` | The escrow this slash belongs to. |
+| `slashed_user` | The address being penalized (the cancellation requester). |
+| `recipient` | The address that will receive the slashed funds if the slash is upheld (typically the other party). |
+| `amount` | Token amount to be transferred, calculated by `calculate_slash_amount`. |
+| `reason` | Human-readable string explaining why the slash was applied. |
+| `slashed_at` | Ledger timestamp when the slash was created. Used to enforce `SLASH_DISPUTE_PERIOD`. |
+| `disputed` | `true` once `dispute_slash` has been called. Prevents double-disputing and blocks `finalize_slash`. |
+
+---
+
+## Slash Lifecycle
+
+### Creation via execute_cancellation
+
+A `SlashRecord` is created inside `execute_cancellation` when a
+cancellation request is executed after its dispute deadline has passed.
+The flow is:
+
+```
+request_cancellation(escrow_id, reason)
+        |
+        v
+CancellationRequest stored with dispute_deadline = now + CANCELLATION_DISPUTE_PERIOD
+        |
+        v
+[CANCELLATION_DISPUTE_PERIOD elapses without dispute]
+        |
+        v
+execute_cancellation(escrow_id) called
+        |
+        v
+apply_slash(env, escrow_id, slashed_user, recipient, reason)
+        |
+        v
+SlashRecord stored; SLASH_DISPUTE_PERIOD window opens
+```
+
+The `slashed_user` is the party who originally called
+`request_cancellation`. The `recipient` is the other party in the escrow.
+
+---
+
+### calculate_slash_amount Formula
+
+```rust
+fn calculate_slash_amount(remaining_balance: i128) -> i128 {
+    remaining_balance * SLASH_PERCENTAGE as i128 / 100
+}
+```
+
+Example: if `remaining_balance = 10_000_000` (1 USDC at 7 decimal places),
+the slash amount is `10_000_000 * 10 / 100 = 1_000_000` (0.1 USDC).
+
+The slash amount is deducted from the escrow's `remaining_balance` and
+held in the `SlashRecord` until either `finalize_slash` or
+`resolve_slash_dispute` executes the transfer.
+
+---
+
+### Dispute Window
+
+After a `SlashRecord` is created, the `slashed_user` has
+`SLASH_DISPUTE_PERIOD` seconds (approximately 6 days) to call
+`dispute_slash`. During this window:
+
+- `finalize_slash` will revert with `CancellationDisputePeriodActive`
+  (error 35) if called before the window closes.
+- `dispute_slash` sets `SlashRecord.disputed = true`, which blocks
+  `finalize_slash` permanently and routes resolution to an admin via
+  `resolve_slash_dispute`.
+
+---
+
+### finalize_slash
+
+```rust
+pub fn finalize_slash(
+    env: Env,
+    escrow_id: u64,
+) -> Result<(), EscrowError>
+```
+
+Callable by anyone after `SLASH_DISPUTE_PERIOD` has elapsed and
+`disputed == false`. Transfers `SlashRecord.amount` from the contract
+to `SlashRecord.recipient` and removes the `SlashRecord` from storage.
+
+**Preconditions:**
+- `SlashRecord` exists for `escrow_id`.
+- `now >= slashed_at + SLASH_DISPUTE_PERIOD`.
+- `disputed == false`.
+
+**Errors:**
+- `SlashNotFound` (38) — no slash record for this escrow.
+- `CancellationDisputePeriodActive` (35) — dispute window still open.
+- `SlashAlreadyDisputed` (39) — `dispute_slash` was already called.
+
+---
+
+### dispute_slash
+
+```rust
+pub fn dispute_slash(
+    env: Env,
+    caller: Address,   // must be the slashed_user
+    escrow_id: u64,
+) -> Result<(), EscrowError>
+```
+
+Called by the slashed party within `SLASH_DISPUTE_PERIOD` to contest
+the slash. Sets `SlashRecord.disputed = true`. After this call, only
+`resolve_slash_dispute` (admin) can settle the outcome.
+
+**Preconditions:**
+- `caller == SlashRecord.slashed_user`.
+- `now < slashed_at + SLASH_DISPUTE_PERIOD`.
+- `disputed == false`.
+
+**Errors:**
+- `SlashNotFound` (38).
+- `SlashAlreadyDisputed` (39).
+- `SlashDisputeDeadlineExpired` (40) — called after the window closed.
+- `Unauthorized` (3) — caller is not the slashed user.
+
+---
+
+### resolve_slash_dispute
+
+```rust
+pub fn resolve_slash_dispute(
+    env: Env,
+    caller: Address,   // must be contract admin
+    escrow_id: u64,
+    upheld: bool,      // true = slash stands, false = slash reversed
+) -> Result<(), EscrowError>
+```
+
+Admin-only. Resolves a disputed slash:
+
+- `upheld = true`: transfers `amount` to `recipient`. Updates reputation
+  for `slashed_user` (slash upheld, score reduced).
+- `upheld = false`: returns `amount` to `slashed_user`. Updates reputation
+  for `slashed_user` (slash reversed, no penalty).
+
+In both cases the `SlashRecord` is removed from storage after resolution.
+
+**Errors:**
+- `SlashNotFound` (38).
+- `AdminOnly` (4) — caller is not the admin.
+
+---
+
+## Reputation Effects
+
+The `ReputationRecord` tracks slash history via two fields:
+
+| Field | Type | Updated when |
+|-------|------|-------------|
+| `slash_count` | `u32` | Incremented by 1 when a slash is **upheld** by `resolve_slash_dispute` or finalized by `finalize_slash`. |
+| `total_slashed` | `i128` | Increased by `SlashRecord.amount` when a slash is upheld or finalized. |
+
+When a slash is **reversed** by `resolve_slash_dispute`, neither
+`slash_count` nor `total_slashed` is incremented — the record is clean.
+
+The `total_score` in `ReputationRecord` is also affected:
+
+| Outcome | Score change |
+|---------|-------------|
+| Slash upheld | `total_score` reduced (exact formula defined in `_update_reputation_internal`). |
+| Slash reversed | No score change. |
+
+See [reputation-scoring.md](./reputation-scoring.md) for the full
+scoring formula.
+
+---
+
+## Error Codes
+
+| Code | Name | Meaning |
+|------|------|---------|
+| 38 | `SlashNotFound` | No `SlashRecord` exists for the given `escrow_id`. |
+| 39 | `SlashAlreadyDisputed` | `dispute_slash` was already called; cannot dispute again or finalize. |
+| 40 | `SlashDisputeDeadlineExpired` | The `SLASH_DISPUTE_PERIOD` window has closed; `dispute_slash` can no longer be called. |
+| 41 | `InvalidSlashAmount` | The calculated slash amount is zero or negative (e.g. `remaining_balance` is zero). |


### PR DESCRIPTION
closes #603 
closes #604
closes #605  
closes #606


docs/bridge-integration.md (#603):
- Full wrapped token registration workflow
- WrappedTokenInfo, BridgeConfirmation, BridgeProtocol types documented
- MIN_BRIDGE_CONFIRMATIONS = 15 explained with rationale
- set_wormhole_bridge, register_wrapped_token, update_bridge_confirmation, get_bridge_confirmation function signatures and CLI examples
- WormholeBridgeInterface::is_wrapped_asset trait explained
- Finalization requirement and is_finalized flow diagram
- BridgeError (54) causes and resolution steps
- End-to-end 5-step CLI walkthrough with Ethereum USDC example
- Wormhole chain ID reference table

docs/slashing-mechanism.md (#604):
- SLASH_DISPUTE_PERIOD (~6 days) and SLASH_PERCENTAGE (10%) constants
- SlashRecord struct — all fields with descriptions
- Full slash lifecycle: execute_cancellation → apply_slash → dispute window
- calculate_slash_amount formula with worked example
- finalize_slash, dispute_slash, resolve_slash_dispute documented
- Reputation effects: slash_count and total_slashed increment rules
- Upheld vs reversed outcomes clearly distinguished
- Error codes 38-41 (SlashNotFound, SlashAlreadyDisputed, SlashDisputeDeadlineExpired, InvalidSlashAmount)

docs/reputation-scoring.md (#605):
- Every ReputationRecord field with unit, increment, and decrement rules
- _update_reputation_internal algorithm in pseudocode
- Scoring formula: +10 base + volume bonus (capped +10) on completion, -5 on dispute, +3 on dispute win, slash penalty capped at -20
- emit_reputation_updated event topic/data documented
- Default zero-score record behavior for new addresses
- Four worked examples: clean completion, disputed loss, dispute win, slash upheld, slash reversed
- get_reputation default-zero fallback documented

docs/arbiter-guide.md (#606):
- Arbiter selection via create_escrow arbiter: Option<Address>
- raise_dispute auth flow (client or freelancer only)
- resolve_dispute auth requirement (arbiter or admin must sign)
- Amount constraint: client_amount + freelancer_amount == remaining_balance
- EscrowStatus::Disputed prerequisite for resolve_dispute
- Complete table of what the arbiter cannot do
- Error codes 3, 7, 9, 10, 20, 23 with descriptions
- Best practices: multisig arbiters, neutral selection, off-chain process

