### PR TITLE
feat: IPFS hashing, resilient indexer, arbitrator DAO, slashing (#14 #15 #16 #17)

### DIFF
--- a/backend/api/controllers/disputeController.js
+++ b/backend/api/controllers/disputeController.js
@@ -10,6 +10,7 @@ import { buildPaginatedResponse, parsePagination } from '../../lib/pagination.js
 import { uploadEvidence } from '../middleware/fileUpload.js';
 import ipfsService from '../../services/ipfsService.js';
 import { broadcastToDispute } from '../websocket/handlers.js';
+import { verifyFile, merkleRoot, hashFile } from '../../services/ipfsHashService.js';
 
 /**
  * List and get handlers assume query/params are already validated by
@@ -482,6 +483,57 @@ const getResolutionHistory = async (req, res) => {
   }
 };
 
+/**
+ * POST /api/disputes/verify-evidence
+ * Body: multipart/form-data with files[] + evidenceIds[]
+ *
+ * Re-uploads files and verifies their SHA-256 hashes against stored values.
+ * Also recomputes the Merkle root and compares against the stored root.
+ */
+const verifyEvidence = async (req, res) => {
+  try {
+    const { evidenceIds } = req.body;
+    const files = req.files ?? [];
+
+    if (!evidenceIds || !files.length) {
+      return res.status(400).json({ error: 'evidenceIds and files are required' });
+    }
+
+    const ids = (Array.isArray(evidenceIds) ? evidenceIds : [evidenceIds]).map(Number);
+
+    const records = await prisma.disputeEvidence.findMany({
+      where: { id: { in: ids } },
+      select: { id: true, fileHash: true, merkleRoot: true, filename: true },
+    });
+
+    if (records.length !== files.length) {
+      return res.status(400).json({ error: 'File count must match evidenceIds count' });
+    }
+
+    const fileResults = files.map((file, i) => {
+      const record = records[i];
+      if (!record?.fileHash) return { id: record?.id, valid: false, reason: 'No stored hash' };
+      const { hex } = hashFile(file.buffer);
+      return { id: record.id, filename: file.originalname, valid: hex === record.fileHash };
+    });
+
+    const storedHashes = records.map(r => r.fileHash).filter(Boolean);
+    const recomputedRoot = merkleRoot(storedHashes);
+    const storedRoot = records[0]?.merkleRoot ?? null;
+    const rootMatch = storedRoot ? recomputedRoot === storedRoot : null;
+
+    return res.json({
+      allValid: fileResults.every(r => r.valid),
+      fileResults,
+      merkleRoot: recomputedRoot,
+      storedMerkleRoot: storedRoot,
+      rootMatch,
+    });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+};
+
 function determineUserRole(dispute, userAddress) {
   if (dispute.raisedByAddress === userAddress) {
     return dispute.escrow.clientAddress === userAddress ? 'client' : 'freelancer';
@@ -532,5 +584,6 @@ export default {
   postAppeal,
   patchAppeal,
   getResolutionHistory,
-  uploadEvidence
+  uploadEvidence,
+  verifyEvidence,
 };

--- a/backend/database/schema.prisma
+++ b/backend/database/schema.prisma
@@ -254,6 +254,10 @@ model DisputeEvidence {
   ipfsCid      String?  @map("ipfs_cid")
   /// IPFS CID for thumbnail (images only)
   thumbnailCid String?  @map("thumbnail_cid")
+  /// SHA-256 hash of the file content (hex)
+  fileHash     String?  @map("file_hash")
+  /// Merkle root of all evidence files in this dispute batch
+  merkleRoot   String?  @map("merkle_root")
   /// Virus scan status: pending | clean | infected | error
   scanStatus   String?  @default("pending") @map("scan_status")
   /// Virus scan result details

--- a/backend/services/ipfsHashService.js
+++ b/backend/services/ipfsHashService.js
@@ -1,0 +1,107 @@
+/**
+ * IPFS Hash & Merkle Verification Service
+ *
+ * Provides:
+ *   - SHA-256 hashing of file buffers
+ *   - Merkle root calculation for multi-file evidence sets
+ *   - Verification of files against stored hashes
+ *
+ * The Merkle root is included when transmitting dispute state to the
+ * smart contract so evidence integrity can be verified on-chain.
+ */
+
+import crypto from 'crypto';
+
+// ── SHA-256 ───────────────────────────────────────────────────────────────────
+
+/**
+ * Computes the SHA-256 hash of a Buffer or string.
+ * @param {Buffer|string} data
+ * @returns {string} hex digest
+ */
+export function sha256(data) {
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+/**
+ * Computes SHA-256 of a file buffer and returns hex + base64 representations.
+ * @param {Buffer} buffer
+ * @returns {{ hex: string, base64: string }}
+ */
+export function hashFile(buffer) {
+  const hash = crypto.createHash('sha256').update(buffer);
+  return { hex: hash.copy().digest('hex'), base64: hash.digest('base64') };
+}
+
+// ── Merkle tree ───────────────────────────────────────────────────────────────
+
+/**
+ * Builds a Merkle tree from an array of hex leaf hashes and returns the root.
+ *
+ * Algorithm: binary Merkle tree, SHA-256(left || right).
+ * Odd number of leaves: duplicate the last leaf.
+ *
+ * @param {string[]} leaves — array of hex SHA-256 hashes
+ * @returns {string} Merkle root as hex string
+ */
+export function merkleRoot(leaves) {
+  if (!leaves || leaves.length === 0) return sha256('empty');
+  if (leaves.length === 1) return leaves[0];
+
+  let level = [...leaves];
+
+  while (level.length > 1) {
+    const next = [];
+    for (let i = 0; i < level.length; i += 2) {
+      const left = level[i];
+      const right = level[i + 1] ?? left; // duplicate last if odd
+      next.push(sha256(left + right));
+    }
+    level = next;
+  }
+
+  return level[0];
+}
+
+/**
+ * Hashes an array of file buffers and returns individual hashes + Merkle root.
+ *
+ * @param {Buffer[]} buffers
+ * @returns {{ hashes: string[], root: string }}
+ */
+export function hashFiles(buffers) {
+  const hashes = buffers.map(b => hashFile(b).hex);
+  const root = merkleRoot(hashes);
+  return { hashes, root };
+}
+
+/**
+ * Verifies a single file buffer against a stored SHA-256 hex hash.
+ *
+ * @param {Buffer} buffer
+ * @param {string} storedHash — hex SHA-256
+ * @returns {boolean}
+ */
+export function verifyFile(buffer, storedHash) {
+  return hashFile(buffer).hex === storedHash;
+}
+
+/**
+ * Verifies a set of file buffers against stored hashes and a Merkle root.
+ *
+ * @param {Buffer[]} buffers
+ * @param {string[]} storedHashes
+ * @param {string}   storedRoot
+ * @returns {{ valid: boolean, fileResults: boolean[], rootMatch: boolean }}
+ */
+export function verifyFiles(buffers, storedHashes, storedRoot) {
+  if (buffers.length !== storedHashes.length) {
+    return { valid: false, fileResults: [], rootMatch: false };
+  }
+  const fileResults = buffers.map((b, i) => verifyFile(b, storedHashes[i]));
+  const recomputedRoot = merkleRoot(fileResults.map((ok, i) => ok ? storedHashes[i] : 'invalid'));
+  const rootMatch = recomputedRoot === storedRoot;
+  return { valid: fileResults.every(Boolean) && rootMatch, fileResults, rootMatch };
+}
+
+export default { sha256, hashFile, hashFiles, merkleRoot, verifyFile, verifyFiles };

--- a/backend/workers/escrowIndexer.js
+++ b/backend/workers/escrowIndexer.js
@@ -1,0 +1,262 @@
+/**
+ * Escrow Ledger Event Indexer — Resilient Sync Pipeline
+ *
+ * Tracks last_processed_ledger in PostgreSQL (IndexerState table).
+ * On startup, catches up from the last saved ledger in batches.
+ * Retries RPC failures with exponential backoff.
+ * Emits performance metrics to console (wire to Prometheus in production).
+ *
+ * ## Resilience guarantees
+ *   - Crash recovery: resumes from last committed ledger on restart
+ *   - RPC downtime: exponential backoff up to MAX_BACKOFF_MS
+ *   - Batch processing: processes BATCH_SIZE ledgers per tick to avoid RPC overload
+ *   - Zero data loss: ledger cursor only advances after successful DB write
+ */
+
+import prisma from '../lib/prisma.js';
+import { withRetry } from '../lib/transaction.js';
+
+const CONTRACT_ID         = process.env.ESCROW_CONTRACT_ID || '';
+const RPC_URL             = process.env.SOROBAN_RPC_URL    || 'https://soroban-testnet.stellar.org';
+const POLL_INTERVAL_MS    = parseInt(process.env.INDEXER_POLL_INTERVAL_MS || '5000',  10);
+const BATCH_SIZE          = parseInt(process.env.INDEXER_BATCH_SIZE       || '100',   10);
+const BASE_BACKOFF_MS     = parseInt(process.env.INDEXER_BASE_BACKOFF_MS  || '1000',  10);
+const MAX_BACKOFF_MS      = parseInt(process.env.INDEXER_MAX_BACKOFF_MS   || '60000', 10);
+const START_LEDGER        = parseInt(process.env.INDEXER_START_LEDGER     || '0',     10);
+
+// ── Metrics ───────────────────────────────────────────────────────────────────
+
+const metrics = {
+  eventsProcessed: 0,
+  ledgersProcessed: 0,
+  rpcErrors: 0,
+  dbErrors: 0,
+  lastTickMs: 0,
+  lastLedger: 0,
+};
+
+function logMetrics() {
+  console.log('[Indexer] metrics', JSON.stringify(metrics));
+}
+
+// ── RPC helpers ───────────────────────────────────────────────────────────────
+
+async function rpcFetch(path, body) {
+  const res = await fetch(`${RPC_URL}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: path, params: body }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) throw new Error(`RPC HTTP ${res.status}`);
+  const json = await res.json();
+  if (json.error) throw new Error(`RPC error: ${json.error.message}`);
+  return json.result;
+}
+
+async function getLatestLedger() {
+  const result = await rpcFetch('getLatestLedger', []);
+  return result.sequence;
+}
+
+async function getEvents(startLedger, endLedger) {
+  const result = await rpcFetch('getEvents', [{
+    startLedger,
+    endLedger,
+    filters: [{ type: 'contract', contractIds: [CONTRACT_ID] }],
+  }]);
+  return result.events ?? [];
+}
+
+// ── Cursor persistence ────────────────────────────────────────────────────────
+
+async function loadCursor() {
+  const state = await prisma.indexerState.upsert({
+    where: { id: 1 },
+    create: { id: 1, lastProcessedLedger: BigInt(START_LEDGER) },
+    update: {},
+  });
+  return Number(state.lastProcessedLedger);
+}
+
+async function saveCursor(ledger) {
+  await prisma.indexerState.update({
+    where: { id: 1 },
+    data: { lastProcessedLedger: BigInt(ledger) },
+  });
+  metrics.lastLedger = ledger;
+}
+
+// ── Event dispatch ────────────────────────────────────────────────────────────
+
+async function dispatchEvent(event) {
+  const topic = event.topic?.[0] ?? '';
+  const escrowId = event.topic?.[1] ? BigInt(event.topic[1]) : null;
+
+  switch (topic) {
+    case 'esc_crt': return handleEscrowCreated(event, escrowId);
+    case 'mil_add': return handleMilestoneAdded(event, escrowId);
+    case 'mil_sub': return handleMilestoneSubmitted(event, escrowId);
+    case 'mil_apr': return handleMilestoneApproved(event, escrowId);
+    case 'funds_rel': return handleFundsReleased(event, escrowId);
+    case 'esc_can': return handleEscrowCancelled(event, escrowId);
+    case 'dis_rai': return handleDisputeRaised(event, escrowId);
+    case 'dis_res': return handleDisputeResolved(event, escrowId);
+    case 'rep_upd': return handleReputationUpdated(event);
+    default:
+      console.warn(`[Indexer] Unknown event topic: ${topic}`);
+  }
+}
+
+async function handleEscrowCreated(event, escrowId) {
+  const [client, freelancer, amount] = event.value ?? [];
+  if (!escrowId || !client) return;
+  await prisma.contractEvent.upsert({
+    where: { tenantId_txHash_eventIndex: { tenantId: 'default', txHash: event.txHash, eventIndex: event.id ?? 0 } },
+    create: {
+      tenantId: 'default', ledger: BigInt(event.ledger), ledgerAt: new Date(event.ledgerClosedAt),
+      contractId: CONTRACT_ID, eventType: 'esc_crt', escrowId,
+      topics: event.topic, data: event.value, txHash: event.txHash, eventIndex: event.id ?? 0,
+    },
+    update: {},
+  });
+}
+
+async function handleMilestoneAdded(event, escrowId) {
+  await prisma.contractEvent.upsert({
+    where: { tenantId_txHash_eventIndex: { tenantId: 'default', txHash: event.txHash, eventIndex: event.id ?? 0 } },
+    create: {
+      tenantId: 'default', ledger: BigInt(event.ledger), ledgerAt: new Date(event.ledgerClosedAt),
+      contractId: CONTRACT_ID, eventType: 'mil_add', escrowId,
+      topics: event.topic, data: event.value, txHash: event.txHash, eventIndex: event.id ?? 0,
+    },
+    update: {},
+  });
+}
+
+async function handleMilestoneSubmitted(event, escrowId) {
+  const [milestoneId] = event.value ?? [];
+  if (!escrowId || milestoneId === undefined) return;
+  await prisma.$transaction([
+    prisma.milestone.updateMany({
+      where: { escrowId, milestoneIndex: Number(milestoneId) },
+      data: { status: 'Submitted', submittedAt: new Date(event.ledgerClosedAt) },
+    }),
+    prisma.contractEvent.upsert({
+      where: { tenantId_txHash_eventIndex: { tenantId: 'default', txHash: event.txHash, eventIndex: event.id ?? 0 } },
+      create: {
+        tenantId: 'default', ledger: BigInt(event.ledger), ledgerAt: new Date(event.ledgerClosedAt),
+        contractId: CONTRACT_ID, eventType: 'mil_sub', escrowId,
+        topics: event.topic, data: event.value, txHash: event.txHash, eventIndex: event.id ?? 0,
+      },
+      update: {},
+    }),
+  ]);
+}
+
+async function handleMilestoneApproved(event, escrowId) {
+  const [milestoneId] = event.value ?? [];
+  if (!escrowId || milestoneId === undefined) return;
+  await prisma.milestone.updateMany({
+    where: { escrowId, milestoneIndex: Number(milestoneId) },
+    data: { status: 'Approved', resolvedAt: new Date(event.ledgerClosedAt) },
+  });
+}
+
+async function handleFundsReleased(event, escrowId) {
+  const [, amount] = event.value ?? [];
+  if (!escrowId || !amount) return;
+  await prisma.$executeRaw`
+    UPDATE escrows SET remaining_balance = (remaining_balance::numeric - ${BigInt(amount)}::numeric)::text
+    WHERE id = ${escrowId}
+  `;
+}
+
+async function handleEscrowCancelled(event, escrowId) {
+  if (!escrowId) return;
+  await prisma.escrow.updateMany({ where: { id: escrowId }, data: { status: 'Cancelled' } });
+}
+
+async function handleDisputeRaised(event, escrowId) {
+  const raisedBy = event.value;
+  if (!escrowId) return;
+  await prisma.$transaction([
+    prisma.escrow.updateMany({ where: { id: escrowId }, data: { status: 'Disputed' } }),
+    prisma.dispute.upsert({
+      where: { escrowId },
+      create: { escrowId, raisedByAddress: String(raisedBy ?? ''), raisedAt: new Date(event.ledgerClosedAt) },
+      update: {},
+    }),
+  ]);
+}
+
+async function handleDisputeResolved(event, escrowId) {
+  if (!escrowId) return;
+  await prisma.escrow.updateMany({ where: { id: escrowId }, data: { status: 'Completed' } });
+}
+
+async function handleReputationUpdated(event) {
+  const [address, newScore] = event.value ?? [];
+  if (!address) return;
+  await prisma.reputationRecord.upsert({
+    where: { address: String(address) },
+    create: { tenantId: 'default', address: String(address), totalScore: BigInt(newScore ?? 0), lastUpdated: new Date() },
+    update: { totalScore: BigInt(newScore ?? 0), lastUpdated: new Date() },
+  });
+}
+
+// ── Main loop ─────────────────────────────────────────────────────────────────
+
+async function processBatch(fromLedger, toLedger) {
+  const events = await getEvents(fromLedger, toLedger);
+  for (const event of events) {
+    await withRetry(() => dispatchEvent(event));
+    metrics.eventsProcessed++;
+  }
+  metrics.ledgersProcessed += toLedger - fromLedger + 1;
+  return events.length;
+}
+
+export async function startIndexer() {
+  if (!CONTRACT_ID) {
+    console.warn('[Indexer] ESCROW_CONTRACT_ID not set — skipping');
+    return;
+  }
+
+  let cursor = await loadCursor();
+  let backoff = BASE_BACKOFF_MS;
+  console.log(`[Indexer] Starting from ledger ${cursor}`);
+
+  const tick = async () => {
+    const t0 = Date.now();
+    try {
+      const latest = await getLatestLedger();
+
+      if (cursor >= latest) return; // fully caught up
+
+      // Catch-up: process in batches
+      while (cursor < latest) {
+        const batchEnd = Math.min(cursor + BATCH_SIZE, latest);
+        await processBatch(cursor + 1, batchEnd);
+        cursor = batchEnd;
+        await saveCursor(cursor);
+      }
+
+      backoff = BASE_BACKOFF_MS; // reset on success
+    } catch (err) {
+      metrics.rpcErrors++;
+      console.error(`[Indexer] Tick error (backoff ${backoff}ms):`, err.message);
+      await new Promise(r => setTimeout(r, backoff));
+      backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+    } finally {
+      metrics.lastTickMs = Date.now() - t0;
+    }
+  };
+
+  // Run immediately then on interval
+  await tick();
+  setInterval(tick, POLL_INTERVAL_MS);
+  setInterval(logMetrics, 60_000);
+}
+
+export default { startIndexer };

--- a/contracts/governance/src/errors.rs
+++ b/contracts/governance/src/errors.rs
@@ -35,4 +35,12 @@ pub enum GovError {
     // Parameters
     InvalidParameter = 19,
     InvalidDuration = 20,
+
+    // Arbitrator DAO
+    AlreadyArbitrator = 21,
+    NotArbitrator = 22,
+    InsufficientStake = 23,
+    StakeCooldownActive = 24,
+    NoStakeToWithdraw = 25,
+    SlashExceedsStake = 26,
 }

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -533,4 +533,188 @@ impl GovernanceContract {
         let config = Storage::config(&env)?;
         Ok(voting_power(&env, &config.token, &address))
     }
+
+    // ── Arbitrator DAO ────────────────────────────────────────────────────────
+
+    /// Minimum stake required to register as an arbitrator (in token base units).
+    /// Configurable via the governance token's decimals; default 1000 units.
+    const MIN_STAKE: i128 = 1_000;
+
+    /// Cooldown period before a non-slashed stake can be withdrawn (7 days in seconds).
+    const WITHDRAW_COOLDOWN: u64 = 604_800;
+
+    /// Percentage of stake slashed on misconduct (10%).
+    const SLASH_PERCENT: i128 = 10;
+
+    /// Stake tokens to register as an arbitrator candidate.
+    ///
+    /// The caller transfers `amount` tokens to this contract.
+    /// If `amount >= MIN_STAKE`, the caller is added to the arbitrator whitelist.
+    ///
+    /// # Arguments
+    /// * `caller` — must `require_auth()`. Tokens deducted from their balance.
+    /// * `amount` — tokens to stake. Must be >= MIN_STAKE.
+    pub fn stake_arbitrator(env: Env, caller: Address, amount: i128) -> Result<(), GovError> {
+        Storage::require_initialized(&env)?;
+        caller.require_auth();
+
+        if amount < Self::MIN_STAKE {
+            return Err(GovError::InsufficientStake);
+        }
+
+        let config = Storage::config(&env)?;
+        token::Client::new(&env, &config.token).transfer(
+            &caller,
+            &env.current_contract_address(),
+            &amount,
+        );
+
+        // Accumulate stake
+        let prev_stake: i128 = env.storage().persistent()
+            .get(&DataKey::ArbitratorStake(caller.clone()))
+            .unwrap_or(0);
+        let new_stake = prev_stake + amount;
+        env.storage().persistent().set(&DataKey::ArbitratorStake(caller.clone()), &new_stake);
+        env.storage().persistent().set(&DataKey::Arbitrator(caller.clone()), &true);
+
+        Storage::bump_persistent(&env, &DataKey::ArbitratorStake(caller.clone()));
+        Storage::bump_persistent(&env, &DataKey::Arbitrator(caller.clone()));
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("arb_stk"), caller.clone()),
+            (amount, new_stake),
+        );
+        Ok(())
+    }
+
+    /// Withdraw stake after the cooldown period (only if not slashed below MIN_STAKE).
+    ///
+    /// Sets a cooldown on first call; tokens are returned on second call after cooldown.
+    pub fn withdraw_stake(env: Env, caller: Address) -> Result<i128, GovError> {
+        Storage::require_initialized(&env)?;
+        caller.require_auth();
+
+        let stake: i128 = env.storage().persistent()
+            .get(&DataKey::ArbitratorStake(caller.clone()))
+            .unwrap_or(0);
+
+        if stake <= 0 {
+            return Err(GovError::NoStakeToWithdraw);
+        }
+
+        let now = env.ledger().timestamp();
+        let cooldown_key = DataKey::WithdrawCooldown(caller.clone());
+
+        match env.storage().persistent().get::<DataKey, u64>(&cooldown_key) {
+            None => {
+                // First call — start cooldown
+                let expires = now + Self::WITHDRAW_COOLDOWN;
+                env.storage().persistent().set(&cooldown_key, &expires);
+                Storage::bump_persistent(&env, &cooldown_key);
+                return Err(GovError::StakeCooldownActive);
+            }
+            Some(expires) if now < expires => {
+                return Err(GovError::StakeCooldownActive);
+            }
+            _ => {}
+        }
+
+        // Cooldown elapsed — return stake and remove arbitrator
+        let config = Storage::config(&env)?;
+        token::Client::new(&env, &config.token).transfer(
+            &env.current_contract_address(),
+            &caller,
+            &stake,
+        );
+
+        env.storage().persistent().remove(&DataKey::ArbitratorStake(caller.clone()));
+        env.storage().persistent().remove(&DataKey::Arbitrator(caller.clone()));
+        env.storage().persistent().remove(&cooldown_key);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("arb_wdr"), caller.clone()),
+            stake,
+        );
+        Ok(stake)
+    }
+
+    /// Governance-driven slash of a misbehaving arbitrator.
+    ///
+    /// Only callable by the contract admin (after a governance vote passes and
+    /// the admin executes the resolution). Slashes SLASH_PERCENT of the
+    /// arbitrator's stake and sends it to `recipient` (victim or treasury).
+    ///
+    /// # Arguments
+    /// * `caller`      — must be admin.
+    /// * `arbitrator`  — address to slash.
+    /// * `recipient`   — receives the slashed tokens.
+    /// * `reason`      — on-chain evidence string (IPFS hash or description).
+    pub fn slash_arbitrator(
+        env: Env,
+        caller: Address,
+        arbitrator: Address,
+        recipient: Address,
+        reason: soroban_sdk::String,
+    ) -> Result<i128, GovError> {
+        Storage::require_initialized(&env)?;
+        caller.require_auth();
+
+        let admin = Storage::admin(&env)?;
+        if caller != admin {
+            return Err(GovError::AdminOnly);
+        }
+
+        let stake: i128 = env.storage().persistent()
+            .get(&DataKey::ArbitratorStake(arbitrator.clone()))
+            .unwrap_or(0);
+
+        if stake <= 0 {
+            return Err(GovError::NotArbitrator);
+        }
+
+        let slash_amount = stake * Self::SLASH_PERCENT / 100;
+        if slash_amount > stake {
+            return Err(GovError::SlashExceedsStake);
+        }
+
+        let remaining = stake - slash_amount;
+
+        // Transfer slashed amount to recipient
+        let config = Storage::config(&env)?;
+        token::Client::new(&env, &config.token).transfer(
+            &env.current_contract_address(),
+            &recipient,
+            &slash_amount,
+        );
+
+        // Update or remove stake
+        if remaining < Self::MIN_STAKE {
+            // Below minimum — remove from whitelist
+            env.storage().persistent().remove(&DataKey::Arbitrator(arbitrator.clone()));
+            env.storage().persistent().remove(&DataKey::ArbitratorStake(arbitrator.clone()));
+        } else {
+            env.storage().persistent().set(&DataKey::ArbitratorStake(arbitrator.clone()), &remaining);
+            Storage::bump_persistent(&env, &DataKey::ArbitratorStake(arbitrator.clone()));
+        }
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("arb_slh"), arbitrator.clone()),
+            (slash_amount, remaining, reason),
+        );
+        Ok(slash_amount)
+    }
+
+    /// Returns whether `address` is a whitelisted arbitrator.
+    pub fn is_arbitrator(env: Env, address: Address) -> bool {
+        env.storage().persistent()
+            .get::<DataKey, bool>(&DataKey::Arbitrator(address))
+            .unwrap_or(false)
+    }
+
+    /// Returns the current stake of `address`.
+    pub fn get_stake(env: Env, address: Address) -> i128 {
+        env.storage().persistent()
+            .get(&DataKey::ArbitratorStake(address))
+            .unwrap_or(0)
+    }
 }

--- a/contracts/governance/src/types.rs
+++ b/contracts/governance/src/types.rs
@@ -145,4 +145,13 @@ pub enum DataKey {
     Proposal(u64),
     /// Whether `voter` has voted on proposal `id`: (proposal_id, voter)
     HasVoted(u64, Address),
+    // ── Arbitrator DAO ────────────────────────────────────────────────────────
+    /// Registered arbitrator whitelist entry — key: Address, value: bool
+    Arbitrator(Address),
+    /// Arbitrator stake — key: Address, value: i128
+    ArbitratorStake(Address),
+    /// Cooldown expiry for stake withdrawal — key: Address, value: u64
+    WithdrawCooldown(Address),
+    /// Slash record counter
+    SlashCounter,
 }


### PR DESCRIPTION
…
closes #817 
closes #818 
closes #819 
closes #820 

#16 — IPFS Metadata Hashing & Verification Pipeline backend/services/ipfsHashService.js:
  - sha256(data) — SHA-256 of any buffer/string
  - hashFile(buffer) → { hex, base64 }
  - merkleRoot(leaves[]) — binary Merkle tree, SHA-256(left||right), duplicates last leaf for odd counts
  - hashFiles(buffers[]) → { hashes[], root }
  - verifyFile(buffer, storedHash) — single file integrity check
  - verifyFiles(buffers[], storedHashes[], storedRoot) — batch verify with root recomputation backend/api/controllers/disputeController.js:
  - Added verifyEvidence() — POST /api/disputes/verify-evidence re-uploads files, checks SHA-256 per file, recomputes Merkle root
  - Imported hashFile, merkleRoot from ipfsHashService backend/database/schema.prisma:
  - Added fileHash (SHA-256 hex) and merkleRoot fields to DisputeEvidence

#17 — Soroban Ledger Event Listener & Resiliency Sync Pipeline backend/workers/escrowIndexer.js (new, replaces stub):
  - loadCursor() / saveCursor() — persists last_processed_ledger in IndexerState table; cursor only advances after successful DB write
  - Catch-up loop: processes BATCH_SIZE ledgers per tick until caught up
  - Exponential backoff on RPC errors (BASE→MAX_BACKOFF_MS)
  - Full event dispatch: esc_crt, mil_add, mil_sub, mil_apr, funds_rel, esc_can, dis_rai, dis_res, rep_upd
  - Per-tick metrics: eventsProcessed, ledgersProcessed, rpcErrors, lastTickMs — logged every 60s
  - Configurable via INDEXER_BATCH_SIZE, INDEXER_BASE_BACKOFF_MS, INDEXER_MAX_BACKOFF_MS env vars

#15 — Arbitrator DAO Election Mechanism
contracts/governance/src/lib.rs:
  - stake_arbitrator(caller, amount) — transfers tokens to contract, adds to whitelist if amount >= MIN_STAKE (1000 units)
  - withdraw_stake(caller) — 7-day cooldown (WITHDRAW_COOLDOWN), removes from whitelist if stake drops below MIN_STAKE
  - is_arbitrator(address) / get_stake(address) — view functions contracts/governance/src/types.rs:
  - Added DataKey variants: Arbitrator, ArbitratorStake, WithdrawCooldown, SlashCounter

#14 — Slashing Mechanism for Malicious Arbitrators contracts/governance/src/lib.rs:
  - slash_arbitrator(caller, arbitrator, recipient, reason) — admin-only, slashes SLASH_PERCENT (10%) of stake, transfers to recipient, removes from whitelist if remaining < MIN_STAKE
  - Emits arb_slh event with (slash_amount, remaining, reason) contracts/governance/src/errors.rs:
  - Added: AlreadyArbitrator, NotArbitrator, InsufficientStake, StakeCooldownActive, NoStakeToWithdraw, SlashExceedsStake

## Summary

Briefly describe what changed and why.

Closes #

## Changes

- 
- 
- 

## Testing

List the exact commands you ran locally.

```bash
# Examples
cargo test --workspace
npm run test -w backend
npm run test -w frontend
npm run lint
```

## Review Notes

Call out any context reviewers should know:

- areas that need extra attention
- follow-up work or known limitations
- deployment or migration considerations

## Checklist

- [ ] Code compiles, or the updated docs reference working commands
- [ ] Tests were added or updated when behavior changed
- [ ] Linting and formatting were run
- [ ] Documentation was updated when needed
- [ ] No breaking changes, or they are clearly described
- [ ] Screenshots or recordings are included for UI changes
