### PR TITLE
feat: add secure GDPR data export and deletion flows

### DIFF
--- a/backend/api/controllers/exportController.js
+++ b/backend/api/controllers/exportController.js
@@ -1,5 +1,7 @@
 import exportService from '../../services/exportService.js';
 
+const LARGE_EXPORT_LIMIT_BYTES = 10 * 1024 * 1024;
+
 /**
  * Export Controller
  * Handles data export/import endpoints for user data portability
@@ -20,7 +22,32 @@ const exportUserData = async (req, res) => {
       });
     }
 
-    const data = await exportService.exportUserData(address);
+    if (req.user?.address !== address && !req.isAdmin) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    const tenantId = req.tenant?.id;
+    const data = await exportService.exportUserData(address, { tenantId });
+    const fileContent = exportService.generateExportFile(data);
+
+    if (req.isAdmin) {
+      await exportService.logAdminExport(address, {
+        tenantId,
+        performedBy: req.adminId ?? req.user?.address ?? 'admin',
+      });
+    }
+
+    if (Buffer.byteLength(fileContent, 'utf8') > LARGE_EXPORT_LIMIT_BYTES) {
+      const queued = await exportService.queueLargeExport(address, {
+        tenantId,
+        requestedBy: req.user?.address,
+      });
+      return res.status(202).json({
+        status: 'queued',
+        message: 'Export is larger than 10MB and will be delivered by email.',
+        jobId: queued.jobId,
+      });
+    }
 
     res.json(data);
   } catch (error) {
@@ -93,8 +120,32 @@ const downloadExportFile = async (req, res) => {
       });
     }
 
-    const data = await exportService.exportUserData(address);
+    if (req.user?.address !== address && !req.isAdmin) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    const tenantId = req.tenant?.id;
+    const data = await exportService.exportUserData(address, { tenantId });
     const fileContent = exportService.generateExportFile(data);
+
+    if (req.isAdmin) {
+      await exportService.logAdminExport(address, {
+        tenantId,
+        performedBy: req.adminId ?? req.user?.address ?? 'admin',
+      });
+    }
+
+    if (Buffer.byteLength(fileContent, 'utf8') > LARGE_EXPORT_LIMIT_BYTES) {
+      const queued = await exportService.queueLargeExport(address, {
+        tenantId,
+        requestedBy: req.user?.address,
+      });
+      return res.status(202).json({
+        status: 'queued',
+        message: 'Export is larger than 10MB and will be delivered by email.',
+        jobId: queued.jobId,
+      });
+    }
 
     res.setHeader('Content-Type', 'application/json');
     res.setHeader(
@@ -110,8 +161,37 @@ const downloadExportFile = async (req, res) => {
   }
 };
 
+/**
+ * Pseudonymize user data
+ * @route DELETE /api/users/:address/data
+ */
+const deleteUserData = async (req, res) => {
+  try {
+    const { address } = req.params;
+
+    if (!address || !address.startsWith('G')) {
+      return res.status(400).json({
+        error: 'Invalid Stellar address format',
+      });
+    }
+
+    const result = await exportService.pseudonymizeUserData(address, {
+      tenantId: req.tenant?.id,
+      performedBy: req.adminId ?? 'admin',
+    });
+
+    res.json({ success: true, ...result });
+  } catch (error) {
+    console.error('GDPR deletion error:', error);
+    res.status(500).json({
+      error: 'Failed to pseudonymize user data',
+    });
+  }
+};
+
 export default {
   exportUserData,
   importUserData,
   downloadExportFile,
+  deleteUserData,
 };

--- a/backend/api/middleware/adminAuth.js
+++ b/backend/api/middleware/adminAuth.js
@@ -36,7 +36,21 @@ const adminAuth = (req, res, next) => {
     return res.status(403).json({ error: 'Invalid admin API key.' });
   }
 
+  req.isAdmin = true;
+  req.adminId = 'admin';
   next();
 };
+
+export function optionalAdminAuth(req, _res, next) {
+  const adminKey = process.env.ADMIN_API_KEY;
+  const providedKey = req.headers['x-admin-api-key'];
+
+  if (adminKey && providedKey === adminKey) {
+    req.isAdmin = true;
+    req.adminId = 'admin';
+  }
+
+  next();
+}
 
 export default adminAuth;

