### PR TITLE
feat: add dispute timeout claim flow for disputed escrows

### DIFF
--- a/contracts/escrow_contract/src/dispute_timeout_tests.rs
+++ b/contracts/escrow_contract/src/dispute_timeout_tests.rs
@@ -1,0 +1,108 @@
+#[cfg(test)]
+#[allow(clippy::module_inception)]
+mod dispute_timeout_tests {
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger as _},
+        token, Address, BytesN, Env,
+    };
+
+    use crate::{EscrowContract, EscrowContractClient, EscrowError, MultisigConfig};
+
+    fn no_multisig(env: &Env) -> MultisigConfig {
+        MultisigConfig {
+            approvers: soroban_sdk::Vec::new(env),
+            weights: soroban_sdk::Vec::new(env),
+            threshold: 0,
+        }
+    }
+
+    fn setup() -> (Env, Address, EscrowContractClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register_contract(None, EscrowContract);
+        let client = EscrowContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+        (env, admin, client)
+    }
+
+    fn register_token(env: &Env, admin: &Address, recipient: &Address, amount: i128) -> Address {
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        token::StellarAssetClient::new(env, &sac.address()).mint(recipient, &amount);
+        sac.address()
+    }
+
+    #[test]
+    fn test_raise_dispute_records_start_ledger() {
+        let (env, admin, client) = setup();
+        let client_addr = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let token = register_token(&env, &admin, &client_addr, 1060);
+
+        env.ledger().with_mut(|l| {
+            l.timestamp = 1_000;
+            l.sequence_number = 25;
+        });
+
+        let escrow_id = client.create_escrow_with_dispute_timeout(
+            &client_addr,
+            &freelancer,
+            &token,
+            &1000,
+            &BytesN::from_array(&env, &[7; 32]),
+            &None,
+            &None,
+            &None,
+            &Some(5),
+            &None,
+            &no_multisig(&env),
+        );
+
+        client.raise_dispute(&client_addr, &escrow_id, &None);
+        let meta = client.get_escrow_meta(&escrow_id);
+        assert_eq!(meta.dispute_timeout, Some(5));
+        assert_eq!(meta.dispute_start_ledger, Some(25));
+    }
+
+    #[test]
+    fn test_claim_dispute_timeout_blocks_early_and_succeeds_after_timeout() {
+        let (env, admin, client) = setup();
+        let client_addr = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let token = register_token(&env, &admin, &client_addr, 1060);
+        let token_client = token::Client::new(&env, &token);
+
+        env.ledger().with_mut(|l| {
+            l.timestamp = 1_000;
+            l.sequence_number = 50;
+        });
+
+        let escrow_id = client.create_escrow_with_dispute_timeout(
+            &client_addr,
+            &freelancer,
+            &token,
+            &1000,
+            &BytesN::from_array(&env, &[8; 32]),
+            &None,
+            &None,
+            &None,
+            &Some(4),
+            &None,
+            &no_multisig(&env),
+        );
+
+        client.raise_dispute(&freelancer, &escrow_id, &None);
+
+        env.ledger().with_mut(|l| l.sequence_number = 53);
+        let early = client.try_claim_dispute_timeout(&client_addr, &escrow_id);
+        assert!(matches!(early, Err(Ok(EscrowError::LockTimeNotExpired))));
+
+        env.ledger().with_mut(|l| l.sequence_number = 54);
+        client.claim_dispute_timeout(&client_addr, &escrow_id);
+
+        let meta = client.get_escrow_meta(&escrow_id);
+        assert_eq!(meta.remaining_balance, 0);
+        assert_eq!(token_client.balance(&client_addr), 500);
+        assert_eq!(token_client.balance(&freelancer), 500);
+    }
+}

--- a/contracts/escrow_contract/src/event_names.rs
+++ b/contracts/escrow_contract/src/event_names.rs
@@ -53,6 +53,7 @@ pub const VESTING_SCHEDULE_CREATED: Symbol = symbol_short!("vest_crt");
 
 pub const DISPUTE_RAISED: Symbol = symbol_short!("dis_rai");
 pub const DISPUTE_RESOLVED: Symbol = symbol_short!("dis_res");
+pub const DISPUTE_TIMEOUT_CLAIMED: Symbol = symbol_short!("dis_tmo");
 
 // ── Cancellations ─────────────────────────────────────────────────────────────
 

--- a/contracts/escrow_contract/src/events.rs
+++ b/contracts/escrow_contract/src/events.rs
@@ -186,6 +186,19 @@ pub fn emit_dispute_resolved(
     );
 }
 
