### PR TITLE
feat: add RecurringScheduleStatus view, client_approve_cancellation, …

### DIFF
--- a/contracts/escrow_contract/src/errors.rs
+++ b/contracts/escrow_contract/src/errors.rs
@@ -97,4 +97,12 @@ pub enum EscrowError {
     // ── Bridge / Cross-Chain ─────────────────────────────────────────────────
     /// Wrapped token not approved, transfer not found, or bridge not yet finalized.
     BridgeError = 54,
+
+    // ── Brief Hash ───────────────────────────────────────────────────────────
+    /// brief_hash must not be the all-zero BytesN<32>; both parties must agree to a documented brief.
+    InvalidBriefHash = 55,
+
+    // ── Buyer Signers ────────────────────────────────────────────────────────
+    /// buyer_signers list exceeds MAX_BUYER_SIGNERS; cap enforced to prevent gas exhaustion.
+    TooManyBuyerSigners = 56,
 }

--- a/contracts/escrow_contract/src/events.rs
+++ b/contracts/escrow_contract/src/events.rs
@@ -324,6 +324,12 @@ pub fn emit_cancellation_executed(
     );
 }
 
+/// Emitted when the counterparty approves a pending cancellation request.
+pub fn emit_cancellation_approved(env: &Env, escrow_id: u64, approver: &Address) {
+    env.events()
+        .publish((symbol_short!("can_apr"), escrow_id), approver.clone());
+}
+
 /// Emitted when a cancellation is requested.
 pub fn emit_cancellation_requested(
     env: &Env,

--- a/contracts/escrow_contract/src/lib.rs
+++ b/contracts/escrow_contract/src/lib.rs
@@ -66,7 +66,7 @@ use storage::StorageManager;
 use types::{CancellationRequest, RecurringInterval, RecurringPaymentConfig, SlashRecord};
 pub use types::{
     DataKey, EscrowState, EscrowStatus, Milestone, MilestoneStatus, MultisigConfig,
-    OptionalTimelock, ReputationRecord, Timelock,
+    OptionalTimelock, RecurringScheduleStatus, ReputationRecord, Timelock,
 };
 
 use soroban_sdk::{
@@ -87,6 +87,13 @@ const SLASH_PERCENTAGE: u64 = 10;
 const RENT_PERIOD_SECONDS: u64 = 86_400;
 const RENT_RESERVE_PERIODS: u64 = 30;
 const RENT_PER_ENTRY_PER_PERIOD: i128 = 1;
+
+/// Maximum number of milestones per escrow. Prevents unbounded storage growth.
+pub const MAX_MILESTONES: u32 = 20;
+
+/// Maximum number of buyer signers per escrow.
+/// Caps the signer list to prevent gas exhaustion when iterating in approve_milestone.
+pub const MAX_BUYER_SIGNERS: u32 = 10;
 
 // ── Granular storage keys ─────────────────────────────────────────────────────
 // Separate keys for meta vs each milestone avoids deserialising the full
@@ -879,6 +886,9 @@ impl EscrowContract {
         lock_time: Option<u64>,
         buyer_signers: soroban_sdk::Vec<Address>,
     ) -> Result<u64, EscrowError> {
+        if buyer_signers.len() > MAX_BUYER_SIGNERS {
+            return Err(EscrowError::TooManyBuyerSigners);
+        }
         Self::create_escrow_internal(
             env,
             client,
@@ -912,6 +922,10 @@ impl EscrowContract {
 
         if total_amount <= 0 {
             return Err(EscrowError::InvalidEscrowAmount);
+        }
+
+        if brief_hash == BytesN::from_array(&env, &[0u8; 32]) {
+            return Err(EscrowError::InvalidBriefHash);
         }
 
         let now = env.ledger().timestamp();
@@ -1000,6 +1014,10 @@ impl EscrowContract {
 
         if payment_amount <= 0 {
             return Err(EscrowError::InvalidMilestoneAmount);
+        }
+
+        if brief_hash == BytesN::from_array(&env, &[0u8; 32]) {
+            return Err(EscrowError::InvalidBriefHash);
         }
 
         let now = env.ledger().timestamp();
@@ -2234,6 +2252,26 @@ impl EscrowContract {
         ContractStorage::load_recurring_config(&env, escrow_id)
     }
 
+    /// Returns a lightweight status summary of a recurring payment schedule.
+    ///
+    /// Prefer this over `get_recurring_config` when only active/paused/cancelled
+    /// state and next-payment info are needed.
+    pub fn get_recurring_schedule_status(
+        env: Env,
+        escrow_id: u64,
+    ) -> Result<RecurringScheduleStatus, EscrowError> {
+        ContractStorage::ensure_live_escrow(&env, escrow_id)?;
+        let r = ContractStorage::load_recurring_config(&env, escrow_id)?;
+        Ok(RecurringScheduleStatus {
+            is_active: !r.paused && !r.cancelled,
+            is_paused: r.paused,
+            is_cancelled: r.cancelled,
+            next_payment_at: r.next_payment_at,
+            payments_remaining: r.payments_remaining,
+            payment_amount: r.payment_amount,
+        })
+    }
+
     pub fn escrow_count(env: Env) -> u64 {
         ContractStorage::escrow_count(&env)
     }
@@ -2305,6 +2343,7 @@ impl EscrowContract {
             requested_at: now,
             dispute_deadline,
             disputed: false,
+            counterparty_approved: false,
         };
         ContractStorage::save_cancellation_request(&env, &request);
 
@@ -2318,6 +2357,37 @@ impl EscrowContract {
         Ok(())
     }
 
+    /// Allows the counterparty to explicitly approve a pending cancellation,
+    /// enabling immediate execution without waiting for the dispute window.
+    pub fn client_approve_cancellation(
+        env: Env,
+        caller: Address,
+        escrow_id: u64,
+    ) -> Result<(), EscrowError> {
+        caller.require_auth();
+        ContractStorage::require_initialized(&env)?;
+        ContractStorage::require_not_paused(&env)?;
+
+        let meta = ContractStorage::load_escrow_meta_with_rent(&env, escrow_id)?;
+        let mut request = ContractStorage::load_cancellation_request(&env, escrow_id)?;
+
+        // Caller must be the counterparty (the party that did NOT request cancellation)
+        let counterparty = if request.requester == meta.client {
+            meta.freelancer.clone()
+        } else {
+            meta.client.clone()
+        };
+        if caller != counterparty {
+            return Err(EscrowError::Unauthorized);
+        }
+
+        request.counterparty_approved = true;
+        ContractStorage::save_cancellation_request(&env, &request);
+
+        events::emit_cancellation_approved(&env, escrow_id, &caller);
+        Ok(())
+    }
+
     /// Executes a cancellation after the dispute period.
     ///
     /// Can be called by anyone after dispute period expires.
@@ -2328,9 +2398,9 @@ impl EscrowContract {
         let mut meta = ContractStorage::load_escrow_meta_with_rent(&env, escrow_id)?;
         let request = ContractStorage::load_cancellation_request(&env, escrow_id)?;
 
-        // Check if dispute period has passed
+        // Check if dispute period has passed (skipped when counterparty already approved)
         let now = env.ledger().timestamp();
-        if now < request.dispute_deadline {
+        if !request.counterparty_approved && now < request.dispute_deadline {
             return Err(EscrowError::CancellationDisputePeriodActive);
         }
 
@@ -3773,5 +3843,320 @@ mod tests {
             &50_i128,
         );
         assert_eq!(mid, 0);
+    }
+
+    // ── Task 1: get_recurring_schedule_status ─────────────────────────────────
+
+    #[test]
+    fn test_get_recurring_schedule_status_after_create_and_pause() {
+        let (env, admin, _, client) = setup();
+        client.initialize(&admin);
+
+        let escrow_client = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+
+        let total_reserve = 2 * ContractStorage::reserve_for_entries(1);
+        token_admin.mint(&escrow_client, &(300_i128 + total_reserve));
+
+        let start_time = env.ledger().timestamp() + 100;
+        let escrow_id = client.create_recurring_escrow(
+            &escrow_client,
+            &freelancer,
+            &token_id,
+            &100_i128,
+            &RecurringInterval::Weekly,
+            &start_time,
+            &None,
+            &Some(3_u32),
+            &BytesN::from_array(&env, &[1; 32]),
+        );
+
+        // After creation: active
+        let status = client.get_recurring_schedule_status(&escrow_id);
+        assert!(status.is_active);
+        assert!(!status.is_paused);
+        assert!(!status.is_cancelled);
+        assert_eq!(status.payments_remaining, 3);
+        assert_eq!(status.payment_amount, 100_i128);
+        assert_eq!(status.next_payment_at, start_time);
+
+        // After pause: not active, paused
+        client.pause_recurring_schedule(&escrow_client, &escrow_id);
+        let status = client.get_recurring_schedule_status(&escrow_id);
+        assert!(!status.is_active);
+        assert!(status.is_paused);
+        assert!(!status.is_cancelled);
+    }
+
+    #[test]
+    fn test_get_recurring_schedule_status_not_found() {
+        let (env, admin, _, client) = setup();
+        client.initialize(&admin);
+
+        let escrow_client = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+
+        let total_reserve = ContractStorage::reserve_for_entries(1);
+        token_admin.mint(&escrow_client, &(100_i128 + total_reserve));
+
+        let escrow_id = client.create_escrow(
+            &escrow_client,
+            &freelancer,
+            &token_id,
+            &100_i128,
+            &BytesN::from_array(&env, &[1; 32]),
+            &None,
+            &None,
+            &None,
+            &no_multisig(&env),
+        );
+
+        let result = client.try_get_recurring_schedule_status(&escrow_id);
+        assert!(result.is_err());
+    }
+
+    // ── Task 2: client_approve_cancellation ───────────────────────────────────
+
+    #[test]
+    fn test_client_approve_cancellation_immediate_execution() {
+        let (env, admin, _, client) = setup();
+        client.initialize(&admin);
+
+        let escrow_client = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+
+        let total_reserve = 2 * ContractStorage::reserve_for_entries(1);
+        token_admin.mint(&escrow_client, &(100_i128 + total_reserve));
+
+        let escrow_id = client.create_escrow(
+            &escrow_client,
+            &freelancer,
+            &token_id,
+            &100_i128,
+            &BytesN::from_array(&env, &[1; 32]),
+            &None,
+            &None,
+            &None,
+            &no_multisig(&env),
+        );
+
+        // Freelancer requests cancellation
+        client.request_cancellation(
+            &freelancer,
+            &escrow_id,
+            &String::from_str(&env, "done"),
+        );
+
+        // Client approves — dispute window still active
+        client.client_approve_cancellation(&escrow_client, &escrow_id);
+
+        // execute_cancellation should succeed immediately (no time advance needed)
+        client.execute_cancellation(&escrow_id);
+
+        assert_eq!(client.get_escrow(&escrow_id).status, EscrowStatus::Cancelled);
+    }
+
+    #[test]
+    fn test_client_approve_cancellation_wrong_party_rejected() {
+        let (env, admin, _, client) = setup();
+        client.initialize(&admin);
+
+        let escrow_client = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+
+        let total_reserve = 2 * ContractStorage::reserve_for_entries(1);
+        token_admin.mint(&escrow_client, &(100_i128 + total_reserve));
+
+        let escrow_id = client.create_escrow(
+            &escrow_client,
+            &freelancer,
+            &token_id,
+            &100_i128,
+            &BytesN::from_array(&env, &[1; 32]),
+            &None,
+            &None,
+            &None,
+            &no_multisig(&env),
+        );
+
+        // Client requests cancellation
+        client.request_cancellation(
+            &escrow_client,
+            &escrow_id,
+            &String::from_str(&env, "done"),
+        );
+
+        // Client tries to approve their own cancellation — must fail
+        let result = client.try_client_approve_cancellation(&escrow_client, &escrow_id);
+        assert!(result.is_err());
+    }
+
+    // ── Task 3: MAX_BUYER_SIGNERS ─────────────────────────────────────────────
+
+    #[test]
+    fn test_create_escrow_rejects_too_many_buyer_signers() {
+        let (env, admin, _, client) = setup();
+        client.initialize(&admin);
+
+        let escrow_client = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+
+        let total_reserve = ContractStorage::reserve_for_entries(1);
+        token_admin.mint(&escrow_client, &(100_i128 + total_reserve));
+
+        // Build MAX_BUYER_SIGNERS + 1 signers
+        let mut signers = soroban_sdk::Vec::new(&env);
+        for _ in 0..(MAX_BUYER_SIGNERS + 1) {
+            signers.push_back(Address::generate(&env));
+        }
+
+        let result = client.try_create_escrow_with_buyer_signers(
+            &escrow_client,
+            &freelancer,
+            &token_id,
+            &100_i128,
+            &BytesN::from_array(&env, &[1; 32]),
+            &None,
+            &None,
+            &None,
+            &signers,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_create_escrow_accepts_max_buyer_signers() {
+        let (env, admin, _, client) = setup();
+        client.initialize(&admin);
+
+        let escrow_client = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+
+        let total_reserve = ContractStorage::reserve_for_entries(1);
+        token_admin.mint(&escrow_client, &(100_i128 + total_reserve));
+
+        // Exactly MAX_BUYER_SIGNERS signers (client is always added, so use MAX - 1 extras)
+        let mut signers = soroban_sdk::Vec::new(&env);
+        for _ in 0..(MAX_BUYER_SIGNERS - 1) {
+            signers.push_back(Address::generate(&env));
+        }
+
+        let result = client.try_create_escrow_with_buyer_signers(
+            &escrow_client,
+            &freelancer,
+            &token_id,
+            &100_i128,
+            &BytesN::from_array(&env, &[1; 32]),
+            &None,
+            &None,
+            &None,
+            &signers,
+        );
+        assert!(result.is_ok());
+    }
+
+    // ── Task 4: brief_hash zero validation ────────────────────────────────────
+
+    #[test]
+    fn test_create_escrow_rejects_zero_brief_hash() {
+        let (env, admin, _, client) = setup();
+        client.initialize(&admin);
+
+        let escrow_client = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+
+        let total_reserve = ContractStorage::reserve_for_entries(1);
+        token_admin.mint(&escrow_client, &(100_i128 + total_reserve));
+
+        let result = client.try_create_escrow(
+            &escrow_client,
+            &freelancer,
+            &token_id,
+            &100_i128,
+            &BytesN::from_array(&env, &[0u8; 32]),
+            &None,
+            &None,
+            &None,
+            &no_multisig(&env),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_create_escrow_accepts_nonzero_brief_hash() {
+        let (env, admin, _, client) = setup();
+        client.initialize(&admin);
+
+        let escrow_client = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+
+        let total_reserve = ContractStorage::reserve_for_entries(1);
+        token_admin.mint(&escrow_client, &(100_i128 + total_reserve));
+
+        let result = client.try_create_escrow(
+            &escrow_client,
+            &freelancer,
+            &token_id,
+            &100_i128,
+            &BytesN::from_array(&env, &[1u8; 32]),
+            &None,
+            &None,
+            &None,
+            &no_multisig(&env),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_create_recurring_escrow_rejects_zero_brief_hash() {
+        let (env, admin, _, client) = setup();
+        client.initialize(&admin);
+
+        let escrow_client = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+
+        let total_reserve = 2 * ContractStorage::reserve_for_entries(1);
+        token_admin.mint(&escrow_client, &(100_i128 + total_reserve));
+
+        let start_time = env.ledger().timestamp() + 100;
+        let result = client.try_create_recurring_escrow(
+            &escrow_client,
+            &freelancer,
+            &token_id,
+            &100_i128,
+            &RecurringInterval::Weekly,
+            &start_time,
+            &None,
+            &Some(1_u32),
+            &BytesN::from_array(&env, &[0u8; 32]),
+        );
+        assert!(result.is_err());
     }
 }

--- a/contracts/escrow_contract/src/types.rs
+++ b/contracts/escrow_contract/src/types.rs
@@ -325,6 +325,24 @@ pub struct ReputationRecord {
     pub last_updated: u64,
 }
 
+/// Lightweight summary of a recurring payment schedule for frontend display.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RecurringScheduleStatus {
+    /// True when the schedule is running (not paused and not cancelled).
+    pub is_active: bool,
+    /// True when the schedule has been paused.
+    pub is_paused: bool,
+    /// True when the schedule has been cancelled.
+    pub is_cancelled: bool,
+    /// Ledger timestamp of the next scheduled payment.
+    pub next_payment_at: u64,
+    /// Number of payments not yet released.
+    pub payments_remaining: u32,
+    /// Token amount released per payment.
+    pub payment_amount: i128,
+}
+
 /// A cancellation request for an escrow.
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -346,6 +364,10 @@ pub struct CancellationRequest {
 
     /// Whether this cancellation has been disputed.
     pub disputed: bool,
+
+    /// Whether the counterparty (non-requester) has explicitly approved the cancellation.
+    /// When true, `execute_cancellation` skips the dispute window check.
+    pub counterparty_approved: bool,
 }
 
 /// A slash record for tracking penalties.


### PR DESCRIPTION
closes #624 
closes #623 
closes #627 
closes #629 


…MAX_BUYER_SIGNERS cap, and brief_hash zero validation

## Summary

Four improvements to the Soroban escrow contract addressing API ergonomics, security, and gas predictability.

---

### 1. RecurringScheduleStatus lightweight view (types.rs, lib.rs)

- Added `RecurringScheduleStatus` struct (#[contracttype]) to types.rs with fields: is_active, is_paused, is_cancelled, next_payment_at, payments_remaining, payment_amount.
- Added `get_recurring_schedule_status(env, escrow_id)` view function that returns the new struct instead of the full 12-field RecurringPaymentConfig.
- Frontends that only need active/paused/cancelled state and next-payment info no longer need to decode the entire config.
- Returns EscrowError::RecurringConfigNotFound (43) when no schedule exists.
- is_active is true only when !paused && !cancelled.

### 2. client_approve_cancellation to short-circuit dispute window (types.rs, events.rs, lib.rs)

- Added `counterparty_approved: bool` field to `CancellationRequest` struct.
- Added `client_approve_cancellation(env, caller, escrow_id)` function:
  - Validates caller is the counterparty (non-requester).
  - Sets counterparty_approved = true on the stored request.
  - Emits new `emit_cancellation_approved` (can_apr) event.
- Modified `execute_cancellation` to skip the CancellationDisputePeriodActive check when counterparty_approved = true, enabling immediate execution.
- Normal (no approval) cancellations still enforce the full dispute window.

### 3. MAX_BUYER_SIGNERS cap in create_escrow_with_buyer_signers (lib.rs)

- Defined `pub const MAX_BUYER_SIGNERS: u32 = 10` with doc comment.
- Also defined `pub const MAX_MILESTONES: u32 = 20` which was referenced but never declared (latent compile error fix).
- `create_escrow_with_buyer_signers` now rejects lists longer than MAX_BUYER_SIGNERS with EscrowError::TooManyBuyerSigners (56).
- Prevents gas exhaustion in approve_milestone from iterating an unbounded signer list.

### 4. brief_hash zero validation (lib.rs, errors.rs)

- Added `EscrowError::InvalidBriefHash = 55` to errors.rs.
- `create_escrow_internal` rejects BytesN<32> all-zero brief_hash.
- Same check applied to `create_recurring_escrow`.
- Enforces that both parties have agreed to a documented brief before funds are locked on-chain.

---

## New error variants

- InvalidBriefHash = 55
- TooManyBuyerSigners = 56

## Tests added (lib.rs)

- test_get_recurring_schedule_status_after_create_and_pause
- test_get_recurring_schedule_status_not_found
- test_client_approve_cancellation_immediate_execution
- test_client_approve_cancellation_wrong_party_rejected
- test_create_escrow_rejects_too_many_buyer_signers
- test_create_escrow_accepts_max_buyer_signers
- test_create_escrow_rejects_zero_brief_hash
- test_create_escrow_accepts_nonzero_brief_hash
- test_create_recurring_escrow_rejects_zero_brief_hash

## Breaking changes

- CancellationRequest gains counterparty_approved: bool (storage migration needed if upgrading a live contract with existing cancellation requests).

## Summary

Briefly describe what changed and why.

Closes #

## Changes

- 
- 
- 

## Testing

List the exact commands you ran locally.

```bash
# Examples
cargo test --workspace
npm run test -w backend
npm run test -w frontend
npm run lint
```

## Review Notes

Call out any context reviewers should know:

- areas that need extra attention
- follow-up work or known limitations
- deployment or migration considerations

## Checklist

- [ ] Code compiles, or the updated docs reference working commands
- [ ] Tests were added or updated when behavior changed
- [ ] Linting and formatting were run
- [ ] Documentation was updated when needed
- [ ] No breaking changes, or they are clearly described
- [ ] Screenshots or recordings are included for UI changes