--- a/backend/api/middleware/auth.js
+++ b/backend/api/middleware/auth.js
@@ -11,6 +11,11 @@ import sessionService from '../../services/sessionService.js';
 const JWT_SECRET = process.env.JWT_SECRET || 'change_this_in_production';
 
 export default async function authMiddleware(req, res, next) {
+  if (req.isAdmin) {
+    req.user = req.user ?? { address: req.adminId ?? 'admin' };
+    return next();
+  }
+
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith('Bearer ')) {
     return res.status(401).json({ error: 'Authentication required' });

--- a/backend/api/routes/userRoutes.js
+++ b/backend/api/routes/userRoutes.js
@@ -8,12 +8,21 @@ import {
 import exportController from '../controllers/exportController.js';
 import authMiddleware from '../middleware/auth.js';
 import { authorizeParamAddress } from '../middleware/authorization.js';
+import adminAuth, { optionalAdminAuth } from '../middleware/adminAuth.js';
+import { createSlidingWindowRateLimiter } from '../middleware/rateLimiter.js';
 
 const router = express.Router();
-router.use(authMiddleware);
+router.use(optionalAdminAuth, authMiddleware);
 
 const validateAddress = [stellarAddressParam('address'), handleValidationErrors];
 const validatePagination = [...paginationQuery, handleValidationErrors];
+const exportRateLimit = createSlidingWindowRateLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 3,
+  prefix: 'data-export',
+  message: 'Too many export requests for this address. Please try again later.',
+  keyGenerator: (req) => `data-export:address:${req.params?.address || 'unknown'}`,
+});
 
 router.get('/:address', validateAddress, userController.getUserProfile);
 router.get('/:address/escrows', validateAddress, validatePagination, userController.getUserEscrows);
@@ -24,7 +33,7 @@ router.get('/:address/stats', validateAddress, userController.getUserStats);
  * @desc   Export all user data in JSON format
  * @returns { version, exportedAt, userAddress, data: { escrows, payments, kyc, reputation } }
  */
-router.get('/:address/export', authorizeParamAddress('address'), exportController.exportUserData);
+router.get('/:address/export', exportRateLimit, exportController.exportUserData);
 
 /**
  * @route  POST /api/users/:address/import
@@ -39,10 +48,12 @@ router.post('/:address/import', authorizeParamAddress('address'), exportControll
  * @desc   Download user data as a file
  * @returns { file: 'data.json', content: {...} }
  */
-router.get(
-  '/:address/export/file',
-  authorizeParamAddress('address'),
-  exportController.downloadExportFile,
-);
+router.get('/:address/export/file', exportRateLimit, exportController.downloadExportFile);
+
+/**
+ * @route  DELETE /api/users/:address/data
+ * @desc   Pseudonymize user data for GDPR deletion/admin retention
+ */
+router.delete('/:address/data', adminAuth, exportController.deleteUserData);
 
 export default router;

--- a/backend/services/exportService.js
+++ b/backend/services/exportService.js
@@ -1,4 +1,15 @@
+import { createHash, randomUUID } from 'crypto';
+
 import prisma from '../lib/prisma.js';
+import { emailQueue } from '../queues/emailQueue.js';
+
+function withTenant(where, tenantId) {
+  return tenantId ? { ...where, tenantId } : where;
+}
+
+function toIso(value) {
+  return value instanceof Date ? value.toISOString() : value ? new Date(value).toISOString() : null;
+}
 
 /**
  * Export/Import Service for Stellar Trust Escrow
@@ -11,12 +22,14 @@ class ExportService {
    * @param {string} address - User's Stellar address
    * @returns {Promise<Object>} Complete user data export
    */
