### PR TITLE
refactor: extract symbol_short! event topic names into event_names.rs…

### DIFF
--- a/contracts/escrow_contract/src/event_names.rs
+++ b/contracts/escrow_contract/src/event_names.rs
@@ -1,0 +1,84 @@
+//! # Event Topic Name Constants
+//!
+//! Central registry of all `symbol_short!` event topic names used by the
+//! escrow contract.  Defining them here as `pub const` makes the full topic
+//! namespace visible in one place, prevents accidental duplication, and
+//! catches typos at compile time rather than at runtime.
+//!
+//! Each constant maps 1-to-1 to a `symbol_short!` call that previously
+//! appeared inline in `events.rs`.
+
+use soroban_sdk::{symbol_short, Symbol};
+
+// ── Escrow lifecycle ──────────────────────────────────────────────────────────
+
+pub const ESCROW_CREATED: Symbol = symbol_short!("esc_crt");
+pub const ESCROW_COMPLETED: Symbol = symbol_short!("esc_done");
+pub const ESCROW_CANCELLED: Symbol = symbol_short!("esc_can");
+
+// ── Milestones ────────────────────────────────────────────────────────────────
+
+pub const MILESTONE_ADDED: Symbol = symbol_short!("mil_add");
+pub const MILESTONE_SUBMITTED: Symbol = symbol_short!("mil_sub");
+pub const MILESTONE_APPROVED: Symbol = symbol_short!("mil_apr");
+pub const MILESTONE_REJECTED: Symbol = symbol_short!("mil_rej");
+pub const MILESTONE_DISPUTED: Symbol = symbol_short!("mil_dis");
+pub const MILESTONE_TITLE_UPDATED: Symbol = symbol_short!("mil_tup");
+pub const MILESTONE_REJECTED_WITH_REASON: Symbol = symbol_short!("mil_rej_r");
+pub const MAX_MILESTONES_SET: Symbol = symbol_short!("mil_cap");
+
+// ── Multisig ──────────────────────────────────────────────────────────────────
+
+pub const MULTISIG_APPROVAL_RECORDED: Symbol = symbol_short!("msig_apr");
+
+// ── Funds ─────────────────────────────────────────────────────────────────────
+
+pub const FUNDS_RELEASED: Symbol = symbol_short!("funds_rel");
+pub const RENT_WITHDRAWN: Symbol = symbol_short!("rent_out");
+
+// ── Recurring payments ────────────────────────────────────────────────────────
+
+pub const RECURRING_SCHEDULE_CREATED: Symbol = symbol_short!("rec_crt");
+pub const RECURRING_PAYMENTS_PROCESSED: Symbol = symbol_short!("rec_pay");
+pub const RECURRING_SCHEDULE_PAUSED: Symbol = symbol_short!("rec_pau");
+pub const RECURRING_SCHEDULE_RESUMED: Symbol = symbol_short!("rec_res");
+pub const RECURRING_SCHEDULE_CANCELLED: Symbol = symbol_short!("rec_can");
+
+// ── Disputes ──────────────────────────────────────────────────────────────────
+
+pub const DISPUTE_RAISED: Symbol = symbol_short!("dis_rai");
+pub const DISPUTE_RESOLVED: Symbol = symbol_short!("dis_res");
+
+// ── Cancellations ─────────────────────────────────────────────────────────────
+
+pub const CANCELLATION_REQUESTED: Symbol = symbol_short!("can_req");
+pub const CANCELLATION_APPROVED: Symbol = symbol_short!("can_apr");
+pub const CANCELLATION_EXECUTED: Symbol = symbol_short!("can_exe");
+
+// ── Slashing ──────────────────────────────────────────────────────────────────
+
+pub const SLASH_APPLIED: Symbol = symbol_short!("slsh_app");
+pub const SLASH_DISPUTED: Symbol = symbol_short!("slsh_dis");
+pub const SLASH_DISPUTE_RESOLVED: Symbol = symbol_short!("slsh_res");
+
+// ── Time locks ────────────────────────────────────────────────────────────────
+
+pub const TIMELOCK_STARTED: Symbol = symbol_short!("tl_start");
+pub const TIMELOCK_RELEASED: Symbol = symbol_short!("tl_rel");
+pub const LOCK_TIME_EXPIRED: Symbol = symbol_short!("lock_exp");
+pub const LOCK_TIME_EXTENDED: Symbol = symbol_short!("lock_ext");
+
+// ── Roles ─────────────────────────────────────────────────────────────────────
+
+pub const CLIENT_ROLE_TRANSFERRED: Symbol = symbol_short!("cl_role");
+pub const ARBITER_UPDATED: Symbol = symbol_short!("arb_upd");
+
+// ── Reputation ────────────────────────────────────────────────────────────────
+
+pub const REPUTATION_UPDATED: Symbol = symbol_short!("rep_upd");
+
+// ── Admin / contract state ────────────────────────────────────────────────────
+
+pub const ADMIN_INITIALIZED: Symbol = symbol_short!("adm_init");
+pub const CONTRACT_PAUSED: Symbol = symbol_short!("paused");
+pub const CONTRACT_UNPAUSED: Symbol = symbol_short!("unpaused");

