### PR TITLE
refactor: close EscrowError discriminant gaps with Reserved variants

### DIFF
--- a/contracts/escrow_contract/src/errors.rs
+++ b/contracts/escrow_contract/src/errors.rs
@@ -25,14 +25,16 @@ pub enum EscrowError {
     // Note: discriminant 6 is reserved / unused.
 
     // ── Escrow State ──────────────────────────────────────────────────────────
-    // Note: discriminants 7 is reserved / unused.
+    /// Reserved for future use.
+    Reserved7 = 7,
     /// No escrow exists for the given `escrow_id`.
     EscrowNotFound = 8,
     /// Operation requires the escrow to be in `Active` status.
     EscrowNotActive = 9,
     /// Operation requires the escrow to be in `Disputed` status.
     EscrowNotDisputed = 10,
-    // Note: discriminant 11 is reserved / unused.
+    /// Reserved for future use.
+    Reserved11 = 11,
     /// Escrow cannot be cancelled while milestone funds are pending release.
     PendingFunds = 12,
 
@@ -55,8 +57,10 @@ pub enum EscrowError {
     /// Deposited amount does not match the sum of milestone amounts.
     AmountMismatch = 20,
     // ── Dispute ───────────────────────────────────────────────────────────────
-    // Note: discriminant 22 is reserved / unused.
-    // Note: discriminant 24 is reserved / unused.
+    /// Reserved for future use.
+    Reserved22 = 22,
+    /// Reserved for future use.
+    Reserved24 = 24,
     // Note: discriminant 23 is reserved / unused.
 
     // ── Deadline ──────────────────────────────────────────────────────────────

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -2,7 +2,7 @@
 
 All public contract functions return `Result<T, EscrowError>`. When a transaction fails, the Soroban diagnostic stream includes the `EscrowError` discriminant as a `u32`. Use this table to map that value to a human-readable description.
 
-Discriminants 7, 11, 22, and 24 are **reserved / unused** — they do not correspond to any current variant and are noted in the table for completeness.
+Discriminants 7, 11, 22, and 24 are **reserved / unused** — they are represented by explicit `Reserved*` variants so the discriminant space stays contiguous without renumbering existing errors.
 
 ---
 
@@ -30,11 +30,11 @@ Discriminants 7, 11, 22, and 24 are **reserved / unused** — they do not corres
 
 | Code | Name                           | User-facing description                          | When it occurs                                                                             |
 | ---- | ------------------------------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| 7    | _(reserved)_                   | —                                                | Unused discriminant.                                                                       |
+| 7    | `Reserved7`                    | Reserved for future use.                         | Placeholder variant to keep the error-code space contiguous without breaking existing codes. |
 | 8    | `EscrowNotFound`               | Escrow not found.                                | No escrow exists for the given `escrow_id`.                                                |
 | 9    | `EscrowNotActive`              | This escrow is not currently active.             | Operation requires `Active` status but escrow is `Completed`, `Disputed`, or `Cancelled`.  |
 | 10   | `EscrowNotDisputed`            | This escrow is not in a disputed state.          | Dispute-resolution function called on a non-disputed escrow.                               |
-| 11   | _(reserved)_                   | —                                                | Unused discriminant.                                                                       |
+| 11   | `Reserved11`                   | Reserved for future use.                         | Placeholder variant to keep the error-code space contiguous without breaking existing codes. |
 | 12   | `CannotCancelWithPendingFunds` | Cannot cancel while milestone funds are pending. | Cancellation attempted while at least one milestone is in `Submitted` or `Approved` state. |
 
 ---
@@ -66,7 +66,7 @@ Discriminants 7, 11, 22, and 24 are **reserved / unused** — they do not corres
 
 | Code | Name                   | User-facing description                    | When it occurs                                           |
 | ---- | ---------------------- | ------------------------------------------ | -------------------------------------------------------- |
-| 22   | _(reserved)_           | —                                          | Unused discriminant.                                     |
+| 22   | `Reserved22`          | Reserved for future use.                 | Placeholder variant to keep the error-code space contiguous without breaking existing codes. |
 | 23   | `DisputeAlreadyExists` | A dispute is already open for this escrow. | `raise_dispute` called when a dispute is already active. |
 
 ---
@@ -75,7 +75,7 @@ Discriminants 7, 11, 22, and 24 are **reserved / unused** — they do not corres
 
 | Code | Name              | User-facing description           | When it occurs                                      |
 | ---- | ----------------- | --------------------------------- | --------------------------------------------------- |
-| 24   | _(reserved)_      | —                                 | Unused discriminant.                                |
+| 24   | `Reserved24`     | Reserved for future use.        | Placeholder variant to keep the error-code space contiguous without breaking existing codes. |
 | 25   | `InvalidDeadline` | The provided deadline is invalid. | Deadline timestamp is in the past at creation time. |
 | 26   | `DeadlineExpired` | The escrow deadline has passed.   | Operation attempted after the escrow deadline.      |
 


### PR DESCRIPTION
Closes #715

## Changes
- add explicit `Reserved7`, `Reserved11`, `Reserved22`, and `Reserved24` variants to `EscrowError`
- keep the existing discriminant values unchanged to avoid a breaking renumbering
- update `docs/error-codes.md` so the reserved slots match the enum implementation

## Testing
- not run locally in this API-only workflow