-  async exportUserData(address) {
-    const [escrows, payments, kyc, reputation] = await Promise.all([
-      this.exportEscrowHistory(address),
-      this.exportPaymentHistory(address),
-      this.exportKycStatus(address),
-      this.exportReputation(address),
+  async exportUserData(address, { tenantId } = {}) {
+    const [escrows, payments, kyc, reputation, adminAuditLog, disputeMessages] = await Promise.all([
+      this.exportEscrowHistory(address, { tenantId }),
+      this.exportPaymentHistory(address, { tenantId }),
+      this.exportKycStatus(address, { tenantId }),
+      this.exportReputation(address, { tenantId }),
+      this.exportAdminAuditLog(address, { tenantId }),
+      this.exportDisputeMessages(address),
     ]);
 
     return {
@@ -28,6 +41,8 @@ class ExportService {
         payments,
         kyc,
         reputation,
+        adminAuditLog,
+        disputeMessages,
       },
     };
   }
@@ -37,9 +52,10 @@ class ExportService {
    * @param {string} address - User's Stellar address
    * @returns {Promise<Array>} Array of escrow records
    */
-  async exportEscrowHistory(address) {
+  async exportEscrowHistory(address, { tenantId } = {}) {
     const escrows = await prisma.escrow.findMany({
       where: {
+        ...(tenantId ? { tenantId } : {}),
         OR: [{ clientAddress: address }, { freelancerAddress: address }],
       },
       include: {
@@ -61,8 +77,8 @@ class ExportService {
       remainingBalance: escrow.remainingBalance,
       status: escrow.status,
       briefHash: escrow.briefHash,
-      deadline: escrow.deadline?.toISOString() || null,
-      createdAt: escrow.createdAt.toISOString(),
+      deadline: toIso(escrow.deadline),
+      createdAt: toIso(escrow.createdAt),
       createdLedger: escrow.createdLedger.toString(),
       milestones: escrow.milestones.map((m) => ({
         milestoneIndex: m.milestoneIndex,
@@ -70,14 +86,14 @@ class ExportService {
         descriptionHash: m.descriptionHash,
         amount: m.amount,
         status: m.status,
-        submittedAt: m.submittedAt?.toISOString() || null,
-        resolvedAt: m.resolvedAt?.toISOString() || null,
+        submittedAt: toIso(m.submittedAt),
+        resolvedAt: toIso(m.resolvedAt),
       })),
       dispute: escrow.dispute
         ? {
             raisedByAddress: escrow.dispute.raisedByAddress,
-            raisedAt: escrow.dispute.raisedAt.toISOString(),
-            resolvedAt: escrow.dispute.resolvedAt?.toISOString() || null,
+            raisedAt: toIso(escrow.dispute.raisedAt),
+            resolvedAt: toIso(escrow.dispute.resolvedAt),
             clientAmount: escrow.dispute.clientAmount,
             freelancerAmount: escrow.dispute.freelancerAmount,
             resolvedBy: escrow.dispute.resolvedBy,
@@ -92,9 +108,9 @@ class ExportService {
    * @param {string} address - User's Stellar address
    * @returns {Promise<Array>} Array of payment records
    */
-  async exportPaymentHistory(address) {
+  async exportPaymentHistory(address, { tenantId } = {}) {
     const payments = await prisma.payment.findMany({
-      where: { address },
+      where: withTenant({ address }, tenantId),
       orderBy: { createdAt: 'desc' },
     });
 
@@ -108,8 +124,8 @@ class ExportService {
       currency: payment.currency,
       status: payment.status,
       refundId: payment.refundId,
-      createdAt: payment.createdAt.toISOString(),
-      updatedAt: payment.updatedAt.toISOString(),
+      createdAt: toIso(payment.createdAt),
+      updatedAt: toIso(payment.updatedAt),
     }));
   }
 
@@ -118,10 +134,12 @@ class ExportService {
    * @param {string} address - User's Stellar address
    * @returns {Promise<Object|null>} KYC record or null
    */
-  async exportKycStatus(address) {
-    const kyc = await prisma.kycVerification.findUnique({
-      where: { address },
-    });
+  async exportKycStatus(address, { tenantId } = {}) {
+    const kyc = tenantId
+      ? await prisma.kycVerification.findFirst({ where: { address, tenantId } })
+      : await prisma.kycVerification.findUnique({
+          where: { address },
+        });
 
     if (!kyc) return null;
 
@@ -129,8 +147,8 @@ class ExportService {
       status: kyc.status,
       reviewResult: kyc.reviewResult,
       rejectLabels: kyc.rejectLabels,
-      createdAt: kyc.createdAt.toISOString(),
-      updatedAt: kyc.updatedAt.toISOString(),
+      createdAt: toIso(kyc.createdAt),
+      updatedAt: toIso(kyc.updatedAt),
     };
   }
 
@@ -139,10 +157,12 @@ class ExportService {
    * @param {string} address - User's Stellar address
    * @returns {Promise<Object|null>} Reputation record or null
    */
-  async exportReputation(address) {
-    const reputation = await prisma.reputationRecord.findUnique({
-      where: { address },
-    });
+  async exportReputation(address, { tenantId } = {}) {
+    const reputation = tenantId
+      ? await prisma.reputationRecord.findFirst({ where: { address, tenantId } })
+      : await prisma.reputationRecord.findUnique({
+          where: { address },
+        });
 
     if (!reputation) return null;
 
@@ -152,9 +172,177 @@ class ExportService {
       disputedEscrows: reputation.disputedEscrows,
       disputesWon: reputation.disputesWon,
       totalVolume: reputation.totalVolume,
-      lastUpdated: reputation.lastUpdated.toISOString(),
-      updatedAt: reputation.updatedAt.toISOString(),
+      lastUpdated: toIso(reputation.lastUpdated),
+      updatedAt: toIso(reputation.updatedAt),
     };
+  }
+
+  async exportAdminAuditLog(address, { tenantId } = {}) {
+    const logs = await prisma.adminAuditLog.findMany({
+      where: withTenant({ targetAddress: address }, tenantId),
+      orderBy: { performedAt: 'desc' },
+    });
+
+    return logs.map((log) => ({
+      action: log.action,
+      targetAddress: log.targetAddress,
+      timestamp: toIso(log.performedAt),
+      outcome: log.reason || 'recorded',
+    }));
+  }
+
+  async exportDisputeMessages(address) {
+    if (!prisma.chatMessage || !prisma.chatRoomKey) return [];
+
+    const roomKeys = await prisma.chatRoomKey.findMany({
+      where: { address },
+      select: { roomId: true },
+    });
+    const roomIds = [...new Set(roomKeys.map((key) => key.roomId).filter(Boolean))];
+
+    const messages = await prisma.chatMessage.findMany({
+      where: {
+        OR: [{ senderAddress: address }, ...(roomIds.length ? [{ roomId: { in: roomIds } }] : [])],
+      },
+      orderBy: { sentAt: 'asc' },
+      select: {
+        id: true,
+        roomId: true,
+        senderAddress: true,
+        ciphertext: true,
+        iv: true,
+        tag: true,
+        sentAt: true,
+      },
+    });
+
+    return messages.map((message) => ({
+      id: message.id,
+      roomId: message.roomId,
+      senderAddress: message.senderAddress,
+      ciphertext: message.ciphertext,
+      iv: message.iv,
+      tag: message.tag,
+      sentAt: toIso(message.sentAt),
+    }));
+  }
+
+  async logAdminExport(address, { tenantId, performedBy = 'admin' } = {}) {
+    return prisma.adminAuditLog.create({
+      data: {
+        ...(tenantId ? { tenantId } : {}),
+        action: 'DATA_EXPORT',
+        targetAddress: address,
+        reason: 'Admin exported user data',
+        performedBy,
+        performedAt: new Date(),
+      },
+    });
+  }
+
+  async queueLargeExport(address, { tenantId, requestedBy } = {}) {
+    const token = randomUUID();
+    const downloadUrl = `/api/users/${address}/export/file?token=${token}`;
+    const user = await prisma.user?.findFirst?.({
+      where: withTenant({ walletAddress: address }, tenantId),
+      select: { email: true },
+    });
+
+    const job = await emailQueue.add('data_export.deliver', {
+      address,
+      tenantId,
+      requestedBy,
+      downloadUrl,
+      recipients: user?.email ? [{ email: user.email }] : [],
+      message: {
+        subject: 'Your Stellar Trust Escrow data export is ready',
+        text: `Your data export is ready: ${downloadUrl}`,
+      },
+    });
+
+    return { jobId: job.id, downloadUrl };
+  }
+
+  pseudonymForAddress(address) {
+    return `anon_${createHash('sha256').update(address).digest('hex').slice(0, 32)}`;
+  }
+
+  async pseudonymizeUserData(address, { tenantId, performedBy = 'admin' } = {}) {
+    const pseudonym = this.pseudonymForAddress(address);
+    const scoped = (where) => withTenant(where, tenantId);
+
+    const result = await prisma.$transaction(async (tx) => {
+      const [
+        escrowsAsClient,
+        escrowsAsFreelancer,
+        escrowsAsArbiter,
+        payments,
+        kyc,
+        reputation,
+        profiles,
+        users,
+      ] = await Promise.all([
+        tx.escrow.updateMany({
+          where: scoped({ clientAddress: address }),
+          data: { clientAddress: pseudonym },
+        }),
+        tx.escrow.updateMany({
+          where: scoped({ freelancerAddress: address }),
+          data: { freelancerAddress: pseudonym },
+        }),
+        tx.escrow.updateMany({
+          where: scoped({ arbiterAddress: address }),
+          data: { arbiterAddress: pseudonym },
+        }),
+        tx.payment.updateMany({
+          where: scoped({ address }),
+          data: { address: pseudonym },
+        }),
+        tx.kycVerification.updateMany({
+          where: scoped({ address }),
+          data: { address: pseudonym, applicantId: null, rejectLabels: [] },
+        }),
+        tx.reputationRecord.updateMany({
+          where: scoped({ address }),
+          data: { address: pseudonym },
+        }),
+        tx.userProfile.updateMany({
+          where: scoped({ address }),
+          data: { address: pseudonym, displayName: null, bio: null, avatarUrl: null },
+        }),
+        tx.user.updateMany({
+          where: scoped({ walletAddress: address }),
+          data: { walletAddress: pseudonym, email: `${pseudonym}@deleted.local` },
+        }),
+      ]);
+
+      await tx.adminAuditLog.create({
+        data: {
+          ...(tenantId ? { tenantId } : {}),
+          action: 'GDPR_DATA_PSEUDONYMIZE',
+          targetAddress: pseudonym,
+          reason: 'Pseudonymized user data',
+          performedBy,
+          performedAt: new Date(),
+        },
+      });
+
+      return {
+        pseudonym,
+        updated: {
+          escrowsAsClient: escrowsAsClient.count,
+          escrowsAsFreelancer: escrowsAsFreelancer.count,
+          escrowsAsArbiter: escrowsAsArbiter.count,
+          payments: payments.count,
+          kyc: kyc.count,
+          reputation: reputation.count,
+          profiles: profiles.count,
+          users: users.count,
+        },
+      };
+    });
+
+    return result;
   }
 
   /**

--- a/backend/tests/exportGdpr.test.js
+++ b/backend/tests/exportGdpr.test.js
@@ -1,0 +1,231 @@
+import { jest } from '@jest/globals';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import request from 'supertest';
+
+const ADDRESS_A = `G${'A'.repeat(55)}`;
+const ADDRESS_B = `G${'B'.repeat(55)}`;
+const ADMIN_API_KEY = 'test-admin-key';
+
+process.env.ADMIN_API_KEY = ADMIN_API_KEY;
+process.env.JWT_SECRET = 'test-secret';
+
+const prismaMock = {
+  escrow: {
+    findMany: jest.fn(),
+    updateMany: jest.fn(),
+  },
+  payment: {
+    findMany: jest.fn(),
+    updateMany: jest.fn(),
+  },
+  kycVerification: {
+    findUnique: jest.fn(),
+    findFirst: jest.fn(),
+    updateMany: jest.fn(),
+  },
+  reputationRecord: {
+    findUnique: jest.fn(),
+    findFirst: jest.fn(),
+    updateMany: jest.fn(),
+  },
+  adminAuditLog: {
+    findMany: jest.fn(),
+    create: jest.fn(),
+  },
+  chatRoomKey: {
+    findMany: jest.fn(),
+  },
+  chatMessage: {
+    findMany: jest.fn(),
+  },
+  user: {
+    findFirst: jest.fn(),
+    updateMany: jest.fn(),
+  },
+  userProfile: {
+    updateMany: jest.fn(),
+  },
+  $transaction: jest.fn(),
+};
+
+const emailQueueMock = {
+  add: jest.fn(async () => ({ id: 'email-1' })),
+};
+
+jest.unstable_mockModule('../lib/prisma.js', () => ({
+  default: prismaMock,
+}));
+
+jest.unstable_mockModule('../queues/emailQueue.js', () => ({
+  emailQueue: emailQueueMock,
+}));
+
+const { default: userRoutes } = await import('../api/routes/userRoutes.js');
+const { default: exportService } = await import('../services/exportService.js');
+
+function bearerToken(address = ADDRESS_A) {
+  return `Bearer ${jwt.sign({ address, type: 'access' }, process.env.JWT_SECRET)}`;
+}
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/users', userRoutes);
+  return app;
+}
+
+function resetExportMocks() {
+  jest.clearAllMocks();
+  prismaMock.escrow.findMany.mockResolvedValue([]);
+  prismaMock.payment.findMany.mockResolvedValue([]);
+  prismaMock.kycVerification.findUnique.mockResolvedValue(null);
+  prismaMock.kycVerification.findFirst.mockResolvedValue(null);
+  prismaMock.reputationRecord.findUnique.mockResolvedValue(null);
+  prismaMock.reputationRecord.findFirst.mockResolvedValue(null);
+  prismaMock.adminAuditLog.findMany.mockResolvedValue([]);
+  prismaMock.adminAuditLog.create.mockResolvedValue({ id: 1 });
+  prismaMock.chatRoomKey.findMany.mockResolvedValue([]);
+  prismaMock.chatMessage.findMany.mockResolvedValue([]);
+  prismaMock.user.findFirst.mockResolvedValue(null);
+}
+
+beforeEach(() => {
+  resetExportMocks();
+});
+
+describe('GDPR export route protection', () => {
+  it('returns 403 when an authenticated user exports a different address', async () => {
+    const app = createApp();
+
+    await request(app)
+      .get(`/api/users/${ADDRESS_B}/export`)
+      .set('Authorization', bearerToken(ADDRESS_A))
+      .expect(403)
+      .expect(({ body }) => {
+        expect(body.error).toBe('Forbidden');
+      });
+
+    expect(prismaMock.escrow.findMany).not.toHaveBeenCalled();
+  });
+
+  it('allows admins to export any address and logs DATA_EXPORT', async () => {
+    const app = createApp();
+
+    await request(app)
+      .get(`/api/users/${ADDRESS_B}/export`)
+      .set('x-admin-api-key', ADMIN_API_KEY)
+      .expect(200);
+
+    expect(prismaMock.adminAuditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: 'DATA_EXPORT',
+        targetAddress: ADDRESS_B,
+        performedBy: 'admin',
+      }),
+    });
+  });
+
+  it('limits exports to 3 requests per address per hour', async () => {
+    const app = createApp();
+
+    for (let i = 0; i < 3; i++) {
+      await request(app)
+        .get(`/api/users/${ADDRESS_A}/export`)
+        .set('Authorization', bearerToken(ADDRESS_A))
+        .expect(200);
+    }
+
+    await request(app)
+      .get(`/api/users/${ADDRESS_A}/export`)
+      .set('Authorization', bearerToken(ADDRESS_A))
+      .expect(429);
+  });
+});
+
+describe('exportService GDPR data scope', () => {
+  it('includes sanitized admin audit actions and dispute messages', async () => {
+    const performedAt = new Date('2026-06-19T12:00:00.000Z');
+    prismaMock.adminAuditLog.findMany.mockResolvedValue([
+      {
+        action: 'SUSPEND_USER',
+        targetAddress: ADDRESS_A,
+        reason: 'appeal denied',
+        performedBy: 'admin@example.com',
+        performedAt,
+      },
+    ]);
+    prismaMock.chatRoomKey.findMany.mockResolvedValue([{ roomId: 'dispute:1' }]);
+    prismaMock.chatMessage.findMany.mockResolvedValue([
+      {
+        id: 7,
+        roomId: 'dispute:1',
+        senderAddress: ADDRESS_B,
+        ciphertext: 'cipher',
+        iv: 'iv',
+        tag: 'tag',
+        sentAt: performedAt,
+      },
+    ]);
+
+    const exported = await exportService.exportUserData(ADDRESS_A, { tenantId: 'tenant_default' });
+
+    expect(prismaMock.adminAuditLog.findMany).toHaveBeenCalledWith({
+      where: { targetAddress: ADDRESS_A, tenantId: 'tenant_default' },
+      orderBy: { performedAt: 'desc' },
+    });
+    expect(prismaMock.chatMessage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          OR: [{ senderAddress: ADDRESS_A }, { roomId: { in: ['dispute:1'] } }],
+        },
+      }),
+    );
+    expect(exported.data.adminAuditLog).toEqual([
+      {
+        action: 'SUSPEND_USER',
+        targetAddress: ADDRESS_A,
+        timestamp: '2026-06-19T12:00:00.000Z',
+        outcome: 'appeal denied',
+      },
+    ]);
+    expect(exported.data.adminAuditLog[0]).not.toHaveProperty('performedBy');
+    expect(exported.data.disputeMessages).toHaveLength(1);
+  });
+
+  it('pseudonymizes address fields while preserving references', async () => {
+    const count = (n) => Promise.resolve({ count: n });
+    prismaMock.escrow.updateMany
+      .mockImplementationOnce(() => count(1))
+      .mockImplementationOnce(() => count(2))
+      .mockImplementationOnce(() => count(0));
+    prismaMock.payment.updateMany.mockResolvedValue({ count: 3 });
+    prismaMock.kycVerification.updateMany.mockResolvedValue({ count: 1 });
+    prismaMock.reputationRecord.updateMany.mockResolvedValue({ count: 1 });
+    prismaMock.userProfile.updateMany.mockResolvedValue({ count: 1 });
+    prismaMock.user.updateMany.mockResolvedValue({ count: 1 });
+    prismaMock.$transaction.mockImplementation(async (callback) => callback(prismaMock));
+
+    const result = await exportService.pseudonymizeUserData(ADDRESS_A, {
+      tenantId: 'tenant_default',
+      performedBy: 'admin',
+    });
+
+    expect(result.pseudonym).toMatch(/^anon_[a-f0-9]{32}$/);
+    expect(prismaMock.escrow.updateMany).toHaveBeenCalledWith({
+      where: { clientAddress: ADDRESS_A, tenantId: 'tenant_default' },
+      data: { clientAddress: result.pseudonym },
+    });
+    expect(prismaMock.payment.updateMany).toHaveBeenCalledWith({
+      where: { address: ADDRESS_A, tenantId: 'tenant_default' },
+      data: { address: result.pseudonym },
+    });
+    expect(prismaMock.adminAuditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: 'GDPR_DATA_PSEUDONYMIZE',
+        targetAddress: result.pseudonym,
+      }),
+    });
+    expect(result.updated.payments).toBe(3);
+  });
+});


### PR DESCRIPTION
Title: Secure GDPR Data Export and Deletion Flows

Description:

This PR fixes GDPR data export authorization and expands the exported data scope.

Changes:
- Enforces owner-or-admin access for user data exports.
- Allows admin exports via admin auth and logs them as `DATA_EXPORT`.
- Adds export-specific rate limiting: 3 exports per address per hour.
- Includes sanitized `AdminAuditLog` entries in user exports.
- Includes dispute chat messages where the user participated.
- Queues exports larger than 10MB for email delivery instead of synchronous streaming.
- Adds admin-only GDPR deletion endpoint that pseudonymizes user data while retaining audit integrity.
- Adds regression tests for access control, admin logging, rate limiting, export contents, and pseudonymization.

Validation:
- `npm run lint`
- `npm test`
- `NEXT_PUBLIC_API_URL=http://localhost:4000 npm run build`
- `cargo test --workspace`

Closes #1006 