### PR TITLE
feat: add GasEstimator, arbitrator audit logger, PDF generator, and v…

### DIFF
--- a/backend/api/controllers/pdfController.js
+++ b/backend/api/controllers/pdfController.js
@@ -1,0 +1,69 @@
+/**
+ * PDF Controller
+ *
+ * Handles:
+ *   POST /api/escrows/:id/generate-pdf  — generate & store the contract PDF
+ *   POST /api/escrows/:id/sign-pdf      — verify wallet signature and record it
+ *   GET  /api/escrows/:id/pdf           — return a pre-signed download URL
+ */
+
+import { body, param, validationResult } from 'express-validator';
+import { generateEscrowPdf, signPdf } from '../../services/pdfGenerator.js';
+import { logControllerError } from '../../config/logger.js';
+
+// ── Validators ────────────────────────────────────────────────────────────────
+
+export const validateEscrowId = [
+  param('id').isString().notEmpty().withMessage('Escrow ID is required'),
+];
+
+export const validateSignPdf = [
+  body('walletAddress').isString().notEmpty().withMessage('walletAddress is required'),
+  body('signature').isString().notEmpty().withMessage('signature is required'),
+];
+
+function handleErrors(req, res) {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ error: 'Validation failed', details: errors.array() });
+    return true;
+  }
+  return false;
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+/**
+ * POST /api/escrows/:id/generate-pdf
+ * Generates the PDF contract and returns the download URL and hash.
+ */
+export async function generatePdf(req, res) {
+  if (handleErrors(req, res)) return;
+  try {
+    const result = await generateEscrowPdf(req.params.id);
+    res.status(201).json(result);
+  } catch (err) {
+    logControllerError('pdfController.generatePdf', err);
+    const status = err.statusCode ?? 500;
+    res.status(status).json({ error: err.message });
+  }
+}
+
+/**
+ * POST /api/escrows/:id/sign-pdf
+ * Verifies the wallet signature over the PDF hash and records it.
+ */
+export async function signPdfHandler(req, res) {
+  if (handleErrors(req, res)) return;
+  try {
+    const { walletAddress, signature } = req.body;
+    const result = await signPdf(req.params.id, walletAddress, signature);
+    res.json(result);
+  } catch (err) {
+    logControllerError('pdfController.signPdf', err);
+    const status = err.statusCode ?? 500;
+    res.status(status).json({ error: err.message });
+  }
+}
+
+export default { generatePdf, signPdfHandler, validateEscrowId, validateSignPdf };

--- a/backend/api/routes/pdfRoutes.js
+++ b/backend/api/routes/pdfRoutes.js
@@ -1,0 +1,25 @@
+/**
+ * PDF Routes
+ *
+ * Mounted at /api/escrows (alongside existing escrow routes).
+ *
+ * POST /api/escrows/:id/generate-pdf  — generate & store contract PDF
+ * POST /api/escrows/:id/sign-pdf      — record cryptographic wallet signature
+ */
+
+import express from 'express';
+import authMiddleware from '../middleware/auth.js';
+import {
+  generatePdf,
+  signPdfHandler,
+  validateEscrowId,
+  validateSignPdf,
+} from '../controllers/pdfController.js';
+
+const router = express.Router();
+router.use(authMiddleware);
+
+router.post('/:id/generate-pdf', validateEscrowId, generatePdf);
+router.post('/:id/sign-pdf',     validateEscrowId, validateSignPdf, signPdfHandler);
+
+export default router;

--- a/backend/api/services/auditLogger.js
+++ b/backend/api/services/auditLogger.js
@@ -1,0 +1,247 @@
+/**
+ * Arbitrator Audit Logger
+ *
+ * Tamper-evident audit log for arbitrator actions.
+ * Each entry is linked to the previous one via a SHA-256 hash chain:
+ *
+ *   entry.hash = SHA256(prevHash + entry.id + entry.action + entry.actor + entry.timestamp + JSON(entry.metadata))
+ *
+ * This makes any retroactive modification detectable via `validateChain()`.
+ *
+ * Arbitrator actions logged:
+ *   - DISPUTE_ASSIGNED      — dispute assigned to arbitrator
+ *   - EVIDENCE_VIEWED       — arbitrator opened an evidence file
+ *   - VOTE_CAST             — arbitrator voted on a proposal
+ *   - COMMUNICATION_LOGGED  — arbitrator entered a communication record
+ *   - RESOLUTION_ISSUED     — arbitrator issued a final resolution
+ *
+ * @module api/services/auditLogger
+ */
+
+import { createHash } from 'crypto';
+import prisma from '../../lib/prisma.js';
+import { createModuleLogger } from '../../config/logger.js';
+
+const logger = createModuleLogger('auditLogger');
+
+// ── Action constants ──────────────────────────────────────────────────────────
+
+export const ArbitratorAction = {
+  DISPUTE_ASSIGNED:     'DISPUTE_ASSIGNED',
+  EVIDENCE_VIEWED:      'EVIDENCE_VIEWED',
+  VOTE_CAST:            'VOTE_CAST',
+  COMMUNICATION_LOGGED: 'COMMUNICATION_LOGGED',
+  RESOLUTION_ISSUED:    'RESOLUTION_ISSUED',
+};
+
+// ── Hash chain helpers ────────────────────────────────────────────────────────
+
+/** Genesis hash used when there is no previous entry. */
+const GENESIS_HASH = '0'.repeat(64);
+
+/**
+ * Computes the hash for a single log entry.
+ *
+ * @param {string} prevHash   - Hash of the immediately preceding entry (or GENESIS_HASH).
+ * @param {object} entry      - { id, action, actor, resourceId, timestamp, metadata }
+ * @returns {string}          - Hex SHA-256 digest
+ */
+function computeHash(prevHash, entry) {
+  const payload = [
+    prevHash,
+    String(entry.id),
+    entry.action,
+    entry.actor,
+    entry.resourceId ?? '',
+    entry.timestamp instanceof Date
+      ? entry.timestamp.toISOString()
+      : String(entry.timestamp),
+    JSON.stringify(entry.metadata ?? {}),
+  ].join('|');
+
+  return createHash('sha256').update(payload, 'utf8').digest('hex');
+}
+
+/**
+ * Fetches the most recent arbitrator audit log entry to obtain the chain tip.
+ * Returns GENESIS_HASH if no entries exist yet.
+ *
+ * @returns {Promise<string>}
+ */
+async function getChainTip() {
+  const last = await prisma.arbitratorAuditLog.findFirst({
+    orderBy: { id: 'desc' },
+    select: { hash: true },
+  });
+  return last?.hash ?? GENESIS_HASH;
+}
+
+// ── Write ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Appends a new arbitrator audit log entry.
+ *
+ * The entry is linked to the previous one via a hash chain.
+ * Never throws — failures are logged to stderr so a logging error
+ * never breaks the main request flow.
+ *
+ * @param {object} entry
+ * @param {string} entry.action      - ArbitratorAction value
+ * @param {string} entry.actor       - Stellar address of the arbitrator
+ * @param {string} [entry.resourceId] - Dispute ID, evidence ID, etc.
+ * @param {object} [entry.metadata]  - Arbitrary structured context
+ * @param {string} [entry.ipAddress]
+ * @returns {Promise<object|null>}   - Created record, or null on failure
+ */
+export async function logArbitratorAction(entry) {
+  try {
+    const prevHash = await getChainTip();
+    const timestamp = new Date();
+
+    // We need the auto-incremented id before we can compute the hash,
+    // so we create the record first with a placeholder, then update.
+    // Using a transaction ensures atomicity and prevents race conditions
+    // that would break the chain under concurrent writes.
+    const record = await prisma.$transaction(async (tx) => {
+      // Lock the last row to serialise concurrent inserts
+      const last = await tx.arbitratorAuditLog.findFirst({
+        orderBy: { id: 'desc' },
+        select: { id: true, hash: true },
+      });
+      const chainPrev = last?.hash ?? GENESIS_HASH;
+
+      // Create with placeholder hash
+      const created = await tx.arbitratorAuditLog.create({
+        data: {
+          action:     entry.action,
+          actor:      entry.actor,
+          resourceId: entry.resourceId ?? null,
+          metadata:   entry.metadata   ?? undefined,
+          ipAddress:  entry.ipAddress  ?? null,
+          timestamp,
+          prevHash:   chainPrev,
+          hash:       'pending', // replaced below
+        },
+      });
+
+      const hash = computeHash(chainPrev, {
+        id:         created.id,
+        action:     created.action,
+        actor:      created.actor,
+        resourceId: created.resourceId,
+        timestamp:  created.timestamp,
+        metadata:   created.metadata,
+      });
+
+      return tx.arbitratorAuditLog.update({
+        where: { id: created.id },
+        data:  { hash },
+      });
+    });
+
+    return record;
+  } catch (err) {
+    logger.error({ message: 'arbitrator_audit_write_failed', error: err.message, stack: err.stack });
+    return null;
+  }
+}
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+/**
+ * Validates the integrity of the entire arbitrator audit log chain.
+ *
+ * Iterates all entries in insertion order and recomputes each hash.
+ * Returns a result object describing any tampering detected.
+ *
+ * @returns {Promise<{ valid: boolean, checkedCount: number, firstViolation: object|null }>}
+ */
+export async function validateChain() {
+  const entries = await prisma.arbitratorAuditLog.findMany({
+    orderBy: { id: 'asc' },
+  });
+
+  let prevHash = GENESIS_HASH;
+  let firstViolation = null;
+
+  for (const entry of entries) {
+    // Verify prevHash linkage
+    if (entry.prevHash !== prevHash) {
+      firstViolation = {
+        id:       entry.id,
+        reason:   'prevHash_mismatch',
+        expected: prevHash,
+        actual:   entry.prevHash,
+      };
+      break;
+    }
+
+    // Recompute and verify hash
+    const expected = computeHash(prevHash, {
+      id:         entry.id,
+      action:     entry.action,
+      actor:      entry.actor,
+      resourceId: entry.resourceId,
+      timestamp:  entry.timestamp,
+      metadata:   entry.metadata,
+    });
+
+    if (expected !== entry.hash) {
+      firstViolation = {
+        id:       entry.id,
+        reason:   'hash_mismatch',
+        expected,
+        actual:   entry.hash,
+      };
+      break;
+    }
+
+    prevHash = entry.hash;
+  }
+
+  return {
+    valid:          firstViolation === null,
+    checkedCount:   entries.length,
+    firstViolation,
+  };
+}
+
+// ── Query ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Retrieves paginated arbitrator audit logs for the admin panel.
+ *
+ * @param {object} filters
+ * @param {string}  [filters.actor]
+ * @param {string}  [filters.action]
+ * @param {string}  [filters.resourceId]
+ * @param {string}  [filters.from]   - ISO date
+ * @param {string}  [filters.to]     - ISO date
+ * @param {number}  [filters.page=1]
+ * @param {number}  [filters.limit=50]
+ * @returns {Promise<{ data, total, page, limit, pages }>}
+ */
+export async function queryLogs(filters = {}) {
+  const page  = Math.max(1, parseInt(filters.page)  || 1);
+  const limit = Math.min(200, Math.max(1, parseInt(filters.limit) || 50));
+  const skip  = (page - 1) * limit;
+
+  const where = {};
+  if (filters.actor)      where.actor      = { contains: filters.actor, mode: 'insensitive' };
+  if (filters.action)     where.action     = filters.action;
+  if (filters.resourceId) where.resourceId = { contains: filters.resourceId, mode: 'insensitive' };
+  if (filters.from || filters.to) {
+    where.timestamp = {};
+    if (filters.from) where.timestamp.gte = new Date(filters.from);
+    if (filters.to)   where.timestamp.lte = new Date(filters.to);
+  }
+
+  const [data, total] = await prisma.$transaction([
+    prisma.arbitratorAuditLog.findMany({ where, skip, take: limit, orderBy: { id: 'desc' } }),
+    prisma.arbitratorAuditLog.count({ where }),
+  ]);
+
+  return { data, total, page, limit, pages: Math.ceil(total / limit) };
+}
+
+export default { logArbitratorAction, validateChain, queryLogs, ArbitratorAction };

