### PR TITLE
Dev sandbox + milestone deps + staged refunds + admin freeze 

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,71 @@ Visit `http://localhost:3000` to see the app.
 
 ---
 
+## 🧪 Local Soroban Sandbox (Docker)
+
+### Prerequisites
+
+- Docker & Docker Compose installed and running
+- Soroban CLI available on your host (for contract deployment)
+
+### Start the Sandbox
+
+```bash
+# From the repository root
+docker compose up -d soroban-sandbox
+
+# Or use the helper script to start the sandbox, deploy contracts,
+# generate dev wallets and wire the frontend config:
+./scripts/start-sandbox.sh
+```
+
+The helper script will:
+
+- Start a local Stellar Quickstart node in Soroban mode (standalone, no public testnet)
+- Deploy core smart contracts to the local network
+- Generate and fund a development account
+- Write contract IDs and Soroban RPC settings into `frontend/.env.local`
+
+### Verify It Is Running
+
+```bash
+# Check the container
+docker ps --filter name=stellar-sandbox
+
+# Check Soroban RPC health
+curl -sf http://localhost:8000/soroban/rpc | jq .
+```
+
+If the RPC endpoint responds and the container is healthy, the sandbox is ready.
+
+### Hot Reloading Contracts
+
+When you change a contract:
+
+```bash
+# Rebuild and redeploy only the changed contract to the existing sandbox
+./scripts/start-sandbox.sh
+```
+
+The script is idempotent and will:
+
+- Rebuild the contract Wasm
+- Upload and redeploy to the already-running sandbox
+- Refresh the contract IDs in `frontend/.env.local`
+
+No full network teardown is required for rapid iteration.
+
+### Teardown
+
+```bash
+# Stop and remove the local Soroban sandbox container
+docker compose down soroban-sandbox
+```
+
+This stops the local network cleanly without touching your database or other services.
+
+---
+
 ## 📁 Project Structure
 
 ```

--- a/contracts/escrow_contract/src/errors.rs
+++ b/contracts/escrow_contract/src/errors.rs
@@ -140,4 +140,12 @@ pub enum EscrowError {
 
     // ── Admin Transfer ───────────────────────────────────────────────────────
     // Note: discriminant 59 is reserved / unused.
+
+    // ── Security Freeze / Admin Multisig ─────────────────────────────────────
+    /// Escrow is frozen; state-mutating operations are blocked.
+    EscrowFrozen = 60,
+    /// Provided admin signatures did not meet the configured threshold.
+    InsufficientAdminSignatures = 61,
+    /// Invalid admin multisig threshold configuration.
+    InvalidAdminThreshold = 62,
 }

--- a/contracts/escrow_contract/src/lib.rs
+++ b/contracts/escrow_contract/src/lib.rs
@@ -2954,16 +2954,68 @@ impl EscrowContract {
                 return Err(EscrowError::EscrowNotActive);
             }
 
-            if meta.submitted_count > 0 || meta.approved_count > meta.released_count {
-                return Err(EscrowError::PendingFunds);
+            // Stage-based cancellation split:
+            // - Deduct platform fee from the remaining escrow balance first.
+            // - Pay any Approved (but not yet Released) milestone amounts to the freelancer.
+            // - Refund the rest to the client.
+            let mut snapshot = Self::calculate_platform_fee(&env, meta.total_amount)?;
+            let mut fee_amount = snapshot.fee_amount;
+            if fee_amount > meta.remaining_balance {
+                fee_amount = meta.remaining_balance;
             }
 
-            let returned = meta.remaining_balance;
-            token::Client::new(&env, &meta.token).transfer(
-                &env.current_contract_address(),
-                &meta.client,
-                &returned,
-            );
+            let mut approved_due: i128 = 0;
+            for mid in 0..meta.milestone_count {
+                let m = ContractStorage::load_milestone(&env, escrow_id, mid)?;
+                if m.status == MS_APPROVED {
+                    approved_due = approved_due
+                        .checked_add(m.amount)
+                        .ok_or(EscrowError::AmountMismatch)?;
+                }
+            }
+
+            let available_after_fee = meta
+                .remaining_balance
+                .checked_sub(fee_amount)
+                .ok_or(EscrowError::AmountMismatch)?;
+            if approved_due > available_after_fee {
+                return Err(EscrowError::AmountMismatch);
+            }
+
+            let freelancer_payout = approved_due;
+            let client_refund = available_after_fee
+                .checked_sub(approved_due)
+                .ok_or(EscrowError::AmountMismatch)?;
+
+            if fee_amount > 0 {
+                let treasury: Address = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::PlatformTreasury)
+                    .ok_or(EscrowError::NotInitialized)?;
+                token::Client::new(&env, &meta.token).transfer(
+                    &env.current_contract_address(),
+                    &treasury,
+                    &fee_amount,
+                );
+                snapshot.collected = true;
+            }
+
+            if freelancer_payout > 0 {
+                token::Client::new(&env, &meta.token).transfer(
+                    &env.current_contract_address(),
+                    &meta.freelancer,
+                    &freelancer_payout,
+                );
+            }
+
+            if client_refund > 0 {
+                token::Client::new(&env, &meta.token).transfer(
+                    &env.current_contract_address(),
+                    &meta.client,
+                    &client_refund,
+                );
+            }
 
             meta.remaining_balance = 0;
             meta.status = EscrowStatus::Cancelled;
@@ -2980,7 +3032,11 @@ impl EscrowContract {
             ContractStorage::save_escrow_meta(&env, &meta);
             ContractStorage::remove_fee_snapshot(&env, escrow_id);
 
-            events::emit_escrow_cancelled(&env, escrow_id, returned);
+            env.events().publish(
+                (symbol_short!("escrow_cancelled_breakdown"), escrow_id),
+                (freelancer_payout, client_refund, fee_amount),
+            );
+            events::emit_escrow_cancelled(&env, escrow_id, client_refund);
             Ok(())
         })
     }
@@ -4672,6 +4728,20 @@ mod tests {
         });
     }
 
+    fn set_milestone_status(
+        env: &Env,
+        contract_id: &Address,
+        escrow_id: u64,
+        milestone_id: u32,
+        status: MilestoneStatus,
+    ) {
+        env.as_contract(contract_id, || {
+            let mut m = ContractStorage::load_milestone(env, escrow_id, milestone_id).unwrap();
+            m.status = status;
+            ContractStorage::save_milestone(env, escrow_id, &m);
+        });
+    }
+
     #[test]
     fn test_dependency_linear_chain_activation_rejected_until_satisfied() {
         let (env, admin, contract_id, client) = setup();
@@ -5380,11 +5450,13 @@ mod tests {
 
     #[test]
     fn test_cancel_escrow() {
-        let (env, admin, _, client) = setup();
+        let (env, admin, contract_id, client) = setup();
         client.initialize(&admin);
 
         let escrow_client = Address::generate(&env);
         let freelancer = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        client.set_platform_treasury(&admin, &treasury);
         let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
         let token_id = token_contract.address();
         let token_admin = token::StellarAssetClient::new(&env, &token_id);
@@ -5412,7 +5484,80 @@ mod tests {
 
         let state = client.get_escrow(&escrow_id);
         assert_eq!(state.status, EscrowStatus::Cancelled);
-        assert_eq!(token_client.balance(&escrow_client), 200_i128);
+        // Default fee tier for 200 is 200 bps => 4 fee.
+        assert_eq!(token_client.balance(&treasury), 4_i128);
+        assert_eq!(token_client.balance(&escrow_client), 196_i128);
+        assert_eq!(token_client.balance(&freelancer), 0_i128);
+
+        // Verify cancellation breakdown event was emitted
+        let all_events = env.events().all();
+        assert!(
+            all_events.iter().any(|e| {
+                let topic = &e.0;
+                topic == &(symbol_short!("escrow_cancelled_breakdown"), escrow_id).into_val(&env)
+            }),
+            "expected escrow_cancelled_breakdown event"
+        );
+    }
+
+    #[test]
+    fn test_cancel_escrow_partial_completion_splits_balance() {
+        let (env, admin, contract_id, client) = setup();
+        client.initialize(&admin);
+
+        let escrow_client = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        client.set_platform_treasury(&admin, &treasury);
+
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+        let token_client = token::Client::new(&env, &token_id);
+
+        token_admin.mint(
+            &escrow_client,
+            &(2_000_i128 + ContractStorage::reserve_for_entries(1)),
+        );
+
+        let escrow_id = client.create_escrow(
+            &escrow_client,
+            &freelancer,
+            &token_id,
+            &2_000_i128,
+            &BytesN::from_array(&env, &[60; 32]),
+            &None,
+            &None,
+            &None,
+            &None,
+            &no_multisig(&env),
+        );
+
+        let m0 = client.add_milestone(
+            &escrow_client,
+            &escrow_id,
+            &String::from_str(&env, "M0"),
+            &BytesN::from_array(&env, &[61; 32]),
+            &1_000_i128,
+        );
+        let m1 = client.add_milestone(
+            &escrow_client,
+            &escrow_id,
+            &String::from_str(&env, "M1"),
+            &BytesN::from_array(&env, &[62; 32]),
+            &1_000_i128,
+        );
+
+        // Simulate partial completion: m0 approved, m1 pending (no release performed).
+        set_milestone_status(&env, &contract_id, escrow_id, m0, MS_APPROVED);
+        set_milestone_status(&env, &contract_id, escrow_id, m1, MS_PENDING);
+
+        client.cancel_escrow(&escrow_client, &escrow_id);
+
+        // Fee for 2_000 @ 150 bps => 30
+        assert_eq!(token_client.balance(&treasury), 30_i128);
+        assert_eq!(token_client.balance(&freelancer), 1_000_i128);
+        assert_eq!(token_client.balance(&escrow_client), 970_i128);
     }
 
     #[test]

--- a/contracts/escrow_contract/src/lib.rs
+++ b/contracts/escrow_contract/src/lib.rs
@@ -99,6 +99,7 @@ use stellar_trust_shared::{
     bump_instance_ttl as shared_bump_instance_ttl,
     bump_persistent_ttl as shared_bump_persistent_ttl,
 };
+use stellar_trust_shared::auth as shared_auth;
 
 mod storage;
 
@@ -245,6 +246,11 @@ impl ContractStorage {
             return Err(EscrowError::AlreadyInitialized);
         }
         instance.set(&DataKey::Admin, admin);
+        // Default admin multisig: 1-of-1 (initializer).
+        let mut signers: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(env);
+        signers.push_back(admin.clone());
+        instance.set(&DataKey::AdminSigners, &signers);
+        instance.set(&DataKey::AdminThreshold, &1_u32);
         instance.set(&DataKey::EscrowCounter, &0_u64);
         // Initialize storage version for upgradeable storage
         StorageManager::init_version(env);
@@ -270,6 +276,20 @@ impl ContractStorage {
             .ok_or(EscrowError::NotInitialized)?;
         if *caller != admin {
             return Err(EscrowError::AdminOnly);
+        }
+        Ok(())
+    }
+
+    fn is_escrow_frozen(env: &Env, escrow_id: u64) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::EscrowFrozen(escrow_id))
+            .unwrap_or(false)
+    }
+
+    fn require_not_frozen(env: &Env, escrow_id: u64) -> Result<(), EscrowError> {
+        if Self::is_escrow_frozen(env, escrow_id) {
+            return Err(EscrowError::EscrowFrozen);
         }
         Ok(())
     }
@@ -950,6 +970,103 @@ impl EscrowContract {
 
     pub fn initialize(env: Env, admin: Address) -> Result<(), EscrowError> {
         ContractStorage::initialize(&env, &admin)
+    }
+
+    pub fn set_admin_multisig(
+        env: Env,
+        caller: Address,
+        admin_signers: soroban_sdk::Vec<Address>,
+        threshold: u32,
+    ) -> Result<(), EscrowError> {
+        ContractStorage::require_admin(&env, &caller)?;
+        caller.require_auth();
+        if threshold == 0 || threshold > admin_signers.len() {
+            return Err(EscrowError::InvalidAdminThreshold);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::AdminSigners, &admin_signers);
+        env.storage()
+            .instance()
+            .set(&DataKey::AdminThreshold, &threshold);
+        ContractStorage::bump_instance_ttl(&env);
+        Ok(())
+    }
+
+    pub fn freeze_escrow(
+        env: Env,
+        escrow_id: u64,
+        admin_signers: soroban_sdk::Vec<Address>,
+    ) -> Result<(), EscrowError> {
+        ContractStorage::require_initialized(&env)?;
+        ContractStorage::ensure_live_escrow(&env, escrow_id)?;
+
+        let configured: soroban_sdk::Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AdminSigners)
+            .unwrap_or(soroban_sdk::Vec::new(&env));
+        let threshold: u32 = env.storage().instance().get(&DataKey::AdminThreshold).unwrap_or(1);
+
+        if shared_auth::require_admin_threshold(&env, &configured, threshold, &admin_signers)
+            .is_err()
+        {
+            return Err(EscrowError::InsufficientAdminSignatures);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::EscrowFrozen(escrow_id), &true);
+        ContractStorage::bump_persistent_ttl(&env, &DataKey::EscrowFrozen(escrow_id));
+
+        env.events().publish(
+            (symbol_short!("escrow_frozen"), escrow_id),
+            (
+                admin_signers,
+                env.ledger().sequence(),
+                env.ledger().timestamp(),
+                true,
+            ),
+        );
+        Ok(())
+    }
+
+    pub fn unfreeze_escrow(
+        env: Env,
+        escrow_id: u64,
+        admin_signers: soroban_sdk::Vec<Address>,
+    ) -> Result<(), EscrowError> {
+        ContractStorage::require_initialized(&env)?;
+        ContractStorage::ensure_live_escrow(&env, escrow_id)?;
+
+        let configured: soroban_sdk::Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AdminSigners)
+            .unwrap_or(soroban_sdk::Vec::new(&env));
+        let threshold: u32 = env.storage().instance().get(&DataKey::AdminThreshold).unwrap_or(1);
+
+        if shared_auth::require_admin_threshold(&env, &configured, threshold, &admin_signers)
+            .is_err()
+        {
+            return Err(EscrowError::InsufficientAdminSignatures);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::EscrowFrozen(escrow_id), &false);
+        ContractStorage::bump_persistent_ttl(&env, &DataKey::EscrowFrozen(escrow_id));
+
+        env.events().publish(
+            (symbol_short!("escrow_unfrozen"), escrow_id),
+            (
+                admin_signers,
+                env.ledger().sequence(),
+                env.ledger().timestamp(),
+                false,
+            ),
+        );
+        Ok(())
     }
 
     /// Ensures any configured milestone dependency is satisfied.
@@ -1896,6 +2013,7 @@ impl EscrowContract {
     ) -> Result<u32, EscrowError> {
         caller.require_auth();
         ContractStorage::require_not_paused(&env)?;
+        ContractStorage::require_not_frozen(&env, escrow_id)?;
 
         if amount <= 0 {
             return Err(EscrowError::InvalidMilestoneAmount);
@@ -2092,6 +2210,7 @@ impl EscrowContract {
     ) -> Result<u32, EscrowError> {
         caller.require_auth();
         ContractStorage::require_not_paused(&env)?;
+        ContractStorage::require_not_frozen(&env, escrow_id)?;
 
         let n = titles.len();
         if n == 0 || n != description_hashes.len() || n != amounts.len() {
@@ -2525,6 +2644,7 @@ impl EscrowContract {
     ) -> Result<(), EscrowError> {
         caller.require_auth();
         ContractStorage::require_not_paused(&env)?;
+        ContractStorage::require_not_frozen(&env, escrow_id)?;
 
         // Load meta only to verify freelancer identity and track submitted_count.
         let mut meta = ContractStorage::load_escrow_meta_with_rent(&env, escrow_id)?;
@@ -2582,6 +2702,7 @@ impl EscrowContract {
     ) -> Result<(), EscrowError> {
         caller.require_auth();
         ContractStorage::require_not_paused(&env)?;
+        ContractStorage::require_not_frozen(&env, escrow_id)?;
 
         let mut meta = ContractStorage::load_escrow_meta_with_rent(&env, escrow_id)?;
         if meta.status != EscrowStatus::Active {
@@ -2673,6 +2794,7 @@ impl EscrowContract {
     ) -> Result<(), EscrowError> {
         caller.require_auth();
         ContractStorage::require_not_paused(&env)?;
+        ContractStorage::require_not_frozen(&env, escrow_id)?;
 
         let mut meta = ContractStorage::load_escrow_meta_with_rent(&env, escrow_id)?;
         if caller != meta.client {
@@ -2822,6 +2944,7 @@ impl EscrowContract {
         ContractStorage::require_initialized(&env)?;
         caller.require_auth();
         ContractStorage::require_not_paused(&env)?;
+        ContractStorage::require_not_frozen(&env, escrow_id)?;
         ContractStorage::with_reentrancy_guard(&env, || {
             let admin: Address = env
                 .storage()
@@ -2945,6 +3068,7 @@ impl EscrowContract {
     pub fn cancel_escrow(env: Env, caller: Address, escrow_id: u64) -> Result<(), EscrowError> {
         caller.require_auth();
         ContractStorage::require_not_paused(&env)?;
+        ContractStorage::require_not_frozen(&env, escrow_id)?;
         ContractStorage::with_reentrancy_guard(&env, || {
             let mut meta = ContractStorage::load_escrow_meta_with_rent(&env, escrow_id)?;
             if caller != meta.client {
@@ -3119,6 +3243,7 @@ impl EscrowContract {
     pub fn partial_cancel(env: Env, caller: Address, escrow_id: u64) -> Result<i128, EscrowError> {
         caller.require_auth();
         ContractStorage::require_not_paused(&env)?;
+        ContractStorage::require_not_frozen(&env, escrow_id)?;
         ContractStorage::with_reentrancy_guard(&env, || {
             let mut meta = ContractStorage::load_escrow_meta_with_rent(&env, escrow_id)?;
             if caller != meta.client {
@@ -3164,6 +3289,7 @@ impl EscrowContract {
         caller.require_auth();
         ContractStorage::require_initialized(&env)?;
         ContractStorage::require_not_paused(&env)?;
+        ContractStorage::require_not_frozen(&env, escrow_id)?;
 
         if duration_ledger == 0 || duration_ledger > 30 * 24 * 60 * 60 {
             return Err(EscrowError::InvalidTimelock);
@@ -3247,6 +3373,7 @@ impl EscrowContract {
     ) -> Result<(), EscrowError> {
         caller.require_auth();
         ContractStorage::require_not_paused(&env)?;
+        ContractStorage::require_not_frozen(&env, escrow_id)?;
 
         let mut meta = ContractStorage::load_escrow_meta_with_rent(&env, escrow_id)?;
         if caller != meta.client && caller != meta.freelancer {
@@ -3302,6 +3429,7 @@ impl EscrowContract {
     ) -> Result<(), EscrowError> {
         caller.require_auth();
         ContractStorage::require_not_paused(&env)?;
+        ContractStorage::require_not_frozen(&env, escrow_id)?;
 
         ContractStorage::with_reentrancy_guard(&env, || {
             let mut meta = ContractStorage::load_escrow_meta_with_rent(&env, escrow_id)?;
@@ -3389,6 +3517,7 @@ impl EscrowContract {
     ) -> Result<(), EscrowError> {
         caller.require_auth();
         ContractStorage::require_not_paused(&env)?;
+        ContractStorage::require_not_frozen(&env, escrow_id)?;
         ContractStorage::with_reentrancy_guard(&env, || {
             let mut meta = ContractStorage::load_escrow_meta_with_rent(&env, escrow_id)?;
 
@@ -4740,6 +4869,96 @@ mod tests {
             m.status = status;
             ContractStorage::save_milestone(env, escrow_id, &m);
         });
+    }
+
+    #[test]
+    fn test_freeze_requires_threshold_and_blocks_operations() {
+        let (env, admin, _contract_id, client) = setup();
+        client.initialize(&admin);
+
+        let admin2 = Address::generate(&env);
+        let admin3 = Address::generate(&env);
+
+        let mut admins: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+        admins.push_back(admin.clone());
+        admins.push_back(admin2.clone());
+        admins.push_back(admin3.clone());
+        client.set_admin_multisig(&admin, &admins, &2_u32);
+
+        let escrow_client = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+
+        token_admin.mint(
+            &escrow_client,
+            &(1_000_i128 + ContractStorage::reserve_for_entries(1)),
+        );
+
+        let escrow_id = client.create_escrow(
+            &escrow_client,
+            &freelancer,
+            &token_id,
+            &1_000_i128,
+            &BytesN::from_array(&env, &[90; 32]),
+            &None,
+            &None,
+            &None,
+            &None,
+            &no_multisig(&env),
+        );
+
+        // Freeze with insufficient signers should fail
+        let mut one: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+        one.push_back(admin.clone());
+        assert_eq!(
+            client
+                .try_freeze_escrow(&escrow_id, &one)
+                .unwrap_err()
+                .unwrap(),
+            EscrowError::InsufficientAdminSignatures
+        );
+
+        // Freeze with 2-of-3 should succeed
+        let mut two: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+        two.push_back(admin.clone());
+        two.push_back(admin2.clone());
+        client.freeze_escrow(&escrow_id, &two);
+
+        // Mutating operation should be blocked
+        let err = client
+            .try_add_milestone(
+                &escrow_client,
+                &escrow_id,
+                &String::from_str(&env, "Blocked"),
+                &BytesN::from_array(&env, &[1; 32]),
+                &1_000_i128,
+            )
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, EscrowError::EscrowFrozen);
+
+        // Unfreeze with insufficient signers rejected
+        assert_eq!(
+            client
+                .try_unfreeze_escrow(&escrow_id, &one)
+                .unwrap_err()
+                .unwrap(),
+            EscrowError::InsufficientAdminSignatures
+        );
+
+        // Unfreeze with threshold signers restores operations
+        client.unfreeze_escrow(&escrow_id, &two);
+
+        let mid = client.add_milestone(
+            &escrow_client,
+            &escrow_id,
+            &String::from_str(&env, "Ok"),
+            &BytesN::from_array(&env, &[2; 32]),
+            &1_000_i128,
+        );
+        assert_eq!(mid, 0_u32);
     }
 
     #[test]

--- a/contracts/escrow_contract/src/lib.rs
+++ b/contracts/escrow_contract/src/lib.rs
@@ -952,6 +952,43 @@ impl EscrowContract {
         ContractStorage::initialize(&env, &admin)
     }
 
+    /// Ensures any configured milestone dependency is satisfied.
+    ///
+    /// Gas overhead: one additional persistent milestone read for the prerequisite.
+    fn require_dependency_satisfied(
+        env: &Env,
+        escrow_id: u64,
+        milestone: &Milestone,
+    ) -> Result<(), EscrowError> {
+        if let Some(prereq_id) = milestone.depends_on {
+            let prereq = ContractStorage::load_milestone(env, escrow_id, prereq_id)?;
+            if prereq.status != MS_APPROVED && prereq.status != MS_RELEASED {
+                return Err(EscrowError::InvalidMilestoneState);
+            }
+        }
+        Ok(())
+    }
+
+    /// Emits an event for each milestone that becomes unlocked by `prereq_id`.
+    ///
+    /// Gas overhead: up to `milestone_count` additional milestone reads (max 20)
+    /// to discover dependents.
+    fn emit_dependents_unlocked(env: &Env, escrow_id: u64, prereq_id: u32) {
+        let meta = match ContractStorage::load_escrow_meta_with_rent(env, escrow_id) {
+            Ok(m) => m,
+            Err(_) => return,
+        };
+
+        for mid in 0..meta.milestone_count {
+            if let Ok(m) = ContractStorage::load_milestone(env, escrow_id, mid) {
+                if m.depends_on == Some(prereq_id) {
+                    env.events()
+                        .publish((symbol_short!("milestone_unlocked"), escrow_id), (mid, prereq_id));
+                }
+            }
+        }
+    }
+
     // ── Oracle Configuration ──────────────────────────────────────────────────
 
     /// Set the primary price oracle contract address. Admin only.
@@ -1916,6 +1953,7 @@ impl EscrowContract {
                 approvals: soroban_sdk::Vec::new(&env),
                 rejection_reason: OptionalBytesN32::None,
                 price_condition: OptionalPriceCondition::None,
+                depends_on: None,
             },
         );
         ContractStorage::save_escrow_meta(&env, &meta);
@@ -1988,6 +2026,7 @@ impl EscrowContract {
                 approvals: soroban_sdk::Vec::new(env),
                 rejection_reason: OptionalBytesN32::None,
                 price_condition: OptionalPriceCondition::None,
+                depends_on: None,
             },
         );
         ContractStorage::save_escrow_meta(env, &meta);
@@ -2129,6 +2168,7 @@ impl EscrowContract {
                     approvals: soroban_sdk::Vec::new(&env),
                     rejection_reason: OptionalBytesN32::None,
                     price_condition: OptionalPriceCondition::None,
+                    depends_on: None,
                 },
             );
             events::emit_milestone_added(
@@ -2190,6 +2230,7 @@ impl EscrowContract {
             if m.status != MS_SUBMITTED {
                 return Err(EscrowError::InvalidMilestoneState);
             }
+            Self::require_dependency_satisfied(&env, escrow_id, &m)?;
             total_amount = total_amount
                 .checked_add(m.amount)
                 .ok_or(EscrowError::AmountMismatch)?;
@@ -2206,6 +2247,7 @@ impl EscrowContract {
                 MS_APPROVED
             };
             ContractStorage::save_milestone(&env, escrow_id, &m);
+            Self::emit_dependents_unlocked(&env, escrow_id, mid);
 
             meta.approved_count = meta
                 .approved_count
@@ -2416,6 +2458,7 @@ impl EscrowContract {
                     approvals: soroban_sdk::Vec::new(&env),
                     rejection_reason: OptionalBytesN32::None,
                     price_condition: OptionalPriceCondition::None,
+                    depends_on: None,
                 },
             );
 
@@ -2508,6 +2551,8 @@ impl EscrowContract {
             return Err(EscrowError::InvalidMilestoneState);
         }
 
+        Self::require_dependency_satisfied(&env, escrow_id, &milestone)?;
+
         milestone.status = MS_SUBMITTED;
         milestone.submitted_at = Some(env.ledger().timestamp());
         ContractStorage::save_milestone(&env, escrow_id, &milestone);
@@ -2556,6 +2601,8 @@ impl EscrowContract {
             return Err(EscrowError::InvalidMilestoneState);
         }
 
+        Self::require_dependency_satisfied(&env, escrow_id, &milestone)?;
+
         let now = env.ledger().timestamp();
         let amount = milestone.amount;
 
@@ -2589,6 +2636,7 @@ impl EscrowContract {
         }
 
         ContractStorage::save_milestone(&env, escrow_id, &milestone);
+        Self::emit_dependents_unlocked(&env, escrow_id, milestone_id);
 
         if meta.approved_count == meta.milestone_count
             && meta.milestone_count > 0
@@ -2785,6 +2833,7 @@ impl EscrowContract {
             if milestone.status != MS_APPROVED {
                 return Err(EscrowError::InvalidMilestoneState);
             }
+            Self::require_dependency_satisfied(&env, escrow_id, &milestone)?;
 
             let mut meta = ContractStorage::load_escrow_meta_with_rent(&env, escrow_id)?;
 
@@ -2819,6 +2868,7 @@ impl EscrowContract {
 
             milestone.status = MS_RELEASED;
             ContractStorage::save_milestone(&env, escrow_id, &milestone);
+            Self::emit_dependents_unlocked(&env, escrow_id, milestone_id);
 
             meta.remaining_balance = meta
                 .remaining_balance
@@ -4612,6 +4662,236 @@ mod tests {
 
     fn advance(env: &Env, seconds: u64) {
         env.ledger().with_mut(|ledger| ledger.timestamp += seconds);
+    }
+
+    fn set_depends_on(env: &Env, contract_id: &Address, escrow_id: u64, milestone_id: u32, prereq: u32) {
+        env.as_contract(contract_id, || {
+            let mut m = ContractStorage::load_milestone(env, escrow_id, milestone_id).unwrap();
+            m.depends_on = Some(prereq);
+            ContractStorage::save_milestone(env, escrow_id, &m);
+        });
+    }
+
+    #[test]
+    fn test_dependency_linear_chain_activation_rejected_until_satisfied() {
+        let (env, admin, contract_id, client) = setup();
+        client.initialize(&admin);
+
+        let escrow_client = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+
+        token_admin.mint(
+            &escrow_client,
+            &(3_000_i128 + (2 * ContractStorage::reserve_for_entries(1))),
+        );
+
+        let escrow_id = client.create_escrow(
+            &escrow_client,
+            &freelancer,
+            &token_id,
+            &3_000_i128,
+            &BytesN::from_array(&env, &[50; 32]),
+            &None,
+            &None,
+            &None,
+            &None,
+            &no_multisig(&env),
+        );
+
+        let a = client.add_milestone(
+            &escrow_client,
+            &escrow_id,
+            &String::from_str(&env, "A"),
+            &BytesN::from_array(&env, &[1; 32]),
+            &1_000_i128,
+        );
+        let b = client.add_milestone(
+            &escrow_client,
+            &escrow_id,
+            &String::from_str(&env, "B"),
+            &BytesN::from_array(&env, &[2; 32]),
+            &1_000_i128,
+        );
+        let c = client.add_milestone(
+            &escrow_client,
+            &escrow_id,
+            &String::from_str(&env, "C"),
+            &BytesN::from_array(&env, &[3; 32]),
+            &1_000_i128,
+        );
+
+        set_depends_on(&env, &contract_id, escrow_id, b, a);
+        set_depends_on(&env, &contract_id, escrow_id, c, b);
+
+        // Cannot submit B before A is approved/released
+        let err = client
+            .try_submit_milestone(&freelancer, &escrow_id, &b)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, EscrowError::InvalidMilestoneState);
+
+        // Submit and approve A
+        client.submit_milestone(&freelancer, &escrow_id, &a);
+        client.approve_milestone(&escrow_client, &escrow_id, &a);
+
+        // Now B can be submitted
+        client.submit_milestone(&freelancer, &escrow_id, &b);
+    }
+
+    #[test]
+    fn test_dependency_branched_dependencies() {
+        let (env, admin, contract_id, client) = setup();
+        client.initialize(&admin);
+
+        let escrow_client = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+
+        token_admin.mint(
+            &escrow_client,
+            &(4_000_i128 + (2 * ContractStorage::reserve_for_entries(1))),
+        );
+
+        let escrow_id = client.create_escrow(
+            &escrow_client,
+            &freelancer,
+            &token_id,
+            &4_000_i128,
+            &BytesN::from_array(&env, &[51; 32]),
+            &None,
+            &None,
+            &None,
+            &None,
+            &no_multisig(&env),
+        );
+
+        let a = client.add_milestone(
+            &escrow_client,
+            &escrow_id,
+            &String::from_str(&env, "A"),
+            &BytesN::from_array(&env, &[4; 32]),
+            &1_000_i128,
+        );
+        let b = client.add_milestone(
+            &escrow_client,
+            &escrow_id,
+            &String::from_str(&env, "B"),
+            &BytesN::from_array(&env, &[5; 32]),
+            &1_000_i128,
+        );
+        let c = client.add_milestone(
+            &escrow_client,
+            &escrow_id,
+            &String::from_str(&env, "C"),
+            &BytesN::from_array(&env, &[6; 32]),
+            &1_000_i128,
+        );
+        let d = client.add_milestone(
+            &escrow_client,
+            &escrow_id,
+            &String::from_str(&env, "D"),
+            &BytesN::from_array(&env, &[7; 32]),
+            &1_000_i128,
+        );
+
+        // B and C both depend on A; D depends on B
+        set_depends_on(&env, &contract_id, escrow_id, b, a);
+        set_depends_on(&env, &contract_id, escrow_id, c, a);
+        set_depends_on(&env, &contract_id, escrow_id, d, b);
+
+        // B and C blocked until A approved
+        assert_eq!(
+            client
+                .try_submit_milestone(&freelancer, &escrow_id, &b)
+                .unwrap_err()
+                .unwrap(),
+            EscrowError::InvalidMilestoneState
+        );
+        assert_eq!(
+            client
+                .try_submit_milestone(&freelancer, &escrow_id, &c)
+                .unwrap_err()
+                .unwrap(),
+            EscrowError::InvalidMilestoneState
+        );
+
+        client.submit_milestone(&freelancer, &escrow_id, &a);
+        client.approve_milestone(&escrow_client, &escrow_id, &a);
+
+        // After A approved, B and C can submit; D still blocked until B approved
+        client.submit_milestone(&freelancer, &escrow_id, &b);
+        client.submit_milestone(&freelancer, &escrow_id, &c);
+        assert_eq!(
+            client
+                .try_submit_milestone(&freelancer, &escrow_id, &d)
+                .unwrap_err()
+                .unwrap(),
+            EscrowError::InvalidMilestoneState
+        );
+    }
+
+    #[test]
+    fn test_emits_unlocked_event_when_prereq_completes() {
+        let (env, admin, contract_id, client) = setup();
+        client.initialize(&admin);
+
+        let escrow_client = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+
+        token_admin.mint(
+            &escrow_client,
+            &(2_000_i128 + (2 * ContractStorage::reserve_for_entries(1))),
+        );
+
+        let escrow_id = client.create_escrow(
+            &escrow_client,
+            &freelancer,
+            &token_id,
+            &2_000_i128,
+            &BytesN::from_array(&env, &[52; 32]),
+            &None,
+            &None,
+            &None,
+            &None,
+            &no_multisig(&env),
+        );
+
+        let a = client.add_milestone(
+            &escrow_client,
+            &escrow_id,
+            &String::from_str(&env, "A"),
+            &BytesN::from_array(&env, &[8; 32]),
+            &1_000_i128,
+        );
+        let b = client.add_milestone(
+            &escrow_client,
+            &escrow_id,
+            &String::from_str(&env, "B"),
+            &BytesN::from_array(&env, &[9; 32]),
+            &1_000_i128,
+        );
+
+        set_depends_on(&env, &contract_id, escrow_id, b, a);
+
+        client.submit_milestone(&freelancer, &escrow_id, &a);
+        client.approve_milestone(&escrow_client, &escrow_id, &a);
+
+        let all_events = env.events().all();
+        assert!(
+            all_events.iter().any(|e| {
+                let topic = &e.0;
+                topic == &(symbol_short!("milestone_unlocked"), escrow_id).into_val(&env)
+            }),
+            "expected milestone_unlocked event"
+        );
     }
 
     #[test]

--- a/contracts/escrow_contract/src/types.rs
+++ b/contracts/escrow_contract/src/types.rs
@@ -666,6 +666,10 @@ pub enum DataKey {
     Reputation(Address),
     /// Contract admin address — value: Address
     Admin,
+    /// Admin signer set for threshold authorization — value: Vec<Address>
+    AdminSigners,
+    /// Required number of admin signatures — value: u32
+    AdminThreshold,
     /// Contract pause state — value: bool
     Paused,
     /// Cancellation request by escrow ID — key: u64, value: CancellationRequest
@@ -716,4 +720,6 @@ pub enum DataKey {
     PlatformFeeTiers,
     /// Applied fee snapshot for an escrow â€” key: u64, value: EscrowFeeSnapshot
     PlatformFeeSnapshot(u64),
+    /// Escrow frozen flag (security freeze) — key: u64, value: bool
+    EscrowFrozen(u64),
 }

--- a/contracts/escrow_contract/src/types.rs
+++ b/contracts/escrow_contract/src/types.rs
@@ -297,6 +297,10 @@ pub struct Milestone {
     /// Optional price-based release condition. When set, funds are released
     /// automatically via `trigger_oracle_release` once the condition is met.
     pub price_condition: OptionalPriceCondition,
+
+    /// Optional prerequisite milestone ID that must be Approved or Released
+    /// before this milestone can be submitted or paid out.
+    pub depends_on: Option<u32>,
 }
 
 /// Configuration for a recurring/subscription escrow.

--- a/contracts/shared/src/auth.rs
+++ b/contracts/shared/src/auth.rs
@@ -1,0 +1,39 @@
+#![no_std]
+
+use soroban_sdk::{Address, Env, Vec};
+
+/// Requires that at least `threshold` unique `signers` are members of `admins`,
+/// and that each signer has authorized the call.
+pub fn require_admin_threshold(
+    env: &Env,
+    admins: &Vec<Address>,
+    threshold: u32,
+    signers: &Vec<Address>,
+) -> Result<(), ()> {
+    if threshold == 0 {
+        return Err(());
+    }
+
+    // Count unique, authorized admin signers.
+    let mut counted: Vec<Address> = Vec::new(env);
+    let mut ok: u32 = 0;
+
+    for i in 0..signers.len() {
+        let s = signers.get(i).ok_or(())?;
+        if counted.contains(&s) {
+            continue;
+        }
+        if !admins.contains(&s) {
+            continue;
+        }
+        s.require_auth();
+        counted.push_back(s);
+        ok = ok.saturating_add(1);
+        if ok >= threshold {
+            return Ok(());
+        }
+    }
+
+    Err(())
+}
+

--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -8,6 +8,8 @@
 
 use soroban_sdk::{Env, IntoVal, Val};
 
+pub mod auth;
+
 // ── TTL constants ─────────────────────────────────────────────────────────────
 
 /// Bump instance storage TTL when remaining ledgers fall below this threshold.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,21 @@ services:
     depends_on:
       - backend
 
+  soroban-sandbox:
+    image: stellar/quickstart:soroban-dev
+    container_name: stellar-sandbox
+    command: ["--enable-soroban-rpc", "--standalone"]
+    ports:
+      - "8000:8000"
+    environment:
+      ENABLE_SOROBAN_RPC: "true"
+      NETWORK: "standalone"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/soroban/rpc || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
 volumes:
   pgdata:
   esdata:

--- a/scripts/start-sandbox.sh
+++ b/scripts/start-sandbox.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTRACTS=("escrow_contract" "insurance_contract")
+FRONTEND_ENV_FILE="$ROOT_DIR/frontend/.env.local"
+SANDBOX_RPC_URL="http://localhost:8000/soroban/rpc"
+SANDBOX_PASSPHRASE="Standalone Network ; February 2017"
+
+echo -e "${YELLOW}Starting local Stellar Quickstart (Soroban sandbox)...${NC}"
+docker compose -f "$ROOT_DIR/docker-compose.yml" up -d soroban-sandbox
+
+echo -e "${YELLOW}Waiting for Soroban RPC to be ready...${NC}"
+for i in {1..30}; do
+  if curl -sf "$SANDBOX_RPC_URL" >/dev/null 2>&1; then
+    echo -e "${GREEN}Soroban RPC is up${NC}"
+    break
+  fi
+  sleep 2
+  if [[ "$i" -eq 30 ]]; then
+    echo -e "${RED}Soroban RPC did not become ready in time${NC}"
+    exit 1
+  fi
+done
+
+echo -e "${YELLOW}Generating dev keypair...${NC}"
+KEYPAIR_JSON=$(soroban keys generate local-dev --network-passphrase "$SANDBOX_PASSPHRASE" --rpc-url "$SANDBOX_RPC_URL" 2>/dev/null || true)
+if [[ -z "${KEYPAIR_JSON:-}" ]]; then
+  echo -e "${YELLOW}Key 'local-dev' may already exist, fetching public key...${NC}"
+  DEV_PUBLIC_KEY=$(soroban keys address local-dev)
+else
+  DEV_PUBLIC_KEY=$(echo "$KEYPAIR_JSON" | grep -E '"public_key"' | sed -E 's/.*"public_key"\s*:\s*"([^"]+)".*/\1/')
+fi
+
+if [[ -z "${DEV_PUBLIC_KEY:-}" ]]; then
+  echo -e "${RED}Failed to determine dev public key${NC}"
+  exit 1
+fi
+
+echo -e "${YELLOW}Funding dev account on sandbox...${NC}"
+docker exec stellar-sandbox soroban lab fund --account "$DEV_PUBLIC_KEY" >/dev/null
+
+ENV_FILE="$ROOT_DIR/.env.sandbox"
+echo -e "${YELLOW}Writing sandbox backend env to $ENV_FILE...${NC}"
+cat > "$ENV_FILE" <<EOF
+SOROBAN_RPC_URL=$SANDBOX_RPC_URL
+SOROBAN_NETWORK_PASSPHRASE=$SANDBOX_PASSPHRASE
+STELLAR_SECRET_KEY=local-dev
+EOF
+
+export SOROBAN_RPC_URL="$SANDBOX_RPC_URL"
+export SOROBAN_NETWORK_PASSPHRASE="$SANDBOX_PASSPHRASE"
+export STELLAR_SECRET_KEY="local-dev"
+
+DEPLOYED_ENV_FILE="$ROOT_DIR/.env.sandbox.deployed"
+> "$DEPLOYED_ENV_FILE"
+
+for contract in "${CONTRACTS[@]}"; do
+  contract_path="$ROOT_DIR/contracts/$contract"
+  if [[ ! -d "$contract_path" ]]; then
+    echo -e "${YELLOW}Skipping missing contract directory $contract_path${NC}"
+    continue
+  fi
+
+  echo -e "\n${YELLOW}Building and deploying $contract to sandbox...${NC}"
+  (cd "$contract_path" && cargo build --release --target wasm32-unknown-unknown)
+
+  wasm_path="$contract_path/target/wasm32-unknown-unknown/release/${contract}.wasm"
+  hash=$(soroban contract upload \
+    --source-account "$STELLAR_SECRET_KEY" \
+    --rpc-url "$SOROBAN_RPC_URL" \
+    --network-passphrase "$SOROBAN_NETWORK_PASSPHRASE" \
+    --wasm "$wasm_path")
+
+  contract_id=$(soroban contract deploy \
+    --source-account "$STELLAR_SECRET_KEY" \
+    --rpc-url "$SOROBAN_RPC_URL" \
+    --network-passphrase "$SOROBAN_NETWORK_PASSPHRASE" \
+    --wasm-hash "$hash")
+
+  echo "${contract^^}_ID=$contract_id" >> "$DEPLOYED_ENV_FILE"
+
+  soroban contract invoke \
+    --source-account "$STELLAR_SECRET_KEY" \
+    --rpc-url "$SOROBAN_RPC_URL" \
+    --network-passphrase "$SOROBAN_NETWORK_PASSPHRASE" \
+    --id "$contract_id" \
+    -- initialize
+done
+
+echo -e "${YELLOW}Writing frontend Soroban env to $FRONTEND_ENV_FILE...${NC}"
+mkdir -p "$(dirname "$FRONTEND_ENV_FILE")"
+
+{
+  echo "NEXT_PUBLIC_SOROBAN_RPC_URL=$SANDBOX_RPC_URL"
+  echo "NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE=$SANDBOX_PASSPHRASE"
+  if [[ -f "$DEPLOYED_ENV_FILE" ]]; then
+    grep '_ID=' "$DEPLOYED_ENV_FILE" | sed 's/^/NEXT_PUBLIC_/' || true
+  fi
+} > "$FRONTEND_ENV_FILE"
+
+echo -e "${GREEN}Local Soroban sandbox is ready.${NC}"
+echo -e "${GREEN}Contracts deployed and frontend .env.local updated.${NC}"
+


### PR DESCRIPTION
## Title
Dev sandbox + milestone deps + staged refunds + admin freeze 
closes #852 
closes  #853 
closes  #854 
closes #855

## Summary
- Adds a Dockerized local Soroban sandbox (Quickstart standalone) plus `scripts/start-sandbox.sh` and README setup/teardown docs. (#852)
- Adds optional milestone dependencies with validation, unlock events, and tests for linear/branched dependency graphs. (#853)
- Implements staged refund protocols on cancellation: deduct platform fee, split remaining balance based on approved milestones, emit breakdown event, add tests. (#854)
- Adds threshold-based admin override for security freeze with configurable admin multisig, freeze/unfreeze audit events, frozen-state enforcement across mutating entrypoints, and tests. (#855)

## Test plan
- [ ] Review `README.md` sandbox instructions
- [ ] (Local) `docker compose up -d soroban-sandbox` then run `./scripts/start-sandbox.sh`
- [ ] (Contracts) `cargo test` (note: current workspace `Cargo.lock` parse issue may need resolving separately)
- [ ] Verify freeze/unfreeze prevents/allows mutating operations as expected

## Notes
- Sandbox is fully standalone (no public testnet dependency).
- Freeze/unfreeze emits audit events including signers + ledger sequence + timestamp.