--- a/contracts/escrow_contract/src/events.rs
+++ b/contracts/escrow_contract/src/events.rs
@@ -6,449 +6,159 @@
 //!
 //! Event topics follow the pattern: `(event_name, primary_identifier)`
 //! Event data carries the payload relevant to that event type.
+//!
+//! All topic name constants live in [`event_names`] — edit that module to
+//! rename or add topics.
 
 #![allow(dead_code)]
 
-use soroban_sdk::{symbol_short, Address, Env};
+use crate::event_names;
+use soroban_sdk::{Address, Env};
 
-/// Emitted when a new escrow is created and funds are locked.
-///
-/// # Arguments
-/// * `escrow_id` - The newly assigned escrow ID
-/// * `client`    - The client's address
-/// * `freelancer`- The freelancer's address
-/// * `amount`    - Total locked amount
-pub fn emit_escrow_created(
-    env: &Env,
-    escrow_id: u64,
-    client: &Address,
-    freelancer: &Address,
-    amount: i128,
-) {
-    env.events().publish(
-        (symbol_short!("esc_crt"), escrow_id),
-        (client.clone(), freelancer.clone(), amount),
-    );
+pub fn emit_escrow_created(env: &Env, escrow_id: u64, client: &Address, freelancer: &Address, amount: i128) {
+    env.events().publish((event_names::ESCROW_CREATED, escrow_id), (client.clone(), freelancer.clone(), amount));
 }
 
-/// Emitted when a new milestone is added to an escrow.
-///
-/// # Arguments
-/// * `escrow_id`    - The escrow this milestone belongs to
-/// * `milestone_id` - The new milestone's ID
-/// * `amount`       - Funds allocated to this milestone
 pub fn emit_milestone_added(env: &Env, escrow_id: u64, milestone_id: u32, amount: i128) {
-    env.events().publish(
-        (symbol_short!("mil_add"), escrow_id),
-        (milestone_id, amount),
-    );
+    env.events().publish((event_names::MILESTONE_ADDED, escrow_id), (milestone_id, amount));
 }
 
-/// Emitted when a freelancer submits work on a milestone.
-///
-/// # Arguments
-/// * `escrow_id`    - The escrow ID
-/// * `milestone_id` - The submitted milestone
-/// * `freelancer`   - Freelancer's address
-pub fn emit_milestone_submitted(
-    env: &Env,
-    escrow_id: u64,
-    milestone_id: u32,
-    freelancer: &Address,
-) {
-    env.events().publish(
-        (symbol_short!("mil_sub"), escrow_id),
-        (milestone_id, freelancer.clone()),
-    );
+pub fn emit_milestone_submitted(env: &Env, escrow_id: u64, milestone_id: u32, freelancer: &Address) {
+    env.events().publish((event_names::MILESTONE_SUBMITTED, escrow_id), (milestone_id, freelancer.clone()));
 }
 
-/// Emitted when a client approves a milestone submission.
-///
-/// # Arguments
-/// * `escrow_id`    - The escrow ID
-/// * `milestone_id` - The approved milestone
-/// * `amount`       - Amount being released
 pub fn emit_milestone_approved(env: &Env, escrow_id: u64, milestone_id: u32, amount: i128) {
-    env.events().publish(
-        (symbol_short!("mil_apr"), escrow_id),
-        (milestone_id, amount),
-    );
+    env.events().publish((event_names::MILESTONE_APPROVED, escrow_id), (milestone_id, amount));
 }
 
-/// Emitted when a multisig approver records a vote; escrow may still be below threshold.
-///
-/// * `accrued_weight` — running sum of weights after this vote
-/// * `threshold`      — configured threshold for final approval
-pub fn emit_multisig_approval_recorded(
-    env: &Env,
-    escrow_id: u64,
-    milestone_id: u32,
-    signer: &Address,
-    accrued_weight: u32,
-    threshold: u32,
-) {
-    env.events().publish(
-        (symbol_short!("msig_apr"), escrow_id),
-        (milestone_id, signer.clone(), accrued_weight, threshold),
-    );
+pub fn emit_multisig_approval_recorded(env: &Env, escrow_id: u64, milestone_id: u32, signer: &Address, accrued_weight: u32, threshold: u32) {
+    env.events().publish((event_names::MULTISIG_APPROVAL_RECORDED, escrow_id), (milestone_id, signer.clone(), accrued_weight, threshold));
 }
 
-/// Emitted when a client rejects a milestone submission, returning it to Pending.
-///
-/// # Arguments
-/// * `escrow_id`    - The escrow ID
-/// * `milestone_id` - The rejected milestone
-/// * `client`       - Client's address
 pub fn emit_milestone_rejected(env: &Env, escrow_id: u64, milestone_id: u32, client: &Address) {
-    env.events().publish(
-        (symbol_short!("mil_rej"), escrow_id),
-        (milestone_id, client.clone()),
-    );
+    env.events().publish((event_names::MILESTONE_REJECTED, escrow_id), (milestone_id, client.clone()));
 }
 
-/// Emitted when a dispute is raised on a specific milestone.
-///
-/// # Arguments
-/// * `escrow_id`    - The escrow ID
-/// * `milestone_id` - The disputed milestone
-/// * `raised_by`    - Address of the party raising the dispute
 pub fn emit_milestone_disputed(env: &Env, escrow_id: u64, milestone_id: u32, raised_by: &Address) {
-    env.events().publish(
-        (symbol_short!("mil_dis"), escrow_id),
-        (milestone_id, raised_by.clone()),
-    );
+    env.events().publish((event_names::MILESTONE_DISPUTED, escrow_id), (milestone_id, raised_by.clone()));
 }
 
-/// Emitted when funds are released to the freelancer for an approved milestone.
-///
-/// # Arguments
-/// * `escrow_id`  - The escrow ID
-/// * `to`         - Recipient (freelancer) address
-/// * `amount`     - Amount released
 pub fn emit_funds_released(env: &Env, escrow_id: u64, to: &Address, amount: i128) {
-    env.events().publish(
-        (symbol_short!("funds_rel"), escrow_id),
-        (to.clone(), amount),
-    );
+    env.events().publish((event_names::FUNDS_RELEASED, escrow_id), (to.clone(), amount));
 }
 
-/// Emitted when all milestones are approved and the escrow is completed.
-///
-/// # Arguments
-/// * `escrow_id` - The completed escrow ID
-///
-/// Added to fix STE-03: indexer needs this event to update escrow status.
 pub fn emit_escrow_completed(env: &Env, escrow_id: u64) {
-    env.events()
-        .publish((symbol_short!("esc_done"), escrow_id), ());
+    env.events().publish((event_names::ESCROW_COMPLETED, escrow_id), ());
 }
 
-/// Emitted when a recurring payment schedule is configured for an escrow.
-pub fn emit_recurring_schedule_created(
-    env: &Env,
-    escrow_id: u64,
-    payment_amount: i128,
-    total_payments: u32,
-    next_payment_at: u64,
-) {
-    env.events().publish(
-        (symbol_short!("rec_crt"), escrow_id),
-        (payment_amount, total_payments, next_payment_at),
-    );
+pub fn emit_recurring_schedule_created(env: &Env, escrow_id: u64, payment_amount: i128, total_payments: u32, next_payment_at: u64) {
+    env.events().publish((event_names::RECURRING_SCHEDULE_CREATED, escrow_id), (payment_amount, total_payments, next_payment_at));
 }
 
-/// Emitted when one or more recurring payments are processed.
-pub fn emit_recurring_payments_processed(
-    env: &Env,
-    escrow_id: u64,
-    processed_count: u32,
-    total_released: i128,
-    next_payment_at: Option<u64>,
-) {
-    env.events().publish(
-        (symbol_short!("rec_pay"), escrow_id),
-        (processed_count, total_released, next_payment_at),
-    );
+pub fn emit_recurring_payments_processed(env: &Env, escrow_id: u64, processed_count: u32, total_released: i128, next_payment_at: Option<u64>) {
+    env.events().publish((event_names::RECURRING_PAYMENTS_PROCESSED, escrow_id), (processed_count, total_released, next_payment_at));
 }
 
-/// Emitted when a recurring schedule is paused.
 pub fn emit_recurring_schedule_paused(env: &Env, escrow_id: u64, paused_by: &Address) {
-    env.events()
-        .publish((symbol_short!("rec_pau"), escrow_id), paused_by.clone());
+    env.events().publish((event_names::RECURRING_SCHEDULE_PAUSED, escrow_id), paused_by.clone());
 }
 
-/// Emitted when a recurring schedule is resumed.
-pub fn emit_recurring_schedule_resumed(
-    env: &Env,
-    escrow_id: u64,
-    resumed_by: &Address,
-    next_payment_at: u64,
-) {
-    env.events().publish(
-        (symbol_short!("rec_res"), escrow_id),
-        (resumed_by.clone(), next_payment_at),
-    );
+pub fn emit_recurring_schedule_resumed(env: &Env, escrow_id: u64, resumed_by: &Address, next_payment_at: u64) {
+    env.events().publish((event_names::RECURRING_SCHEDULE_RESUMED, escrow_id), (resumed_by.clone(), next_payment_at));
 }
 
-/// Emitted when a recurring schedule is cancelled.
-pub fn emit_recurring_schedule_cancelled(
-    env: &Env,
-    escrow_id: u64,
-    cancelled_by: &Address,
-    refunded_amount: i128,
-) {
-    env.events().publish(
-        (symbol_short!("rec_can"), escrow_id),
-        (cancelled_by.clone(), refunded_amount),
-    );
+pub fn emit_recurring_schedule_cancelled(env: &Env, escrow_id: u64, cancelled_by: &Address, refunded_amount: i128) {
+    env.events().publish((event_names::RECURRING_SCHEDULE_CANCELLED, escrow_id), (cancelled_by.clone(), refunded_amount));
 }
 
-/// Emitted when an escrow is cancelled and remaining funds returned to client.
-///
-/// # Arguments
-/// * `escrow_id`         - The escrow ID
-/// * `returned_amount`   - Amount returned to the client
 pub fn emit_escrow_cancelled(env: &Env, escrow_id: u64, returned_amount: i128) {
-    env.events()
-        .publish((symbol_short!("esc_can"), escrow_id), returned_amount);
+    env.events().publish((event_names::ESCROW_CANCELLED, escrow_id), returned_amount);
 }
 
-/// Emitted when a dispute is raised on an escrow.
-///
-/// # Arguments
-/// * `escrow_id`   - The escrow ID
-/// * `raised_by`   - Address of the party raising the dispute
-/// * `reason_hash` - IPFS hash of the dispute reason document
 pub fn emit_dispute_raised(env: &Env, escrow_id: u64, raised_by: &Address) {
-    env.events()
-        .publish((symbol_short!("dis_rai"), escrow_id), raised_by.clone());
+    env.events().publish((event_names::DISPUTE_RAISED, escrow_id), raised_by.clone());
 }
 
-/// Emitted when a dispute is resolved and funds are distributed.
-///
-/// # Arguments
-/// * `escrow_id`           - The escrow ID
-/// * `client_amount`       - Amount returned to client
-/// * `freelancer_amount`   - Amount sent to freelancer
-pub fn emit_dispute_resolved(
-    env: &Env,
-    escrow_id: u64,
-    client_amount: i128,
-    freelancer_amount: i128,
-) {
-    env.events().publish(
-        (symbol_short!("dis_res"), escrow_id),
-        (client_amount, freelancer_amount),
-    );
+pub fn emit_dispute_resolved(env: &Env, escrow_id: u64, client_amount: i128, freelancer_amount: i128) {
+    env.events().publish((event_names::DISPUTE_RESOLVED, escrow_id), (client_amount, freelancer_amount));
 }
 
-/// Emitted when a user's reputation score is updated.
-///
-/// # Arguments
-/// * `address`   - The user whose reputation changed
-/// * `new_score` - Their updated total reputation score
 pub fn emit_reputation_updated(env: &Env, address: &Address, new_score: u64) {
-    env.events()
-        .publish((symbol_short!("rep_upd"),), (address.clone(), new_score));
+    env.events().publish((event_names::REPUTATION_UPDATED,), (address.clone(), new_score));
 }
 
-/// Emitted when a time lock expires on an escrow.
-///
-/// # Arguments
-/// * `escrow_id` - The escrow ID
-/// * `lock_time` - The timestamp when the lock expired
 pub fn emit_lock_time_expired(env: &Env, escrow_id: u64, lock_time: u64) {
-    env.events()
-        .publish((symbol_short!("lock_exp"), escrow_id), lock_time);
+    env.events().publish((event_names::LOCK_TIME_EXPIRED, escrow_id), lock_time);
 }
 
-/// Emitted when a time lock is extended.
-///
-/// # Arguments
-/// * `escrow_id`       - The escrow ID
-/// * `old_lock_time`  - The previous lock time
-/// * `new_lock_time`  - The new lock time
-/// * `extended_by`     - Address of the party that extended the lock
 pub fn emit_timelock_started(env: &Env, escrow_id: u64, duration_ledger: u64, start_ledger: u64) {
-    env.events().publish(
-        (symbol_short!("tl_start"), escrow_id),
-        (duration_ledger, start_ledger),
-    );
+    env.events().publish((event_names::TIMELOCK_STARTED, escrow_id), (duration_ledger, start_ledger));
 }
 
 pub fn emit_timelock_released(env: &Env, escrow_id: u64, released_ledger: u64) {
-    env.events()
-        .publish((symbol_short!("tl_rel"), escrow_id), released_ledger);
+    env.events().publish((event_names::TIMELOCK_RELEASED, escrow_id), released_ledger);
 }
 
-pub fn emit_lock_time_extended(
-    env: &Env,
-    escrow_id: u64,
-    old_lock_time: u64,
-    new_lock_time: u64,
-    extended_by: &Address,
-) {
-    env.events().publish(
-        (symbol_short!("lock_ext"), escrow_id),
-        (old_lock_time, new_lock_time, extended_by.clone()),
-    );
+pub fn emit_lock_time_extended(env: &Env, escrow_id: u64, old_lock_time: u64, new_lock_time: u64, extended_by: &Address) {
+    env.events().publish((event_names::LOCK_TIME_EXTENDED, escrow_id), (old_lock_time, new_lock_time, extended_by.clone()));
 }
 
-/// Emitted when the contract is paused.
 pub fn emit_contract_paused(env: &Env, admin: &Address) {
-    env.events()
-        .publish((symbol_short!("paused"),), admin.clone());
+    env.events().publish((event_names::CONTRACT_PAUSED,), admin.clone());
 }
 
-/// Emitted when the contract is unpaused.
 pub fn emit_contract_unpaused(env: &Env, admin: &Address) {
-    env.events()
-        .publish((symbol_short!("unpaused"),), admin.clone());
+    env.events().publish((event_names::CONTRACT_UNPAUSED,), admin.clone());
 }
 
-/// Emitted when a cancellation is executed after the dispute period.
-///
-/// # Arguments
-/// * `escrow_id`      - The escrow ID
-/// * `client_amount`  - Amount returned to the requester
-/// * `slash_amount`   - Amount slashed as penalty
-pub fn emit_cancellation_executed(
-    env: &Env,
-    escrow_id: u64,
-    client_amount: i128,
-    slash_amount: i128,
-) {
-    env.events().publish(
-        (symbol_short!("can_exe"), escrow_id),
-        (client_amount, slash_amount),
-    );
+pub fn emit_cancellation_executed(env: &Env, escrow_id: u64, client_amount: i128, slash_amount: i128) {
+    env.events().publish((event_names::CANCELLATION_EXECUTED, escrow_id), (client_amount, slash_amount));
 }
 
-/// Emitted when the counterparty approves a pending cancellation request.
 pub fn emit_cancellation_approved(env: &Env, escrow_id: u64, approver: &Address) {
-    env.events()
-        .publish((symbol_short!("can_apr"), escrow_id), approver.clone());
+    env.events().publish((event_names::CANCELLATION_APPROVED, escrow_id), approver.clone());
 }
 
-/// Emitted when a cancellation is requested.
-pub fn emit_cancellation_requested(
-    env: &Env,
-    escrow_id: u64,
-    requester: &Address,
-    reason: &soroban_sdk::String,
-    dispute_deadline: u64,
-) {
-    env.events().publish(
-        (symbol_short!("can_req"), escrow_id),
-        (requester.clone(), reason.clone(), dispute_deadline),
-    );
+pub fn emit_cancellation_requested(env: &Env, escrow_id: u64, requester: &Address, reason: &soroban_sdk::String, dispute_deadline: u64) {
+    env.events().publish((event_names::CANCELLATION_REQUESTED, escrow_id), (requester.clone(), reason.clone(), dispute_deadline));
 }
 
-/// Emitted when a slash is applied to a user.
-pub fn emit_slash_applied(
-    env: &Env,
-    escrow_id: u64,
-    slashed_user: &Address,
-    recipient: &Address,
-    amount: i128,
-    reason: &soroban_sdk::String,
-) {
-    env.events().publish(
-        (symbol_short!("slsh_app"), escrow_id),
-        (
-            slashed_user.clone(),
-            recipient.clone(),
-            amount,
-            reason.clone(),
-        ),
-    );
+pub fn emit_slash_applied(env: &Env, escrow_id: u64, slashed_user: &Address, recipient: &Address, amount: i128, reason: &soroban_sdk::String) {
+    env.events().publish((event_names::SLASH_APPLIED, escrow_id), (slashed_user.clone(), recipient.clone(), amount, reason.clone()));
 }
 
-/// Emitted when a slash is disputed.
 pub fn emit_slash_disputed(env: &Env, escrow_id: u64, disputer: &Address, amount: i128) {
-    env.events().publish(
-        (symbol_short!("slsh_dis"), escrow_id),
-        (disputer.clone(), amount),
-    );
+    env.events().publish((event_names::SLASH_DISPUTED, escrow_id), (disputer.clone(), amount));
 }
 
-/// Emitted when a slash dispute is resolved.
 pub fn emit_slash_dispute_resolved(env: &Env, escrow_id: u64, upheld: bool, amount: i128) {
-    env.events()
-        .publish((symbol_short!("slsh_res"), escrow_id), (upheld, amount));
+    env.events().publish((event_names::SLASH_DISPUTE_RESOLVED, escrow_id), (upheld, amount));
 }
 
-/// Emitted when the client role is transferred to a new address.
-///
-/// # Arguments
-/// * `escrow_id`   - The escrow ID
-/// * `old_client`  - The previous client address
-/// * `new_client`  - The new client address
-pub fn emit_client_role_transferred(
-    env: &Env,
-    escrow_id: u64,
-    old_client: &Address,
-    new_client: &Address,
-) {
-    env.events().publish(
-        (symbol_short!("cl_role"), escrow_id),
-        (old_client.clone(), new_client.clone()),
-    );
+pub fn emit_client_role_transferred(env: &Env, escrow_id: u64, old_client: &Address, new_client: &Address) {
+    env.events().publish((event_names::CLIENT_ROLE_TRANSFERRED, escrow_id), (old_client.clone(), new_client.clone()));
 }
 
-/// Emitted when a client updates a pending milestone's title.
-///
-/// # Arguments
-/// * `escrow_id`    - The escrow ID
-/// * `milestone_id` - The milestone whose title was updated
-/// * `new_title`    - The corrected title
-pub fn emit_milestone_title_updated(
-    env: &Env,
-    escrow_id: u64,
-    milestone_id: u32,
-    new_title: &soroban_sdk::String,
-) {
-    env.events().publish(
-        (symbol_short!("mil_tup"), escrow_id),
-        (milestone_id, new_title.clone()),
-    );
+pub fn emit_milestone_title_updated(env: &Env, escrow_id: u64, milestone_id: u32, new_title: &soroban_sdk::String) {
+    env.events().publish((event_names::MILESTONE_TITLE_UPDATED, escrow_id), (milestone_id, new_title.clone()));
 }
 
-/// Emitted when the contract is initialized with an admin address.
 pub fn emit_admin_initialized(env: &Env, admin: &Address) {
-    env.events()
-        .publish((symbol_short!("adm_init"),), admin.clone());
+    env.events().publish((event_names::ADMIN_INITIALIZED,), admin.clone());
 }
 
-/// Emitted when the admin updates the maximum milestone cap.
 pub fn emit_max_milestones_set(env: &Env, new_max: u32) {
-    env.events().publish((symbol_short!("mil_cap"),), new_max);
+    env.events().publish((event_names::MAX_MILESTONES_SET,), new_max);
 }
 
-/// Emitted when a milestone is rejected with an IPFS reason hash.
-pub fn emit_milestone_rejected_with_reason(
-    env: &Env,
-    escrow_id: u64,
-    milestone_id: u32,
-    client: &Address,
-    reason_hash: &soroban_sdk::BytesN<32>,
-) {
-    env.events().publish(
-        (symbol_short!("mil_rej_r"), escrow_id),
-        (milestone_id, client.clone(), reason_hash.clone()),
-    );
+pub fn emit_milestone_rejected_with_reason(env: &Env, escrow_id: u64, milestone_id: u32, client: &Address, reason_hash: &soroban_sdk::BytesN<32>) {
+    env.events().publish((event_names::MILESTONE_REJECTED_WITH_REASON, escrow_id), (milestone_id, client.clone(), reason_hash.clone()));
 }
 
-/// Emitted when a client withdraws excess rent overpayment.
 pub fn emit_rent_withdrawn(env: &Env, escrow_id: u64, recipient: &Address, amount: i128) {
-    env.events().publish(
-        (symbol_short!("rent_out"), escrow_id),
-        (recipient.clone(), amount),
-    );
+    env.events().publish((event_names::RENT_WITHDRAWN, escrow_id), (recipient.clone(), amount));
 }
 
-/// Emitted when the arbiter is updated on an escrow.
 pub fn emit_arbiter_updated(env: &Env, escrow_id: u64, new_arbiter: &Option<Address>) {
-    env.events()
-        .publish((symbol_short!("arb_upd"), escrow_id), new_arbiter.clone());
+    env.events().publish((event_names::ARBITER_UPDATED, escrow_id), new_arbiter.clone());
 }

--- a/contracts/escrow_extensions/src/event_names.rs
+++ b/contracts/escrow_extensions/src/event_names.rs
@@ -1,0 +1,30 @@
+//! # Event Topic Name Constants — Extensions
+//!
+//! Central registry of all `symbol_short!` event topic names used by the
+//! escrow extensions contract (batch, fees, arbitration, upgrades).
+
+use soroban_sdk::{symbol_short, Symbol};
+
+// ── Batch ─────────────────────────────────────────────────────────────────────
+
+pub const BATCH_ESCROW_CREATED: Symbol = symbol_short!("bat_crt");
+pub const BATCH_COMPLETED: Symbol = symbol_short!("bat_done");
+
+// ── Fees ──────────────────────────────────────────────────────────────────────
+
+pub const FEE_COLLECTED: Symbol = symbol_short!("fee_col");
+pub const FEE_DISTRIBUTED: Symbol = symbol_short!("fee_dis");
+pub const FEE_EMERGENCY_WITHDRAWN: Symbol = symbol_short!("fee_emg");
+
+// ── Arbitration ───────────────────────────────────────────────────────────────
+
+pub const DISPUTE_OPENED: Symbol = symbol_short!("arb_opn");
+pub const VOTE_CAST: Symbol = symbol_short!("arb_vot");
+pub const DISPUTE_RESOLVED: Symbol = symbol_short!("arb_res");
+pub const VOTER_SLASHED: Symbol = symbol_short!("arb_slh");
+
+// ── Upgrade ───────────────────────────────────────────────────────────────────
+
+pub const UPGRADE_QUEUED: Symbol = symbol_short!("upg_que");
+pub const UPGRADE_EXECUTED: Symbol = symbol_short!("upg_exe");
+pub const UPGRADE_CANCELLED: Symbol = symbol_short!("upg_can");

--- a/contracts/escrow_extensions/src/events.rs
+++ b/contracts/escrow_extensions/src/events.rs
@@ -1,102 +1,79 @@
-use soroban_sdk::{symbol_short, Address, BytesN, Env};
+//! # Extension Contract Events
+//!
+//! All topic name constants live in [`event_names`] — edit that module to
+//! rename or add topics.
+
+use crate::event_names;
+use soroban_sdk::{Address, BytesN, Env};
 
 // ── Batch ─────────────────────────────────────────────────────────────────────
 
 /// Emitted once per escrow created inside a batch.
-/// topic: (bat_crt, escrow_id)  data: (client, freelancer, amount)
-pub fn emit_batch_escrow_created(
-    env: &Env,
-    escrow_id: u64,
-    client: &Address,
-    freelancer: &Address,
-    amount: i128,
-) {
-    env.events().publish(
-        (symbol_short!("bat_crt"), escrow_id),
-        (client.clone(), freelancer.clone(), amount),
-    );
+/// topic: (BATCH_ESCROW_CREATED, escrow_id)  data: (client, freelancer, amount)
+pub fn emit_batch_escrow_created(env: &Env, escrow_id: u64, client: &Address, freelancer: &Address, amount: i128) {
+    env.events().publish((event_names::BATCH_ESCROW_CREATED, escrow_id), (client.clone(), freelancer.clone(), amount));
 }
 
 /// Emitted once for the whole batch.
-/// topic: (bat_done,)  data: (count, total_amount)
+/// topic: (BATCH_COMPLETED,)  data: (count, total_amount)
 pub fn emit_batch_completed(env: &Env, count: u32, total_amount: i128) {
-    env.events()
-        .publish((symbol_short!("bat_done"),), (count, total_amount));
+    env.events().publish((event_names::BATCH_COMPLETED,), (count, total_amount));
 }
 
 // ── Fees ──────────────────────────────────────────────────────────────────────
 
 /// Emitted when a protocol fee is collected on escrow release.
-/// topic: (fee_col, escrow_id)  data: (token, amount)
+/// topic: (FEE_COLLECTED, escrow_id)  data: (token, amount)
 pub fn emit_fee_collected(env: &Env, escrow_id: u64, token: &Address, amount: i128) {
-    env.events().publish(
-        (symbol_short!("fee_col"), escrow_id),
-        (token.clone(), amount),
-    );
+    env.events().publish((event_names::FEE_COLLECTED, escrow_id), (token.clone(), amount));
 }
 
 /// Emitted when accumulated fees are distributed to recipients.
-/// topic: (fee_dis,)  data: (token, total_distributed)
+/// topic: (FEE_DISTRIBUTED,)  data: (token, total_distributed)
 pub fn emit_fee_distributed(env: &Env, token: &Address, total: i128) {
-    env.events()
-        .publish((symbol_short!("fee_dis"),), (token.clone(), total));
+    env.events().publish((event_names::FEE_DISTRIBUTED,), (token.clone(), total));
 }
 
 /// Emitted on emergency fee withdrawal.
 pub fn emit_fee_emergency_withdrawn(env: &Env, token: &Address, amount: i128, to: &Address) {
-    env.events().publish(
-        (symbol_short!("fee_emg"),),
-        (token.clone(), amount, to.clone()),
-    );
+    env.events().publish((event_names::FEE_EMERGENCY_WITHDRAWN,), (token.clone(), amount, to.clone()));
 }
 
 // ── Arbitration ───────────────────────────────────────────────────────────────
 
 /// Emitted when an on-chain arbitration dispute is opened.
 pub fn emit_dispute_opened(env: &Env, escrow_id: u64, voting_closes_at: u64) {
-    env.events()
-        .publish((symbol_short!("arb_opn"), escrow_id), voting_closes_at);
+    env.events().publish((event_names::DISPUTE_OPENED, escrow_id), voting_closes_at);
 }
 
 /// Emitted when a vote is cast.
 pub fn emit_vote_cast(env: &Env, escrow_id: u64, voter: &Address, stake: u64, for_client: bool) {
-    env.events().publish(
-        (symbol_short!("arb_vot"), escrow_id),
-        (voter.clone(), stake, for_client),
-    );
+    env.events().publish((event_names::VOTE_CAST, escrow_id), (voter.clone(), stake, for_client));
 }
 
 /// Emitted when a dispute is resolved.
 pub fn emit_dispute_resolved(env: &Env, escrow_id: u64, client_wins: bool) {
-    env.events()
-        .publish((symbol_short!("arb_res"), escrow_id), client_wins);
+    env.events().publish((event_names::DISPUTE_RESOLVED, escrow_id), client_wins);
 }
 
 /// Emitted when a voter is slashed for being on the losing side by > 90%.
 pub fn emit_voter_slashed(env: &Env, escrow_id: u64, voter: &Address, stake: u64) {
-    env.events().publish(
-        (symbol_short!("arb_slh"), escrow_id),
-        (voter.clone(), stake),
-    );
+    env.events().publish((event_names::VOTER_SLASHED, escrow_id), (voter.clone(), stake));
 }
 
 // ── Upgrade ───────────────────────────────────────────────────────────────────
 
 /// Emitted when an upgrade is queued.
 pub fn emit_upgrade_queued(env: &Env, new_wasm_hash: &BytesN<32>, executable_after: u64) {
-    env.events().publish(
-        (symbol_short!("upg_que"),),
-        (new_wasm_hash.clone(), executable_after),
-    );
+    env.events().publish((event_names::UPGRADE_QUEUED,), (new_wasm_hash.clone(), executable_after));
 }
 
 /// Emitted when a queued upgrade is executed.
 pub fn emit_upgrade_executed(env: &Env, new_wasm_hash: &BytesN<32>) {
-    env.events()
-        .publish((symbol_short!("upg_exe"),), new_wasm_hash.clone());
+    env.events().publish((event_names::UPGRADE_EXECUTED,), new_wasm_hash.clone());
 }
 
 /// Emitted when a pending upgrade is cancelled.
 pub fn emit_upgrade_cancelled(env: &Env) {
-    env.events().publish((symbol_short!("upg_can"),), ());
+    env.events().publish((event_names::UPGRADE_CANCELLED,), ());
 }


### PR DESCRIPTION
Closes #710

## Changes

- Created `contracts/escrow_contract/src/event_names.rs` with 35 `pub const` event topic constants
- Updated `contracts/escrow_contract/src/events.rs` — all inline `symbol_short!` replaced with `event_names::*` constants
- Created `contracts/escrow_extensions/src/event_names.rs` with 13 `pub const` event topic constants  
- Updated `contracts/escrow_extensions/src/events.rs` — same treatment
- Added `mod event_names;` to both `lib.rs` files

## Result
Zero raw `symbol_short!` calls remain in either `events.rs`. All topic names are now visible in one place per contract, preventing duplication and typos.