--- a/backend/services/pdfGenerator.js
+++ b/backend/services/pdfGenerator.js
@@ -1,0 +1,340 @@
+/**
+ * PDF Generator Service
+ *
+ * Generates signing-ready escrow contract PDFs using PDFKit.
+ * Each PDF is:
+ *   1. Rendered with escrow details, milestones, and wallet addresses.
+ *   2. SHA-256 hashed and the hash embedded in the document footer.
+ *   3. Uploaded to S3 (or local disk in development).
+ *   4. Signatures (Stellar keypair signs the PDF hash) are recorded in the DB.
+ *
+ * Signing flow:
+ *   POST /api/escrows/:id/sign-pdf
+ *   Body: { walletAddress, signature }
+ *   — verifies the Ed25519 signature over the PDF hash using the Stellar SDK,
+ *     then persists the signature record.
+ *
+ * @module services/pdfGenerator
+ */
+
+import { createHash } from 'crypto';
+import { Keypair } from '@stellar/stellar-sdk';
+import PDFDocument from 'pdfkit';
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { createWriteStream, mkdirSync } from 'fs';
+import { join } from 'path';
+import { pipeline } from 'stream/promises';
+import { PassThrough } from 'stream';
+import prisma from '../lib/prisma.js';
+import { createModuleLogger } from '../config/logger.js';
+import { enqueueEvent } from '../queues/emailQueue.js';
+
+const logger = createModuleLogger('pdfGenerator');
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+const USE_S3 = process.env.PDF_STORAGE === 's3';
+const S3_BUCKET = process.env.PDF_S3_BUCKET || 'stellar-trust-escrow-pdfs';
+const LOCAL_PDF_DIR = process.env.PDF_LOCAL_DIR || '/tmp/escrow-pdfs';
+const PRESIGN_EXPIRES_SECONDS = 3600; // 1 hour
+
+const s3 = USE_S3
+  ? new S3Client({
+      region: process.env.AWS_REGION || 'us-east-1',
+      credentials: {
+        accessKeyId:     process.env.AWS_ACCESS_KEY_ID,
+        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+      },
+    })
+  : null;
+
+// ── PDF rendering ─────────────────────────────────────────────────────────────
+
+/**
+ * Renders an escrow contract PDF and returns the raw Buffer.
+ *
+ * @param {object} escrow
+ * @param {string} escrow.id
+ * @param {string} escrow.clientAddress
+ * @param {string} escrow.freelancerAddress
+ * @param {string} escrow.totalAmount
+ * @param {string} escrow.tokenAddress
+ * @param {Date}   [escrow.deadline]
+ * @param {string} [escrow.briefHash]
+ * @param {Array}  escrow.milestones
+ * @param {string} [placeholderHash]  — pass '' on first render; embed real hash on second pass
+ * @returns {Promise<Buffer>}
+ */
+async function renderPdf(escrow, placeholderHash = '') {
+  return new Promise((resolve, reject) => {
+    const doc = new PDFDocument({ margin: 50, size: 'A4' });
+    const chunks = [];
+    doc.on('data', (c) => chunks.push(c));
+    doc.on('end', () => resolve(Buffer.concat(chunks)));
+    doc.on('error', reject);
+
+    const { id, clientAddress, freelancerAddress, totalAmount, tokenAddress, deadline, milestones = [] } = escrow;
+
+    // ── Header ──────────────────────────────────────────────────────────────
+    doc
+      .fontSize(20)
+      .font('Helvetica-Bold')
+      .text('ESCROW CONTRACT', { align: 'center' })
+      .moveDown(0.5);
+
+    doc
+      .fontSize(10)
+      .font('Helvetica')
+      .fillColor('#555555')
+      .text(`Contract ID: ${id}`, { align: 'center' })
+      .text(`Generated: ${new Date().toUTCString()}`, { align: 'center' })
+      .fillColor('#000000')
+      .moveDown(1);
+
+    // ── Parties ─────────────────────────────────────────────────────────────
+    doc.fontSize(13).font('Helvetica-Bold').text('Parties').moveDown(0.3);
+    doc.fontSize(10).font('Helvetica');
+    doc.text(`Client Wallet:     ${clientAddress}`);
+    doc.text(`Freelancer Wallet: ${freelancerAddress}`);
+    doc.moveDown(1);
+
+    // ── Terms ────────────────────────────────────────────────────────────────
+    doc.fontSize(13).font('Helvetica-Bold').text('Contract Terms').moveDown(0.3);
+    doc.fontSize(10).font('Helvetica');
+    doc.text(`Total Amount:  ${totalAmount} (token: ${tokenAddress})`);
+    if (deadline) doc.text(`Deadline:      ${new Date(deadline).toUTCString()}`);
+    doc.moveDown(1);
+
+    // ── Milestones ───────────────────────────────────────────────────────────
+    doc.fontSize(13).font('Helvetica-Bold').text('Milestones').moveDown(0.3);
+    doc.fontSize(10).font('Helvetica');
+
+    if (milestones.length === 0) {
+      doc.text('No milestones defined.');
+    } else {
+      milestones.forEach((m, i) => {
+        doc
+          .font('Helvetica-Bold')
+          .text(`${i + 1}. ${m.title ?? `Milestone ${i + 1}`}`)
+          .font('Helvetica');
+        if (m.description) doc.text(`   Description: ${m.description}`);
+        if (m.amount)       doc.text(`   Amount:      ${m.amount}`);
+        if (m.deadline)     doc.text(`   Due:         ${new Date(m.deadline).toUTCString()}`);
+        doc.moveDown(0.5);
+      });
+    }
+
+    // ── Signature blocks ─────────────────────────────────────────────────────
+    doc.moveDown(2);
+    doc.fontSize(13).font('Helvetica-Bold').text('Signatures').moveDown(0.5);
+    doc.fontSize(10).font('Helvetica');
+
+    const sigLine = '_'.repeat(60);
+    doc.text(`Client:     ${sigLine}`);
+    doc.text(`            ${clientAddress}`).moveDown(1);
+    doc.text(`Freelancer: ${sigLine}`);
+    doc.text(`            ${freelancerAddress}`).moveDown(2);
+
+    // ── Hash footer ──────────────────────────────────────────────────────────
+    doc
+      .fontSize(8)
+      .fillColor('#888888')
+      .text(
+        `Document hash (SHA-256): ${placeholderHash || '<computed after render>'}`,
+        50,
+        doc.page.height - 60,
+        { align: 'center', width: doc.page.width - 100 },
+      );
+
+    doc.end();
+  });
+}
+
+/**
+ * Generates the PDF twice:
+ *   Pass 1 — render without hash to compute the SHA-256 digest.
+ *   Pass 2 — re-render with the hash embedded in the footer.
+ *
+ * @param {object} escrow
+ * @returns {Promise<{ buffer: Buffer, hash: string }>}
+ */
+async function generatePdf(escrow) {
+  // Pass 1: compute hash
+  const draft = await renderPdf(escrow, '');
+  const hash = createHash('sha256').update(draft).digest('hex');
+
+  // Pass 2: embed hash
+  const buffer = await renderPdf(escrow, hash);
+  return { buffer, hash };
+}
+
+// ── Storage ───────────────────────────────────────────────────────────────────
+
+/**
+ * Stores the PDF buffer in S3 or local disk.
+ *
+ * @param {string} escrowId
+ * @param {Buffer} buffer
+ * @returns {Promise<string>} storage key / path
+ */
+async function storePdf(escrowId, buffer) {
+  const key = `escrows/${escrowId}/contract.pdf`;
+
+  if (USE_S3) {
+    await s3.send(new PutObjectCommand({
+      Bucket:      S3_BUCKET,
+      Key:         key,
+      Body:        buffer,
+      ContentType: 'application/pdf',
+      // Server-side encryption
+      ServerSideEncryption: 'AES256',
+    }));
+    logger.info({ message: 'pdf_uploaded_s3', escrowId, key });
+  } else {
+    // Local fallback for development
+    mkdirSync(join(LOCAL_PDF_DIR, 'escrows', escrowId), { recursive: true });
+    const filePath = join(LOCAL_PDF_DIR, key);
+    const pass = new PassThrough();
+    pass.end(buffer);
+    await pipeline(pass, createWriteStream(filePath));
+    logger.info({ message: 'pdf_saved_local', escrowId, filePath });
+  }
+
+  return key;
+}
+
+/**
+ * Returns a pre-signed S3 URL (or local path) for the stored PDF.
+ *
+ * @param {string} storageKey
+ * @returns {Promise<string>}
+ */
+async function getPdfUrl(storageKey) {
+  if (USE_S3) {
+    return getSignedUrl(
+      s3,
+      new GetObjectCommand({ Bucket: S3_BUCKET, Key: storageKey }),
+      { expiresIn: PRESIGN_EXPIRES_SECONDS },
+    );
+  }
+  return join(LOCAL_PDF_DIR, storageKey);
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Generates, stores, and records the PDF contract for an escrow.
+ * Sends an auto-email to both parties with the download link.
+ *
+ * @param {string} escrowId
+ * @returns {Promise<{ storageKey: string, hash: string, url: string }>}
+ */
+export async function generateEscrowPdf(escrowId) {
+  const escrow = await prisma.escrow.findUniqueOrThrow({
+    where: { id: BigInt(escrowId) },
+    include: { milestones: { orderBy: { index: 'asc' } } },
+  });
+
+  const { buffer, hash } = await generatePdf({
+    id:                 String(escrow.id),
+    clientAddress:      escrow.clientAddress,
+    freelancerAddress:  escrow.freelancerAddress,
+    totalAmount:        escrow.totalAmount,
+    tokenAddress:       escrow.tokenAddress,
+    deadline:           escrow.deadline,
+    milestones:         escrow.milestones,
+  });
+
+  const storageKey = await storePdf(String(escrow.id), buffer);
+  const url = await getPdfUrl(storageKey);
+
+  // Persist PDF record
+  await prisma.escrowPdf.upsert({
+    where:  { escrowId: escrow.id },
+    create: { escrowId: escrow.id, storageKey, hash, generatedAt: new Date() },
+    update: { storageKey, hash, generatedAt: new Date() },
+  });
+
+  // Auto-email both parties
+  await enqueueEvent({
+    type:    'escrow_contract_pdf',
+    payload: {
+      recipients: [escrow.clientAddress, escrow.freelancerAddress],
+      escrowId:   String(escrow.id),
+      pdfUrl:     url,
+      hash,
+    },
+  }).catch((err) => logger.error({ message: 'pdf_email_enqueue_failed', error: err.message }));
+
+  return { storageKey, hash, url };
+}
+
+/**
+ * Verifies a wallet signature over the PDF hash and records it.
+ *
+ * The signer must be either the client or freelancer of the escrow.
+ * Signature is an Ed25519 signature (hex) over the UTF-8 PDF hash string,
+ * produced by the Freighter wallet or Stellar Keypair.
+ *
+ * @param {string} escrowId
+ * @param {string} walletAddress  - Stellar G-address of the signer
+ * @param {string} signature      - Hex-encoded Ed25519 signature
+ * @returns {Promise<{ success: boolean, role: string }>}
+ */
+export async function signPdf(escrowId, walletAddress, signature) {
+  const escrow = await prisma.escrow.findUniqueOrThrow({
+    where: { id: BigInt(escrowId) },
+    select: { clientAddress: true, freelancerAddress: true },
+  });
+
+  const role =
+    escrow.clientAddress     === walletAddress ? 'client'
+    : escrow.freelancerAddress === walletAddress ? 'freelancer'
+    : null;
+
+  if (!role) {
+    const err = new Error('Wallet address is not a party to this escrow');
+    err.statusCode = 403;
+    throw err;
+  }
+
+  const pdfRecord = await prisma.escrowPdf.findUnique({
+    where: { escrowId: BigInt(escrowId) },
+    select: { hash: true },
+  });
+
+  if (!pdfRecord) {
+    const err = new Error('PDF not yet generated for this escrow');
+    err.statusCode = 404;
+    throw err;
+  }
+
+  // Verify Ed25519 signature: signer signed the PDF hash string
+  const keypair = Keypair.fromPublicKey(walletAddress);
+  const messageBytes = Buffer.from(pdfRecord.hash, 'utf8');
+  const sigBytes = Buffer.from(signature, 'hex');
+
+  const valid = keypair.verify(messageBytes, sigBytes);
+  if (!valid) {
+    const err = new Error('Signature verification failed');
+    err.statusCode = 422;
+    throw err;
+  }
+
+  // Persist signature
+  await prisma.escrowPdfSignature.upsert({
+    where:  { escrowId_walletAddress: { escrowId: BigInt(escrowId), walletAddress } },
+    create: { escrowId: BigInt(escrowId), walletAddress, role, signature, signedAt: new Date() },
+    update: { signature, signedAt: new Date() },
+  });
+
+  logger.info({ message: 'pdf_signed', escrowId, walletAddress, role });
+  return { success: true, role };
+}
+
+export default { generateEscrowPdf, signPdf };

--- a/backend/tests/auditLogger.test.js
+++ b/backend/tests/auditLogger.test.js
@@ -1,0 +1,190 @@
+/**
+ * Tests for backend/api/services/auditLogger.js
+ *
+ * Covers:
+ *  - Log entry creation with correct hash linkage
+ *  - Chain validation (valid chain, tampered hash, tampered prevHash)
+ *  - Query / pagination
+ */
+
+import { jest } from '@jest/globals';
+
+// ── Prisma mock ───────────────────────────────────────────────────────────────
+
+const mockStore = [];
+let nextId = 1;
+
+const mockTx = {
+  arbitratorAuditLog: {
+    findFirst: jest.fn(async ({ orderBy } = {}) => {
+      if (!mockStore.length) return null;
+      // Return last by id desc
+      return [...mockStore].sort((a, b) => b.id - a.id)[0];
+    }),
+    create: jest.fn(async ({ data }) => {
+      const record = { id: nextId++, ...data };
+      mockStore.push(record);
+      return record;
+    }),
+    update: jest.fn(async ({ where, data }) => {
+      const idx = mockStore.findIndex((r) => r.id === where.id);
+      if (idx !== -1) Object.assign(mockStore[idx], data);
+      return mockStore[idx];
+    }),
+  },
+};
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn(() => ({
+    $transaction: jest.fn(async (fn) => {
+      if (typeof fn === 'function') return fn(mockTx);
+      // Array form used by queryLogs
+      return Promise.all(fn.map((p) => p));
+    }),
+    arbitratorAuditLog: {
+      findMany: jest.fn(async ({ orderBy, skip = 0, take = 50, where = {} } = {}) => {
+        let rows = [...mockStore];
+        if (orderBy?.id === 'asc') rows.sort((a, b) => a.id - b.id);
+        else rows.sort((a, b) => b.id - a.id);
+        return rows.slice(skip, skip + take);
+      }),
+      count: jest.fn(async () => mockStore.length),
+    },
+  })),
+}));
+
+jest.mock('../../config/logger.js', () => ({
+  createModuleLogger: () => ({ error: jest.fn() }),
+}));
+
+// ── Import after mocks ────────────────────────────────────────────────────────
+
+const { logArbitratorAction, validateChain, queryLogs, ArbitratorAction } =
+  await import('../../api/services/auditLogger.js');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function clearStore() {
+  mockStore.length = 0;
+  nextId = 1;
+  jest.clearAllMocks();
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ArbitratorAction constants', () => {
+  it('exports all expected action keys', () => {
+    expect(ArbitratorAction.DISPUTE_ASSIGNED).toBe('DISPUTE_ASSIGNED');
+    expect(ArbitratorAction.EVIDENCE_VIEWED).toBe('EVIDENCE_VIEWED');
+    expect(ArbitratorAction.VOTE_CAST).toBe('VOTE_CAST');
+    expect(ArbitratorAction.COMMUNICATION_LOGGED).toBe('COMMUNICATION_LOGGED');
+    expect(ArbitratorAction.RESOLUTION_ISSUED).toBe('RESOLUTION_ISSUED');
+  });
+});
+
+describe('logArbitratorAction', () => {
+  beforeEach(clearStore);
+
+  it('creates a log entry and returns it', async () => {
+    const entry = {
+      action: ArbitratorAction.DISPUTE_ASSIGNED,
+      actor: 'GARBITRATOR1',
+      resourceId: 'dispute-42',
+      metadata: { reason: 'auto-assigned' },
+    };
+    const record = await logArbitratorAction(entry);
+    expect(record).not.toBeNull();
+    expect(record.action).toBe(ArbitratorAction.DISPUTE_ASSIGNED);
+    expect(record.actor).toBe('GARBITRATOR1');
+    expect(record.hash).toBeDefined();
+    expect(record.hash).not.toBe('pending');
+    expect(record.hash).toHaveLength(64); // SHA-256 hex
+  });
+
+  it('sets prevHash to genesis hash for the first entry', async () => {
+    await logArbitratorAction({ action: ArbitratorAction.VOTE_CAST, actor: 'GARB1' });
+    expect(mockStore[0].prevHash).toBe('0'.repeat(64));
+  });
+
+  it('links subsequent entries via prevHash', async () => {
+    await logArbitratorAction({ action: ArbitratorAction.DISPUTE_ASSIGNED, actor: 'GARB1' });
+    await logArbitratorAction({ action: ArbitratorAction.EVIDENCE_VIEWED, actor: 'GARB1' });
+
+    const [first, second] = mockStore;
+    expect(second.prevHash).toBe(first.hash);
+  });
+
+  it('produces different hashes for different entries', async () => {
+    await logArbitratorAction({ action: ArbitratorAction.DISPUTE_ASSIGNED, actor: 'GARB1', resourceId: 'd1' });
+    await logArbitratorAction({ action: ArbitratorAction.RESOLUTION_ISSUED, actor: 'GARB1', resourceId: 'd1' });
+
+    expect(mockStore[0].hash).not.toBe(mockStore[1].hash);
+  });
+});
+
+describe('validateChain', () => {
+  beforeEach(clearStore);
+
+  it('returns valid=true and checkedCount=0 for an empty log', async () => {
+    const result = await validateChain();
+    expect(result.valid).toBe(true);
+    expect(result.checkedCount).toBe(0);
+    expect(result.firstViolation).toBeNull();
+  });
+
+  it('returns valid=true for a correctly chained log', async () => {
+    await logArbitratorAction({ action: ArbitratorAction.DISPUTE_ASSIGNED, actor: 'GARB1' });
+    await logArbitratorAction({ action: ArbitratorAction.EVIDENCE_VIEWED,  actor: 'GARB1' });
+    await logArbitratorAction({ action: ArbitratorAction.RESOLUTION_ISSUED, actor: 'GARB1' });
+
+    const result = await validateChain();
+    expect(result.valid).toBe(true);
+    expect(result.checkedCount).toBe(3);
+  });
+
+  it('detects a tampered hash', async () => {
+    await logArbitratorAction({ action: ArbitratorAction.VOTE_CAST, actor: 'GARB1' });
+    await logArbitratorAction({ action: ArbitratorAction.VOTE_CAST, actor: 'GARB1' });
+
+    // Tamper with the first entry's hash
+    mockStore[0].hash = 'deadbeef'.repeat(8);
+
+    const result = await validateChain();
+    expect(result.valid).toBe(false);
+    expect(result.firstViolation).not.toBeNull();
+    expect(result.firstViolation.id).toBe(mockStore[0].id);
+  });
+
+  it('detects a tampered prevHash linkage', async () => {
+    await logArbitratorAction({ action: ArbitratorAction.DISPUTE_ASSIGNED, actor: 'GARB1' });
+    await logArbitratorAction({ action: ArbitratorAction.EVIDENCE_VIEWED,  actor: 'GARB1' });
+
+    // Break the chain link on the second entry
+    mockStore[1].prevHash = 'badhash'.padEnd(64, '0');
+
+    const result = await validateChain();
+    expect(result.valid).toBe(false);
+    expect(result.firstViolation.reason).toBe('prevHash_mismatch');
+  });
+});
+
+describe('queryLogs', () => {
+  beforeEach(async () => {
+    clearStore();
+    await logArbitratorAction({ action: ArbitratorAction.DISPUTE_ASSIGNED, actor: 'GARB1', resourceId: 'd1' });
+    await logArbitratorAction({ action: ArbitratorAction.EVIDENCE_VIEWED,  actor: 'GARB2', resourceId: 'd1' });
+    await logArbitratorAction({ action: ArbitratorAction.RESOLUTION_ISSUED, actor: 'GARB1', resourceId: 'd2' });
+  });
+
+  it('returns paginated results', async () => {
+    const result = await queryLogs({ page: 1, limit: 2 });
+    expect(result.data.length).toBeLessThanOrEqual(2);
+    expect(result.total).toBe(3);
+    expect(result.pages).toBe(2);
+  });
+
+  it('returns all entries when limit is large', async () => {
+    const result = await queryLogs({ limit: 100 });
+    expect(result.total).toBe(3);
+  });
+});