+pub fn emit_dispute_timeout_claimed(
+    env: &Env,
+    escrow_id: u64,
+    client_amount: i128,
+    freelancer_amount: i128,
+    claimed_at_ledger: u32,
+) {
+    env.events().publish(
+        (ev::DISPUTE_TIMEOUT_CLAIMED, escrow_id),
+        (client_amount, freelancer_amount, claimed_at_ledger),
+    );
+}
+
 pub fn emit_reputation_updated(env: &Env, address: &Address, new_score: u64) {
     env.events()
         .publish((ev::REPUTATION_UPDATED,), (address.clone(), new_score));

--- a/contracts/escrow_contract/src/lib.rs
+++ b/contracts/escrow_contract/src/lib.rs
@@ -58,6 +58,7 @@ mod batch_add_milestones_cap_tests;
 mod batch_approve_release_e2e_tests;
 mod bridge;
 mod bridge_tests;
+mod dispute_timeout_tests;
 mod errors;
 mod event_names;
 mod event_tests;
@@ -217,6 +218,8 @@ pub struct EscrowMeta {
     pub buyer_signers: soroban_sdk::Vec<Address>,
     pub created_at: u64,
     pub deadline: Option<u64>,
+    pub dispute_timeout: Option<u32>,
+    pub dispute_start_ledger: Option<u32>,
     /// Optional lock time (ledger timestamp) - funds locked until this time.
     pub lock_time: Option<u64>,
     /// Optional extension deadline for the lock time.
@@ -404,6 +407,8 @@ impl ContractStorage {
             buyer_signers: meta.buyer_signers.clone(),
             created_at: meta.created_at,
             deadline: meta.deadline,
+            dispute_timeout: meta.dispute_timeout,
+            dispute_start_ledger: meta.dispute_start_ledger,
             lock_time: meta.lock_time,
             lock_time_extension: meta.lock_time_extension,
             timelock: meta.timelock,
@@ -1239,6 +1244,37 @@ impl EscrowContract {
             deadline,
             lock_time,
             None,
+            None,
+        )
+    }
+
+    /// Creates a new escrow and stores an optional dispute-timeout window in ledger sequences.
+    pub fn create_escrow_with_dispute_timeout(
+        env: Env,
+        client: Address,
+        freelancer: Address,
+        token: Address,
+        total_amount: i128,
+        brief_hash: BytesN<32>,
+        arbiter: Option<Address>,
+        deadline: Option<u64>,
+        lock_time: Option<u64>,
+        dispute_timeout: Option<u32>,
+        _timelock: Option<Timelock>,
+        _multisig_config: MultisigConfig,
+    ) -> Result<u64, EscrowError> {
+        Self::create_escrow_internal(
+            env,
+            client,
+            freelancer,
+            token,
+            total_amount,
+            brief_hash,
+            arbiter,
+            deadline,
+            lock_time,
+            dispute_timeout,
+            None,
         )
     }
 
@@ -1275,6 +1311,7 @@ impl EscrowContract {
             deadline,
             lock_time,
             None,
+            None,
         )?;
         events::emit_nft_gated_escrow_created(&env, escrow_id, &nft_contract, token_id);
         Ok(escrow_id)
@@ -1305,6 +1342,7 @@ impl EscrowContract {
             arbiter,
             deadline,
             lock_time,
+            None,
             Some(buyer_signers),
         )
     }
@@ -1352,6 +1390,7 @@ impl EscrowContract {
         arbiter: Option<Address>,
         deadline: Option<u64>,
         lock_time: Option<u64>,
+        dispute_timeout: Option<u32>,
         buyer_signers: Option<soroban_sdk::Vec<Address>>,
     ) -> Result<u64, EscrowError> {
         // Auth + validation before any storage I/O
@@ -1443,6 +1482,8 @@ impl EscrowContract {
                 buyer_signers: buyer_signers.clone(),
                 created_at: now,
                 deadline,
+                dispute_timeout,
+                dispute_start_ledger: None,
                 lock_time,
                 lock_time_extension: None,
                 timelock: OptionalTimelock::None,
@@ -1547,6 +1588,8 @@ impl EscrowContract {
             buyer_signers,
             created_at: now,
             deadline: None,
+            dispute_timeout: None,
+            dispute_start_ledger: None,
             lock_time: None,
             lock_time_extension: None,
             timelock: OptionalTimelock::None,
@@ -2878,6 +2921,7 @@ impl EscrowContract {
         }
 
         meta.status = EscrowStatus::Disputed;
+        meta.dispute_start_ledger = Some(env.ledger().sequence());
         Self::remove_from_vec_index(
             &env,
             &DataKey::EscrowsByStatus(EscrowStatus::Active),
@@ -2953,6 +2997,7 @@ impl EscrowContract {
         }
 
         meta.remaining_balance = 0;
+        meta.dispute_start_ledger = None;
         meta.status = EscrowStatus::Completed;
         Self::remove_from_vec_index(
             &env,
@@ -2972,6 +3017,48 @@ impl EscrowContract {
         Self::_update_reputation_internal(&env, &meta.client, false, true, client_amount);
         Self::_update_reputation_internal(&env, &meta.freelancer, false, true, freelancer_amount);
 
+        Ok(())
+    }
+
+    /// Allows either party to settle a disputed escrow after the configured timeout has elapsed.
+    pub fn claim_dispute_timeout(
+        env: Env,
+        caller: Address,
+        escrow_id: u64,
+    ) -> Result<(), EscrowError> {
+        caller.require_auth();
+        ContractStorage::require_not_paused(&env)?;
+
+        let mut meta = ContractStorage::load_escrow_meta_with_rent(&env, escrow_id)?;
+        if caller != meta.client && caller != meta.freelancer {
+            return Err(EscrowError::Unauthorized);
+        }
+        if meta.status != EscrowStatus::Disputed {
+            return Err(EscrowError::EscrowNotDisputed);
+        }
+
+        let dispute_timeout = meta.dispute_timeout.ok_or(EscrowError::LockTimeNotExpired)?;
+        let dispute_start = meta.dispute_start_ledger.ok_or(EscrowError::LockTimeNotExpired)?;
+        let current_sequence = env.ledger().sequence();
+        let timeout_sequence = dispute_start.saturating_add(dispute_timeout);
+        if current_sequence < timeout_sequence {
+            return Err(EscrowError::LockTimeNotExpired);
+        }
+
+        let client_amount = meta.remaining_balance / 2;
+        let freelancer_amount = meta.remaining_balance - client_amount;
+        let token = token::Client::new(&env, &meta.token);
+        let contract_addr = env.current_contract_address();
+        if client_amount > 0 { token.transfer(&contract_addr, &meta.client, &client_amount); }
+        if freelancer_amount > 0 { token.transfer(&contract_addr, &meta.freelancer, &freelancer_amount); }
+
+        meta.remaining_balance = 0;
+        meta.dispute_start_ledger = None;
+        meta.status = EscrowStatus::Completed;
+        Self::remove_from_vec_index(&env, &DataKey::EscrowsByStatus(EscrowStatus::Disputed), escrow_id);
+        Self::append_to_vec_index(&env, &DataKey::EscrowsByStatus(EscrowStatus::Completed), escrow_id);
+        ContractStorage::save_escrow_meta(&env, &meta);
+        events::emit_dispute_timeout_claimed(&env, escrow_id, client_amount, freelancer_amount, current_sequence);
         Ok(())
     }
 
@@ -3289,6 +3376,7 @@ impl EscrowContract {
             arbiter.clone(),
             deadline,
             None, // lock_time
+            None, // dispute_timeout
             None, // buyer_signers
         )?;
 
@@ -3873,6 +3961,7 @@ impl EscrowContract {
 
         // Raise dispute on escrow
         meta.status = EscrowStatus::Disputed;
+        meta.dispute_start_ledger = Some(env.ledger().sequence());
         Self::remove_from_vec_index(
             &env,
             &DataKey::EscrowsByStatus(EscrowStatus::CancellationPending),

--- a/contracts/escrow_contract/src/storage.rs
+++ b/contracts/escrow_contract/src/storage.rs
@@ -236,6 +236,8 @@ impl StorageManager {
                     buyer_signers: soroban_sdk::Vec::new(env),
                     created_at: v1_escrow.created_at,
                     deadline: v1_escrow.deadline,
+                    dispute_timeout: None,
+                    dispute_start_ledger: None,
                     lock_time: v1_escrow.lock_time,
                     lock_time_extension: v1_escrow.lock_time_extension,
                     timelock: OptionalTimelock::None,

--- a/contracts/escrow_contract/src/types.rs
+++ b/contracts/escrow_contract/src/types.rs
@@ -372,6 +372,12 @@ pub struct EscrowState {
     /// TODO (contributor): implement auto-cancel on deadline
     pub deadline: Option<u64>,
 
+    /// Optional dispute-timeout window in ledger sequences.
+    pub dispute_timeout: Option<u32>,
+
+    /// Ledger sequence captured when a dispute was raised.
+    pub dispute_start_ledger: Option<u32>,
+
     /// Optional lock time (ledger timestamp) - funds locked until this time.
     /// When set, funds cannot be released until this timestamp has passed.
     /// Useful for vesting schedules, deferred payments, or future-dated agreements.


### PR DESCRIPTION
Closes #814

## Changes
- add optional dispute-timeout support to escrow creation through a dedicated constructor
- record the dispute start ledger when disputes are raised and allow either party to claim a timeout settlement later
- emit a dispute-timeout event and cover the ledger-sequence timeout flow with tests

## Testing
- not run locally in this API-only workflow