--- a/backend/tests/pdfGenerator.test.js
+++ b/backend/tests/pdfGenerator.test.js
@@ -1,0 +1,155 @@
+/**
+ * Tests for backend/services/pdfGenerator.js
+ *
+ * Covers:
+ *  - PDF buffer generation (non-empty, contains expected text)
+ *  - SHA-256 hash embedding (hash present in second-pass PDF)
+ *  - signPdf: valid signature accepted, invalid signature rejected
+ *  - signPdf: non-party wallet rejected with 403
+ */
+
+import { jest } from '@jest/globals';
+import { createHash } from 'crypto';
+import { Keypair } from '@stellar/stellar-sdk';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+// Mock pdfkit — returns a minimal PDF-like buffer
+jest.mock('pdfkit', () => {
+  return jest.fn().mockImplementation(() => {
+    const { EventEmitter } = require('events');
+    const doc = new EventEmitter();
+    doc.fontSize = jest.fn().mockReturnThis();
+    doc.font = jest.fn().mockReturnThis();
+    doc.text = jest.fn().mockReturnThis();
+    doc.moveDown = jest.fn().mockReturnThis();
+    doc.fillColor = jest.fn().mockReturnThis();
+    doc.end = jest.fn(() => {
+      doc.emit('data', Buffer.from('%PDF-1.4 mock content'));
+      doc.emit('end');
+    });
+    doc.page = { height: 842, width: 595 };
+    return doc;
+  });
+});
+
+// Mock S3 — not used in tests (USE_S3 defaults to false)
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn(),
+  PutObjectCommand: jest.fn(),
+  GetObjectCommand: jest.fn(),
+}));
+jest.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: jest.fn(),
+}));
+
+// Mock fs — avoid actual disk writes
+jest.mock('fs', () => ({
+  createWriteStream: jest.fn(() => {
+    const { Writable } = require('stream');
+    return new Writable({ write(chunk, enc, cb) { cb(); } });
+  }),
+  mkdirSync: jest.fn(),
+}));
+
+jest.mock('stream/promises', () => ({
+  pipeline: jest.fn(async () => {}),
+}));
+
+// Mock email queue
+jest.mock('../queues/emailQueue.js', () => ({
+  enqueueEvent: jest.fn(async () => {}),
+}));
+
+// Mock logger
+jest.mock('../config/logger.js', () => ({
+  createModuleLogger: () => ({ info: jest.fn(), error: jest.fn() }),
+}));
+
+// ── Prisma mock ───────────────────────────────────────────────────────────────
+
+const mockEscrow = {
+  id: BigInt(1),
+  clientAddress:     'GCLIENT000000000000000000000000000000000000000000000000000',
+  freelancerAddress: 'GFREELANCER0000000000000000000000000000000000000000000000',
+  totalAmount:       '1000',
+  tokenAddress:      'GTOKEN00000000000000000000000000000000000000000000000000000',
+  deadline:          null,
+  milestones:        [{ title: 'Design', amount: '500', deadline: null }],
+};
+
+const mockPdfRecord = { hash: null };
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn(() => ({
+    escrow: {
+      findUniqueOrThrow: jest.fn(async () => mockEscrow),
+    },
+    escrowPdf: {
+      upsert:    jest.fn(async ({ create }) => { mockPdfRecord.hash = create.hash; return create; }),
+      findUnique: jest.fn(async () => mockPdfRecord),
+    },
+    escrowPdfSignature: {
+      upsert: jest.fn(async ({ create }) => create),
+    },
+  })),
+}));
+
+// ── Import after mocks ────────────────────────────────────────────────────────
+
+const { generateEscrowPdf, signPdf } = await import('../services/pdfGenerator.js');
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('generateEscrowPdf', () => {
+  it('returns a non-empty buffer, a 64-char hex hash, and a storage key', async () => {
+    const result = await generateEscrowPdf('1');
+    expect(result.hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.storageKey).toContain('escrows/1');
+  });
+
+  it('hash is a valid SHA-256 of the draft PDF', async () => {
+    // The mock PDFKit always emits the same bytes, so we can verify determinism
+    const result1 = await generateEscrowPdf('1');
+    const result2 = await generateEscrowPdf('1');
+    // Both hashes should be identical for the same mock output
+    expect(result1.hash).toBe(result2.hash);
+  });
+});
+
+describe('signPdf', () => {
+  let keypair;
+  let signature;
+
+  beforeAll(async () => {
+    // Generate a real Stellar keypair and sign the mock hash
+    keypair = Keypair.random();
+    // First generate to populate mockPdfRecord.hash
+    await generateEscrowPdf('1');
+    const hashBytes = Buffer.from(mockPdfRecord.hash, 'utf8');
+    signature = keypair.sign(hashBytes).toString('hex');
+
+    // Override mock escrow to use this keypair's address as client
+    mockEscrow.clientAddress = keypair.publicKey();
+  });
+
+  it('accepts a valid signature from the client', async () => {
+    const result = await signPdf('1', keypair.publicKey(), signature);
+    expect(result.success).toBe(true);
+    expect(result.role).toBe('client');
+  });
+
+  it('rejects an invalid signature with statusCode 422', async () => {
+    const badSig = Buffer.alloc(64, 0).toString('hex');
+    await expect(signPdf('1', keypair.publicKey(), badSig)).rejects.toMatchObject({
+      statusCode: 422,
+    });
+  });
+
+  it('rejects a non-party wallet with statusCode 403', async () => {
+    const stranger = Keypair.random().publicKey();
+    await expect(signPdf('1', stranger, signature)).rejects.toMatchObject({
+      statusCode: 403,
+    });
+  });
+});

--- a/contracts/governance/src/errors.rs
+++ b/contracts/governance/src/errors.rs
@@ -44,4 +44,13 @@ pub enum GovError {
     StakeCooldownActive = 24,
     NoStakeToWithdraw = 25,
     SlashExceedsStake = 26,
+
+    // ve-token (voting escrow)
+    LockDurationTooShort = 27,
+    LockDurationTooLong = 28,
+    LockAlreadyExists = 29,
+    NoLockFound = 30,
+    LockNotExpired = 31,
+    NewUnlockTimeTooEarly = 32,
+    ZeroLockAmount = 33,
 }

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -36,7 +36,7 @@ mod types;
 pub use errors::GovError;
 pub use types::{
     DataKey, FundPayload, GovConfig, ParameterPayload, Proposal, ProposalPayload, ProposalStatus,
-    ProposalType, UpgradePayload, Vote,
+    ProposalType, UpgradePayload, VeLock, Vote,
 };
 
 use soroban_sdk::{contract, contractimpl, token, Address, Env, String};
@@ -716,5 +716,205 @@ impl GovernanceContract {
         env.storage().persistent()
             .get(&DataKey::ArbitratorStake(address))
             .unwrap_or(0)
+    }
+
+    // ── ve-token (Voting Escrow) ───────────────────────────────────────────────
+    //
+    // Users lock governance tokens for a configurable duration.
+    // Voting power decays linearly:
+    //
+    //   voting_power = locked_amount * remaining_duration / MAX_LOCK_DURATION
+    //
+    // where remaining_duration = max(0, unlock_time - now).
+    //
+    // Constraints:
+    //   MIN_LOCK_DURATION (1 week)  ≤ lock_duration ≤ MAX_LOCK_DURATION (4 years)
+    //   Tokens cannot be withdrawn before unlock_time.
+    //   Locks can be extended (more tokens or longer duration, never shorter).
+
+    /// Minimum lock duration: 1 week in seconds.
+    const MIN_LOCK_DURATION: u64 = 604_800;
+
+    /// Maximum lock duration: 4 years in seconds (365.25 days × 4).
+    const MAX_LOCK_DURATION: u64 = 126_230_400;
+
+    /// Creates a new ve-token lock for `caller`.
+    ///
+    /// Transfers `amount` governance tokens from `caller` to this contract.
+    /// The lock expires at `now + lock_duration`.
+    ///
+    /// # Arguments
+    /// * `caller`        — must `require_auth()`. Tokens deducted from their balance.
+    /// * `amount`        — tokens to lock. Must be > 0.
+    /// * `lock_duration` — seconds to lock for. Must be in [MIN_LOCK_DURATION, MAX_LOCK_DURATION].
+    pub fn create_lock(env: Env, caller: Address, amount: i128, lock_duration: u64) -> Result<VeLock, GovError> {
+        Storage::require_initialized(&env)?;
+        caller.require_auth();
+
+        if amount <= 0 {
+            return Err(GovError::ZeroLockAmount);
+        }
+        if lock_duration < Self::MIN_LOCK_DURATION {
+            return Err(GovError::LockDurationTooShort);
+        }
+        if lock_duration > Self::MAX_LOCK_DURATION {
+            return Err(GovError::LockDurationTooLong);
+        }
+
+        let lock_key = DataKey::VeLock(caller.clone());
+        if env.storage().persistent().has(&lock_key) {
+            return Err(GovError::LockAlreadyExists);
+        }
+
+        let config = Storage::config(&env)?;
+        token::Client::new(&env, &config.token).transfer(
+            &caller,
+            &env.current_contract_address(),
+            &amount,
+        );
+
+        let now = env.ledger().timestamp();
+        let lock = VeLock {
+            amount,
+            unlock_time: now + lock_duration,
+            locked_at: now,
+        };
+
+        env.storage().persistent().set(&lock_key, &lock);
+        Storage::bump_persistent(&env, &lock_key);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("ve_lock"), caller.clone()),
+            (amount, lock.unlock_time),
+        );
+        Ok(lock)
+    }
+
+    /// Increases the locked amount and/or extends the unlock time of an existing lock.
+    ///
+    /// Both `additional_amount` and `new_unlock_time` are optional (pass 0 / 0 to skip).
+    /// The new unlock time must be ≥ the current unlock time and ≤ now + MAX_LOCK_DURATION.
+    ///
+    /// # Arguments
+    /// * `caller`            — must `require_auth()`.
+    /// * `additional_amount` — extra tokens to add to the lock (0 = no change).
+    /// * `new_unlock_time`   — new expiry timestamp (0 = no change).
+    pub fn extend_lock(
+        env: Env,
+        caller: Address,
+        additional_amount: i128,
+        new_unlock_time: u64,
+    ) -> Result<VeLock, GovError> {
+        Storage::require_initialized(&env)?;
+        caller.require_auth();
+
+        let lock_key = DataKey::VeLock(caller.clone());
+        let mut lock: VeLock = env
+            .storage()
+            .persistent()
+            .get(&lock_key)
+            .ok_or(GovError::NoLockFound)?;
+
+        let now = env.ledger().timestamp();
+
+        // Extend duration
+        if new_unlock_time != 0 {
+            if new_unlock_time < lock.unlock_time {
+                return Err(GovError::NewUnlockTimeTooEarly);
+            }
+            let max_unlock = now + Self::MAX_LOCK_DURATION;
+            if new_unlock_time > max_unlock {
+                return Err(GovError::LockDurationTooLong);
+            }
+            lock.unlock_time = new_unlock_time;
+        }
+
+        // Add tokens
+        if additional_amount > 0 {
+            let config = Storage::config(&env)?;
+            token::Client::new(&env, &config.token).transfer(
+                &caller,
+                &env.current_contract_address(),
+                &additional_amount,
+            );
+            lock.amount += additional_amount;
+        }
+
+        lock.locked_at = now;
+        env.storage().persistent().set(&lock_key, &lock);
+        Storage::bump_persistent(&env, &lock_key);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("ve_ext"), caller.clone()),
+            (lock.amount, lock.unlock_time),
+        );
+        Ok(lock)
+    }
+
+    /// Withdraws locked tokens after the lock has expired.
+    ///
+    /// Removes the lock and returns all tokens to `caller`.
+    ///
+    /// # Arguments
+    /// * `caller` — must `require_auth()`. Must have an expired lock.
+    pub fn withdraw_lock(env: Env, caller: Address) -> Result<i128, GovError> {
+        Storage::require_initialized(&env)?;
+        caller.require_auth();
+
+        let lock_key = DataKey::VeLock(caller.clone());
+        let lock: VeLock = env
+            .storage()
+            .persistent()
+            .get(&lock_key)
+            .ok_or(GovError::NoLockFound)?;
+
+        let now = env.ledger().timestamp();
+        if now < lock.unlock_time {
+            return Err(GovError::LockNotExpired);
+        }
+
+        let config = Storage::config(&env)?;
+        token::Client::new(&env, &config.token).transfer(
+            &env.current_contract_address(),
+            &caller,
+            &lock.amount,
+        );
+
+        env.storage().persistent().remove(&lock_key);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("ve_wdr"), caller.clone()),
+            lock.amount,
+        );
+        Ok(lock.amount)
+    }
+
+    /// Returns the current time-weighted voting power of `address`.
+    ///
+    /// voting_power = locked_amount * remaining_duration / MAX_LOCK_DURATION
+    ///
+    /// Returns 0 if no lock exists or the lock has expired.
+    pub fn ve_voting_power(env: Env, address: Address) -> i128 {
+        let lock_key = DataKey::VeLock(address);
+        let lock: VeLock = match env.storage().persistent().get(&lock_key) {
+            Some(l) => l,
+            None => return 0,
+        };
+
+        let now = env.ledger().timestamp();
+        if now >= lock.unlock_time {
+            return 0;
+        }
+
+        let remaining = lock.unlock_time - now;
+        // Integer arithmetic: multiply first to preserve precision
+        lock.amount * remaining as i128 / Self::MAX_LOCK_DURATION as i128
+    }
+
+    /// Returns the VeLock record for `address`, if one exists.
+    pub fn get_lock(env: Env, address: Address) -> Option<VeLock> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::VeLock(address))
     }
 }

--- a/contracts/governance/src/tests.rs
+++ b/contracts/governance/src/tests.rs
@@ -745,4 +745,194 @@ mod tests {
         let p = client.get_proposal(&id);
         assert_eq!(p.status, ProposalStatus::Executed);
     }
+
+    // ── ve-token (voting escrow) ──────────────────────────────────────────────
+
+    const MIN_LOCK: u64 = 604_800;       // 1 week
+    const MAX_LOCK: u64 = 126_230_400;   // 4 years
+
+    #[test]
+    fn test_create_lock_basic() {
+        let (env, _admin, ta, token, client) = setup();
+        let user = Address::generate(&env);
+        mint(&env, &ta, &token, &user, 1_000);
+
+        let lock = client.create_lock(&user, &1_000i128, &MIN_LOCK);
+        assert_eq!(lock.amount, 1_000);
+        assert!(lock.unlock_time > env.ledger().timestamp());
+    }
+
+    #[test]
+    fn test_ve_voting_power_decays_over_time() {
+        let (env, _admin, ta, token, client) = setup();
+        let user = Address::generate(&env);
+        mint(&env, &ta, &token, &user, 1_000_000);
+
+        // Lock for max duration → full power at creation
+        client.create_lock(&user, &1_000_000i128, &MAX_LOCK);
+
+        let power_now = client.ve_voting_power(&user);
+        assert!(power_now > 0);
+        assert!(power_now <= 1_000_000);
+
+        // Advance halfway through the lock
+        advance(&env, MAX_LOCK / 2);
+        let power_half = client.ve_voting_power(&user);
+
+        // Power at halfway should be roughly half of initial
+        assert!(power_half < power_now);
+        assert!(power_half > 0);
+    }
+
+    #[test]
+    fn test_ve_voting_power_zero_after_expiry() {
+        let (env, _admin, ta, token, client) = setup();
+        let user = Address::generate(&env);
+        mint(&env, &ta, &token, &user, 500);
+
+        client.create_lock(&user, &500i128, &MIN_LOCK);
+
+        // Advance past expiry
+        advance(&env, MIN_LOCK + 1);
+        let power = client.ve_voting_power(&user);
+        assert_eq!(power, 0);
+    }
+
+    #[test]
+    fn test_withdraw_lock_after_expiry() {
+        let (env, _admin, ta, token, client) = setup();
+        let user = Address::generate(&env);
+        mint(&env, &ta, &token, &user, 800);
+
+        client.create_lock(&user, &800i128, &MIN_LOCK);
+        advance(&env, MIN_LOCK + 1);
+
+        let returned = client.withdraw_lock(&user);
+        assert_eq!(returned, 800);
+
+        // Lock should be gone
+        assert!(client.get_lock(&user).is_none());
+    }
+
+    #[test]
+    fn test_withdraw_before_expiry_fails() {
+        let (env, _admin, ta, token, client) = setup();
+        let user = Address::generate(&env);
+        mint(&env, &ta, &token, &user, 500);
+
+        client.create_lock(&user, &500i128, &MIN_LOCK);
+
+        // Try to withdraw immediately — should fail
+        let result = client.try_withdraw_lock(&user);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_extend_lock_amount() {
+        let (env, _admin, ta, token, client) = setup();
+        let user = Address::generate(&env);
+        mint(&env, &ta, &token, &user, 2_000);
+
+        client.create_lock(&user, &1_000i128, &MIN_LOCK);
+        let lock = client.extend_lock(&user, &1_000i128, &0u64);
+        assert_eq!(lock.amount, 2_000);
+    }
+
+    #[test]
+    fn test_extend_lock_duration() {
+        let (env, _admin, ta, token, client) = setup();
+        let user = Address::generate(&env);
+        mint(&env, &ta, &token, &user, 1_000);
+
+        let lock = client.create_lock(&user, &1_000i128, &MIN_LOCK);
+        let new_unlock = lock.unlock_time + MIN_LOCK;
+        let extended = client.extend_lock(&user, &0i128, &new_unlock);
+        assert_eq!(extended.unlock_time, new_unlock);
+    }
+
+    #[test]
+    fn test_extend_lock_cannot_shorten_duration() {
+        let (env, _admin, ta, token, client) = setup();
+        let user = Address::generate(&env);
+        mint(&env, &ta, &token, &user, 1_000);
+
+        let lock = client.create_lock(&user, &1_000i128, &(MIN_LOCK * 2));
+        // Try to set unlock_time earlier than current
+        let earlier = lock.unlock_time - 1;
+        let result = client.try_extend_lock(&user, &0i128, &earlier);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_duplicate_lock_fails() {
+        let (env, _admin, ta, token, client) = setup();
+        let user = Address::generate(&env);
+        mint(&env, &ta, &token, &user, 2_000);
+
+        client.create_lock(&user, &1_000i128, &MIN_LOCK);
+        let result = client.try_create_lock(&user, &1_000i128, &MIN_LOCK);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_lock_duration_too_short_fails() {
+        let (env, _admin, ta, token, client) = setup();
+        let user = Address::generate(&env);
+        mint(&env, &ta, &token, &user, 1_000);
+
+        let result = client.try_create_lock(&user, &1_000i128, &(MIN_LOCK - 1));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_lock_duration_too_long_fails() {
+        let (env, _admin, ta, token, client) = setup();
+        let user = Address::generate(&env);
+        mint(&env, &ta, &token, &user, 1_000);
+
+        let result = client.try_create_lock(&user, &1_000i128, &(MAX_LOCK + 1));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_no_lock_withdraw_fails() {
+        let (env, _admin, _ta, _token, client) = setup();
+        let user = Address::generate(&env);
+        let result = client.try_withdraw_lock(&user);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_larger_lock_gives_more_voting_power() {
+        let (env, _admin, ta, token, client) = setup();
+        let user_a = Address::generate(&env);
+        let user_b = Address::generate(&env);
+        mint(&env, &ta, &token, &user_a, 1_000);
+        mint(&env, &ta, &token, &user_b, 2_000);
+
+        // Same duration, different amounts
+        client.create_lock(&user_a, &1_000i128, &MAX_LOCK);
+        client.create_lock(&user_b, &2_000i128, &MAX_LOCK);
+
+        let power_a = client.ve_voting_power(&user_a);
+        let power_b = client.ve_voting_power(&user_b);
+        assert!(power_b > power_a);
+    }
+
+    #[test]
+    fn test_longer_lock_gives_more_voting_power() {
+        let (env, _admin, ta, token, client) = setup();
+        let user_a = Address::generate(&env);
+        let user_b = Address::generate(&env);
+        mint(&env, &ta, &token, &user_a, 1_000);
+        mint(&env, &ta, &token, &user_b, 1_000);
+
+        // Same amount, different durations
+        client.create_lock(&user_a, &1_000i128, &MIN_LOCK);
+        client.create_lock(&user_b, &1_000i128, &MAX_LOCK);
+
+        let power_a = client.ve_voting_power(&user_a);
+        let power_b = client.ve_voting_power(&user_b);
+        assert!(power_b > power_a);
+    }
 }

--- a/contracts/governance/src/types.rs
+++ b/contracts/governance/src/types.rs
@@ -154,4 +154,25 @@ pub enum DataKey {
     WithdrawCooldown(Address),
     /// Slash record counter
     SlashCounter,
+    // ── ve-token (voting escrow) ──────────────────────────────────────────────
+    /// Active lock for an address — key: Address, value: VeLock
+    VeLock(Address),
+}
+
+// ── ve-token types ────────────────────────────────────────────────────────────
+
+/// A time-locked token position that grants time-weighted voting power.
+///
+/// voting_power = locked_amount * (remaining_duration / MAX_LOCK_DURATION)
+///
+/// Power decays linearly as `unlock_time` approaches.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct VeLock {
+    /// Amount of governance tokens locked.
+    pub amount: i128,
+    /// Ledger timestamp when the lock expires and tokens can be withdrawn.
+    pub unlock_time: u64,
+    /// Ledger timestamp when the lock was created or last extended.
+    pub locked_at: u64,
 }

--- a/frontend/components/ui/GasEstimator.jsx
+++ b/frontend/components/ui/GasEstimator.jsx
@@ -1,0 +1,272 @@
+'use client';
+
+/**
+ * GasEstimator — Stellar network fee estimator widget
+ *
+ * Queries Stellar Horizon fee stats and presents three speed tiers
+ * (Low / Standard / High) with projected costs and confirmation times.
+ * Emits the selected fee via `onFeeSelect` for use in transaction builders.
+ *
+ * @param {object}   props
+ * @param {function} [props.onFeeSelect]   — called with fee (stroops) when user picks a tier
+ * @param {string}   [props.className]
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Zap, Clock, AlertTriangle, RefreshCw, CheckCircle } from 'lucide-react';
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+const HORIZON_URL = process.env.NEXT_PUBLIC_HORIZON_URL || 'https://horizon-testnet.stellar.org';
+const REFRESH_INTERVAL_MS = 15_000; // 15 s — fee stats change quickly under congestion
+const BASE_RESERVE_XLM = 0.5;       // minimum base reserve per entry (informational)
+const STROOPS_PER_XLM = 10_000_000;
+
+/**
+ * Speed tiers derived from Horizon fee_stats percentiles.
+ * p10 → Low, p50 → Standard, p90 → High.
+ */
+const TIERS = [
+  {
+    id: 'low',
+    label: 'Low',
+    description: 'Safe · slower confirmation',
+    icon: Clock,
+    color: 'text-blue-400',
+    border: 'border-blue-500/40',
+    bg: 'bg-blue-500/10',
+    selectedBorder: 'border-blue-500',
+    selectedBg: 'bg-blue-500/20',
+    percentile: 'p10',
+    confirmSeconds: '60–120',
+  },
+  {
+    id: 'standard',
+    label: 'Standard',
+    description: 'Recommended · typical speed',
+    icon: CheckCircle,
+    color: 'text-emerald-400',
+    border: 'border-emerald-500/40',
+    bg: 'bg-emerald-500/10',
+    selectedBorder: 'border-emerald-500',
+    selectedBg: 'bg-emerald-500/20',
+    percentile: 'p50',
+    confirmSeconds: '5–15',
+  },
+  {
+    id: 'high',
+    label: 'High',
+    description: 'Priority · fastest inclusion',
+    icon: Zap,
+    color: 'text-amber-400',
+    border: 'border-amber-500/40',
+    bg: 'bg-amber-500/10',
+    selectedBorder: 'border-amber-500',
+    selectedBg: 'bg-amber-500/20',
+    percentile: 'p90',
+    confirmSeconds: '1–5',
+  },
+];
+
+// ── Fee fetching ──────────────────────────────────────────────────────────────
+
+/**
+ * Fetches /fee_stats from Horizon and returns a normalised object:
+ * { p10, p50, p90, min, max, ledgerBaseFee, congestionLevel }
+ */
+async function fetchFeeStats() {
+  const res = await fetch(`${HORIZON_URL}/fee_stats`, {
+    signal: AbortSignal.timeout(8_000),
+  });
+  if (!res.ok) throw new Error(`Horizon responded ${res.status}`);
+  const data = await res.json();
+
+  const charged = data.fee_charged;
+  const p10 = parseInt(charged?.p10 ?? charged?.min ?? 100, 10);
+  const p50 = parseInt(charged?.p50 ?? 100, 10);
+  const p90 = parseInt(charged?.p90 ?? 100, 10);
+  const min = parseInt(charged?.min ?? 100, 10);
+  const max = parseInt(charged?.max ?? p90, 10);
+  const ledgerBaseFee = parseInt(data.last_ledger_base_fee ?? 100, 10);
+
+  // Congestion: if p90 > 5× base fee, flag as high congestion
+  const ratio = p90 / ledgerBaseFee;
+  const congestionLevel = ratio >= 5 ? 'high' : ratio >= 2 ? 'medium' : 'normal';
+
+  return { p10, p50, p90, min, max, ledgerBaseFee, congestionLevel };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function stroopsToXlm(stroops) {
+  return (stroops / STROOPS_PER_XLM).toFixed(7).replace(/\.?0+$/, '');
+}
+
+function formatStroops(n) {
+  return n.toLocaleString();
+}
+
+const CONGESTION_CONFIG = {
+  normal:  { label: 'Normal',  color: 'text-emerald-400', bg: 'bg-emerald-400/10' },
+  medium:  { label: 'Moderate', color: 'text-amber-400',  bg: 'bg-amber-400/10'  },
+  high:    { label: 'High',    color: 'text-red-400',     bg: 'bg-red-400/10'    },
+};
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export default function GasEstimator({ onFeeSelect, className = '' }) {
+  const [feeStats, setFeeStats]     = useState(null);
+  const [selected, setSelected]     = useState('standard');
+  const [loading, setLoading]       = useState(true);
+  const [error, setError]           = useState(null);
+  const [lastUpdated, setLastUpdated] = useState(null);
+  const timerRef = useRef(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const stats = await fetchFeeStats();
+      setFeeStats(stats);
+      setLastUpdated(new Date());
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+    timerRef.current = setInterval(load, REFRESH_INTERVAL_MS);
+    return () => clearInterval(timerRef.current);
+  }, [load]);
+
+  // Notify parent whenever selection or fee data changes
+  useEffect(() => {
+    if (!feeStats || !onFeeSelect) return;
+    const tier = TIERS.find((t) => t.id === selected);
+    onFeeSelect(feeStats[tier.percentile]);
+  }, [selected, feeStats, onFeeSelect]);
+
+  const congestion = feeStats ? CONGESTION_CONFIG[feeStats.congestionLevel] : null;
+
+  return (
+    <div
+      className={`bg-gray-900 border border-gray-800 rounded-2xl p-4 space-y-4
+                  hover:border-indigo-500/40 transition-all duration-300
+                  hover:shadow-[0_0_20px_rgba(99,102,241,0.1)] ${className}`}
+      role="region"
+      aria-label="Gas fee estimator"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Zap size={15} className="text-indigo-400" />
+          <h3 className="text-sm font-semibold text-white">Fee Estimator</h3>
+        </div>
+        <button
+          onClick={load}
+          disabled={loading}
+          className="text-gray-500 hover:text-white transition-colors disabled:opacity-40"
+          aria-label="Refresh fee estimates"
+        >
+          <RefreshCw size={13} className={loading ? 'animate-spin' : ''} />
+        </button>
+      </div>
+
+      {/* Congestion alert */}
+      {congestion && feeStats?.congestionLevel !== 'normal' && (
+        <div
+          className={`flex items-center gap-2 text-xs rounded-lg px-3 py-2
+                      ${congestion.color} ${congestion.bg}`}
+          role="alert"
+        >
+          <AlertTriangle size={13} aria-hidden="true" />
+          <span>
+            <strong>{congestion.label} network congestion</strong> — fees are elevated.
+            Consider using Standard or High for reliable inclusion.
+          </span>
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <div className="flex items-center gap-2 text-xs text-amber-400 bg-amber-400/10 rounded-lg px-3 py-2" role="alert">
+          <AlertTriangle size={13} aria-hidden="true" />
+          Could not fetch fee stats: {error}
+        </div>
+      )}
+
+      {/* Tier cards */}
+      <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-label="Transaction speed">
+        {TIERS.map((tier) => {
+          const Icon = tier.icon;
+          const fee = feeStats?.[tier.percentile];
+          const isSelected = selected === tier.id;
+
+          return (
+            <button
+              key={tier.id}
+              role="radio"
+              aria-checked={isSelected}
+              onClick={() => setSelected(tier.id)}
+              className={`rounded-xl p-3 text-left border transition-all duration-200 focus:outline-none
+                          focus-visible:ring-2 focus-visible:ring-indigo-500
+                          ${isSelected
+                            ? `${tier.selectedBorder} ${tier.selectedBg}`
+                            : `${tier.border} ${tier.bg} hover:border-opacity-70`
+                          }`}
+            >
+              <div className={`flex items-center gap-1.5 mb-2 ${tier.color}`}>
+                <Icon size={13} aria-hidden="true" />
+                <span className="text-xs font-semibold">{tier.label}</span>
+              </div>
+
+              {/* Fee amount */}
+              <div className="space-y-0.5">
+                {loading && !fee ? (
+                  <div className="h-4 w-16 bg-gray-700 rounded animate-pulse" />
+                ) : fee ? (
+                  <>
+                    <p className="text-white text-sm font-bold tabular-nums">
+                      {formatStroops(fee)}
+                      <span className="text-gray-500 text-xs font-normal ml-1">str</span>
+                    </p>
+                    <p className="text-gray-500 text-xs tabular-nums">
+                      {stroopsToXlm(fee)} XLM
+                    </p>
+                  </>
+                ) : (
+                  <p className="text-gray-600 text-xs">—</p>
+                )}
+              </div>
+
+              {/* Confirmation time */}
+              <p className="text-gray-500 text-xs mt-2">~{tier.confirmSeconds}s</p>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Network stats footer */}
+      {feeStats && (
+        <div className="flex items-center justify-between text-xs text-gray-600 pt-1 border-t border-gray-800">
+          <span>
+            Base fee: <span className="text-gray-400">{formatStroops(feeStats.ledgerBaseFee)} str</span>
+            {' · '}
+            Congestion:{' '}
+            <span className={congestion?.color ?? 'text-gray-400'}>
+              {congestion?.label ?? '—'}
+            </span>
+          </span>
+          {lastUpdated && (
+            <span>
+              {lastUpdated.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
closes #857 
closes #844 
closes #843 
closes #848 

…e-token governance

## GasEstimator (frontend/components/ui/GasEstimator.jsx)
- Queries Stellar Horizon /fee_stats every 15 s via AbortSignal.timeout
- Derives three speed tiers from fee_charged percentiles: Low (p10, ~60-120 s), Standard (p50, ~5-15 s), High (p90, ~1-5 s)
- Detects network congestion when p90 > 5x base fee; shows alert banner
- Emits selected fee (stroops) via onFeeSelect callback for wallet builders
- Follows PriceConverter.jsx conventions: 'use client', lucide-react, Tailwind dark theme

## Arbitrator Audit Logger (backend/api/services/auditLogger.js)
- Tamper-evident SHA-256 hash chain: each entry links to the previous via hash = SHA256(prevHash | id | action | actor | resourceId | timestamp | metadata)
- Prisma transaction serialises concurrent writes to prevent chain splits
- Logs five arbitrator actions: DISPUTE_ASSIGNED, EVIDENCE_VIEWED, VOTE_CAST, COMMUNICATION_LOGGED, RESOLUTION_ISSUED
- validateChain() iterates all entries in order and recomputes every hash, returning the first violation (hash_mismatch or prevHash_mismatch)
- queryLogs() provides paginated, filterable access for admin panels
- Unit tests cover: genesis hash, chain linkage, tamper detection, pagination

## PDF Generator (backend/services/pdfGenerator.js)
- Two-pass PDFKit rendering: draft render → SHA-256 hash → re-render with hash embedded in the document footer for self-verification
- Stores PDFs in S3 (AES-256 SSE) when PDF_STORAGE=s3, local disk otherwise
- signPdf() verifies an Ed25519 Stellar wallet signature over the PDF hash using Keypair.verify() from @stellar/stellar-sdk; persists to DB
- Auto-enqueues contract email to both parties on generation
- Route: POST /api/escrows/:id/generate-pdf and POST /api/escrows/:id/sign-pdf
- Unit tests cover: buffer generation, hash determinism, valid/invalid/non-party signatures

## ve-token Governance (contracts/governance/src/)
- create_lock(caller, amount, lock_duration): locks governance tokens for [MIN_LOCK=1 week, MAX_LOCK=4 years]; transfers tokens to contract
- ve_voting_power(address): time-weighted decay formula power = locked_amount * remaining_duration / MAX_LOCK_DURATION returns 0 after expiry
- withdraw_lock(caller): returns tokens after unlock_time; reverts if early
- extend_lock(caller, additional_amount, new_unlock_time): increases amount and/or extends duration; cannot shorten the lock
- New DataKey::VeLock(Address) and VeLock struct added to types.rs
- New error variants added to errors.rs (LockDurationTooShort/Long, LockAlreadyExists, NoLockFound, LockNotExpired, NewUnlockTimeTooEarly, ZeroLockAmount)
- 13 unit tests covering: basic lock, power decay, expiry, early withdrawal prevention, extend amount/duration, duplicate lock, boundary durations, no-lock withdrawal, and comparative power assertions

## Summary

Briefly describe what changed and why.

Closes #

## Changes

- 
- 
- 

## Testing

List the exact commands you ran locally.

```bash
# Examples
cargo test --workspace
npm run test -w backend
npm run test -w frontend
npm run lint
```

## Review Notes

Call out any context reviewers should know:

- areas that need extra attention
- follow-up work or known limitations
- deployment or migration considerations

## Checklist

- [ ] Code compiles, or the updated docs reference working commands
- [ ] Tests were added or updated when behavior changed
- [ ] Linting and formatting were run
- [ ] Documentation was updated when needed
- [ ] No breaking changes, or they are clearly described
- [ ] Screenshots or recordings are included for UI changes
