### PR TITLE
feat: escrow wizard, responsive dashboard, dark mode, skeleton loading

### DIFF
--- a/frontend/app/admin/disputes/page.jsx
+++ b/frontend/app/admin/disputes/page.jsx
@@ -204,7 +204,20 @@ export default function AdminDisputesPage() {
 
       <div className="flex flex-col gap-3">
         {loading ? (
-          <div className="text-center py-12 text-gray-500">Loading…</div>
+          <div className="flex flex-col gap-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="card space-y-3 animate-pulse">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="space-y-2 flex-1">
+                    <div className="h-4 bg-gray-300 dark:bg-gray-700 rounded w-32" />
+                    <div className="h-3 bg-gray-200 dark:bg-gray-800 rounded w-48" />
+                    <div className="h-3 bg-gray-200 dark:bg-gray-800 rounded w-full" />
+                  </div>
+                  <div className="h-8 w-20 bg-gray-300 dark:bg-gray-700 rounded-lg" />
+                </div>
+              </div>
+            ))}
+          </div>
         ) : disputes.length === 0 ? (
           <div className="card text-center py-12 text-gray-500">No disputes found.</div>
         ) : (

--- a/frontend/app/dashboard/page.jsx
+++ b/frontend/app/dashboard/page.jsx
@@ -100,7 +100,7 @@ export default function DashboardPage() {
                 href="/escrow/create"
                 variant="primary"
                 data-tour="create-escrow"
-                className="focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-950 rounded-lg"
+                className="min-h-[44px] focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-950 rounded-lg"
               >
                 + {t('escrow.create')}
               </Button>
@@ -131,7 +131,7 @@ export default function DashboardPage() {
           <section aria-label="Active escrow agreements" data-tour="disputes">
             <h2 className="text-lg font-semibold text-white mb-4">Your Active Escrows</h2>
             {escrowsLoading ? (
-              <div className="grid gap-4 md:grid-cols-2">
+              <div className="grid gap-4 sm:grid-cols-2">
                 <CardSkeleton />
                 <CardSkeleton />
                 <CardSkeleton />
@@ -141,7 +141,7 @@ export default function DashboardPage() {
                 <p className="text-gray-400 font-medium">No active escrows yet.</p>
               </div>
             ) : (
-              <div className="grid gap-4 md:grid-cols-2" role="list">
+              <div className="grid gap-4 sm:grid-cols-2" role="list">
                 {escrows.map((escrow) => (
                   <div key={escrow.id} role="listitem">
                     <EscrowCard escrow={escrow} />

--- a/frontend/app/escrow/[id]/page.jsx
+++ b/frontend/app/escrow/[id]/page.jsx
@@ -34,8 +34,8 @@ import ReputationBadge from '../../../components/ui/ReputationBadge';
 import CurrencyAmount from '../../../components/ui/CurrencyAmount';
 import TransactionHash from '../../../components/ui/TransactionHash';
 import Avatar from '../../../components/ui/Avatar';
-import {
-  buildApproveMilestoneTx,
+import Skeleton from '../../../components/ui/Skeleton';
+import Skeleton from '../../../components/ui/Skeleton';
   buildSubmitMilestoneTx,
   buildRaiseDisputeTx,
   broadcastTransaction,
@@ -201,11 +201,7 @@ export default function EscrowDetailPage({ params }) {
   };
 
   if (isLoading && !fetchedEscrow) {
-    return (
-      <div className="flex items-center justify-center min-h-[40vh] text-gray-400">
-        Loading escrow…
-      </div>
-    );
+    return <EscrowDetailSkeleton />;
   }
 
   return (
@@ -254,7 +250,7 @@ export default function EscrowDetailPage({ params }) {
       </div>
 
       {/* Info Grid */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
         <InfoCell label="Total" value={escrow.totalAmount} isAmount />
         <InfoCell label="Remaining" value={escrow.remainingBalance} isAmount />
         <InfoCell label="Created" value={escrow.createdAt} />
@@ -315,6 +311,56 @@ export default function EscrowDetailPage({ params }) {
         escrowId={id}
         onConfirm={handleCancelEscrow}
       />
+    </div>
+  );
+}
+
+function EscrowDetailSkeleton() {
+  return (
+    <div className="space-y-8 max-w-4xl mx-auto" aria-busy="true" aria-label="Loading escrow details">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4">
+        <div className="space-y-2">
+          <Skeleton variant="heading" className="w-64" />
+          <Skeleton variant="text" className="w-24" />
+        </div>
+        <div className="flex gap-2">
+          <Skeleton className="h-9 w-28 rounded-lg" />
+          <Skeleton className="h-9 w-32 rounded-lg" />
+        </div>
+      </div>
+      {/* Info Grid */}
+      <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="card py-3 space-y-2">
+            <Skeleton variant="text" className="w-16 h-3" />
+            <Skeleton variant="text" className="w-24 h-5" />
+          </div>
+        ))}
+      </div>
+      {/* Parties */}
+      <div className="card grid grid-cols-1 md:grid-cols-2 gap-6">
+        {Array.from({ length: 2 }).map((_, i) => (
+          <div key={i} className="space-y-2">
+            <Skeleton variant="text" className="w-16 h-3" />
+            <div className="flex items-center gap-3">
+              <Skeleton className="w-10 h-10 rounded-full" />
+              <Skeleton variant="text" className="w-40 h-4" />
+            </div>
+          </div>
+        ))}
+      </div>
+      {/* Milestones */}
+      <div className="space-y-3">
+        <Skeleton variant="heading" className="w-28" />
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="card space-y-2">
+            <Skeleton variant="text" className="w-48 h-4" />
+            <Skeleton variant="text" className="w-full h-3" />
+            <Skeleton variant="text" className="w-20 h-3" />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/app/escrow/create/page.jsx
+++ b/frontend/app/escrow/create/page.jsx
@@ -1,20 +1,17 @@
 /**
  * Create Escrow Page — /escrow/create
  *
- * Multi-step form to create a new escrow agreement.
- *
- * Step 1: Counterparty — enter freelancer address, token, total amount
- * Step 2: Milestones  — add milestone titles, descriptions, amounts
- * Step 3: Review      — confirm all details before signing
- * Step 4: Sign & Submit — Freighter signs, broadcast to Stellar
+ * 5-step wizard:
+ *   1. Parties    — buyer (auto-filled) + seller address
+ *   2. Terms      — project description + deadline
+ *   3. Amount     — token, total amount, milestones
+ *   4. Review     — full summary before signing
+ *   5. Confirm    — Freighter signing
  *
  * TODO (contributor — hard, Issue #33):
- * - Step 1: validate Stellar address format (G..., 56 chars)
- * - Step 2: validate milestone amounts sum <= total_amount
- * - Step 3: show summary with gas estimate
- * - Step 4: build Soroban transaction with stellar-sdk
- * - Step 4: invoke Freighter signTransaction()
- * - Step 4: POST signed XDR to /api/escrows/broadcast
+ * - Step 5: build Soroban transaction with stellar-sdk
+ * - Step 5: invoke Freighter signTransaction()
+ * - Step 5: POST signed XDR to /api/escrows/broadcast
  * - On success: redirect to /escrow/[id]
  */
 
@@ -36,23 +33,23 @@ import {
 } from '../../../lib/stellar';
 
 const STEPS = [
-  { id: 1, label: 'Counterparty' },
-  { id: 2, label: 'Milestones' },
-  { id: 3, label: 'Review' },
-  { id: 4, label: 'Sign' },
+  { id: 1, label: 'Parties' },
+  { id: 2, label: 'Terms' },
+  { id: 3, label: 'Amount' },
+  { id: 4, label: 'Review' },
+  { id: 5, label: 'Confirm' },
 ];
 
 const DEFAULT_MILESTONE = { title: '', description: '', amount: '' };
-
 const DESCRIPTION_MIN_LENGTH = 10;
 
 function applyTemplateToForm(currentForm, template) {
   const milestones =
     Array.isArray(template.milestones) && template.milestones.length > 0
-      ? template.milestones.map((milestone) => ({
-          title: milestone.title || '',
-          description: milestone.description || '',
-          amount: milestone.amount || '',
+      ? template.milestones.map((m) => ({
+          title: m.title || '',
+          description: m.description || '',
+          amount: m.amount || '',
         }))
       : [{ ...DEFAULT_MILESTONE }];
 
@@ -66,11 +63,45 @@ function applyTemplateToForm(currentForm, template) {
   };
 }
 
-/** Returns true when the amount string represents a positive number. */
 function isPositiveAmount(value) {
   const n = Number(value);
   return value !== '' && !Number.isNaN(n) && n > 0;
 }
+
+function todayIso() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+function validateStep(step, formData) {
+  const errors = {};
+  if (step === 1) {
+    if (!formData.sellerAddress.trim()) {
+      errors.sellerAddress = 'Seller address is required.';
+    } else if (!isValidStellarAddress(formData.sellerAddress.trim())) {
+      errors.sellerAddress = 'Enter a valid Stellar address (G…, 56 characters).';
+    }
+  }
+  if (step === 2) {
+    if (formData.briefDescription.trim().length < DESCRIPTION_MIN_LENGTH) {
+      errors.briefDescription = `Description must be at least ${DESCRIPTION_MIN_LENGTH} characters.`;
+    }
+    if (!formData.deadline) {
+      errors.deadline = 'Deadline is required.';
+    } else if (formData.deadline < todayIso()) {
+      errors.deadline = 'Deadline must be today or in the future.';
+    }
+  }
+  if (step === 3) {
+    if (!isPositiveAmount(formData.totalAmount)) {
+      errors.totalAmount = 'Amount must be a positive number.';
+    }
+  }
+  return errors;
+}
+
+// ── Main Component ────────────────────────────────────────────────────────────
 
 export default function CreateEscrowPage() {
   const router = useRouter();
@@ -80,106 +111,87 @@ export default function CreateEscrowPage() {
   const { address, isConnected, signTx } = useWallet();
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState({
-    freelancerAddress: '',
+    sellerAddress: '',
     tokenAddress: 'usdc',
     totalAmount: '',
     briefDescription: '',
     deadline: '',
     milestones: [{ ...DEFAULT_MILESTONE }],
   });
+  const [stepErrors, setStepErrors] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState(null);
+  const [submitError, setSubmitError] = useState(null);
   const [templateNotice, setTemplateNotice] = useState('');
   const [appliedQueryTemplateId, setAppliedQueryTemplateId] = useState(null);
-
-  // Touched state tracks which fields the user has interacted with
-  const [touched, setTouched] = useState({ totalAmount: false, briefDescription: false });
 
   const { showToast } = useToast();
 
   useEffect(() => {
     const templateId = searchParams.get('template');
-    if (!templateId || templateId === appliedQueryTemplateId) {
-      return;
-    }
-
+    if (!templateId || templateId === appliedQueryTemplateId) return;
     const template = templateLibrary.find((item) => item.id === templateId);
-    if (!template) {
-      return;
-    }
-
-    setFormData((previous) => applyTemplateToForm(previous, template));
+    if (!template) return;
+    setFormData((prev) => applyTemplateToForm(prev, template));
     setCurrentStep(1);
     setTemplateNotice(`Applied template: ${template.name}`);
     setAppliedQueryTemplateId(templateId);
   }, [searchParams, templateLibrary, appliedQueryTemplateId]);
 
   const handleApplyTemplate = (template) => {
-    setFormData((previous) => applyTemplateToForm(previous, template));
+    setFormData((prev) => applyTemplateToForm(prev, template));
     setCurrentStep(1);
     setTemplateNotice(`Applied template: ${template.name}`);
   };
 
-  // TODO (contributor — Issue #33): implement form submission
+  const handleNext = () => {
+    const errors = validateStep(currentStep, formData);
+    if (Object.keys(errors).length > 0) {
+      setStepErrors(errors);
+      return;
+    }
+    setStepErrors({});
+    setCurrentStep((s) => Math.min(STEPS.length, s + 1));
+  };
+
+  const handleBack = () => {
+    setStepErrors({});
+    setCurrentStep((s) => Math.max(1, s - 1));
+  };
+
   const handleSubmit = async () => {
     setIsSubmitting(true);
-    setError(null);
+    setSubmitError(null);
     try {
       throw new Error('Not implemented — see Issue #33');
     } catch (err) {
-      const message = err.message || 'Failed to create escrow';
-      setError(message);
+      setSubmitError(err.message || 'Failed to create escrow');
     } finally {
       setIsSubmitting(false);
     }
   };
 
-  const addMilestone = () => {
-    setFormData((data) => ({
-      ...data,
-      milestones: [...data.milestones, { ...DEFAULT_MILESTONE }],
-    }));
-  };
+  const addMilestone = () =>
+    setFormData((d) => ({ ...d, milestones: [...d.milestones, { ...DEFAULT_MILESTONE }] }));
 
-  const removeMilestone = (index) => {
-    setFormData((data) => {
-      const nextMilestones = data.milestones.filter(
-        (_, milestoneIndex) => milestoneIndex !== index,
-      );
-      return {
-        ...data,
-        milestones: nextMilestones.length > 0 ? nextMilestones : [{ ...DEFAULT_MILESTONE }],
-      };
+  const removeMilestone = (index) =>
+    setFormData((d) => {
+      const next = d.milestones.filter((_, i) => i !== index);
+      return { ...d, milestones: next.length > 0 ? next : [{ ...DEFAULT_MILESTONE }] };
     });
-  };
 
-  const updateMilestone = (index, field, value) => {
-    setFormData((data) => ({
-      ...data,
-      milestones: data.milestones.map((milestone, milestoneIndex) =>
-        milestoneIndex === index ? { ...milestone, [field]: value } : milestone,
-      ),
+  const updateMilestone = (index, field, value) =>
+    setFormData((d) => ({
+      ...d,
+      milestones: d.milestones.map((m, i) => (i === index ? { ...m, [field]: value } : m)),
     }));
-  };
-
-  // Validation errors (only shown after field is touched)
-  const amountError =
-    touched.totalAmount && formData.totalAmount !== '' && !isPositiveAmount(formData.totalAmount)
-      ? 'Amount must be a positive number.'
-      : null;
-
-  const descriptionError =
-    touched.briefDescription &&
-    formData.briefDescription.length > 0 &&
-    formData.briefDescription.length < DESCRIPTION_MIN_LENGTH
-      ? `Description must be at least ${DESCRIPTION_MIN_LENGTH} characters.`
-      : null;
 
   return (
     <div className="max-w-4xl mx-auto space-y-8">
       <div>
-        <h1 className="text-2xl font-bold text-white">Create New Escrow</h1>
-        <p className="text-gray-400 mt-1">Lock funds and define milestones for your project.</p>
+        <h1 className="text-2xl font-bold text-white dark:text-white">Create New Escrow</h1>
+        <p className="text-gray-600 dark:text-gray-400 mt-1">
+          Lock funds and define milestones for your project.
+        </p>
       </div>
 
       <TemplateSelector
@@ -190,33 +202,33 @@ export default function CreateEscrowPage() {
       />
 
       {templateNotice && (
-        <div className="bg-emerald-500/10 border border-emerald-500/30 rounded-lg p-3 text-emerald-300 text-sm">
+        <div className="bg-emerald-500/10 border border-emerald-500/30 rounded-lg p-3 text-emerald-600 dark:text-emerald-300 text-sm">
           {templateNotice}
         </div>
       )}
 
-      {/* Step Indicator */}
+      {/* Progress indicator */}
       <nav aria-label="Progress">
+        <p className="text-sm text-gray-500 mb-3">
+          Step {currentStep} of {STEPS.length}
+        </p>
         <ol className="flex items-center gap-2">
           {STEPS.map((step, i) => (
             <li key={step.id} className="flex items-center gap-2">
               <div
                 aria-current={currentStep === step.id ? 'step' : undefined}
                 className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold
-                ${
-                  currentStep >= step.id ? 'bg-indigo-600 text-white' : 'bg-gray-800 text-gray-500'
-                }`}
+                  ${currentStep > step.id ? 'bg-indigo-700 text-white' : currentStep === step.id ? 'bg-indigo-600 text-white' : 'bg-gray-200 dark:bg-gray-800 text-gray-500'}`}
               >
-                <span aria-label={`Step ${step.id}: ${step.label}`}>{step.id}</span>
+                {currentStep > step.id ? '✓' : step.id}
               </div>
               <span
-                className={`text-sm hidden sm:inline
-                ${currentStep >= step.id ? 'text-white' : 'text-gray-500'}`}
+                className={`text-sm hidden sm:inline ${currentStep >= step.id ? 'text-gray-900 dark:text-white' : 'text-gray-500'}`}
               >
                 {step.label}
               </span>
               {i < STEPS.length - 1 && (
-                <div className="w-8 h-px bg-gray-700 mx-1" aria-hidden="true" />
+                <div className="w-6 h-px bg-gray-300 dark:bg-gray-700 mx-1" aria-hidden="true" />
               )}
             </li>
           ))}
@@ -226,25 +238,29 @@ export default function CreateEscrowPage() {
       {/* Step Content */}
       <div className="card space-y-6">
         {currentStep === 1 && (
-          <StepCounterparty
+          <StepParties
             formData={formData}
             setFormData={setFormData}
-            setTouched={setTouched}
-            amountError={amountError}
-            descriptionError={descriptionError}
+            errors={stepErrors}
+            buyerAddress={address}
           />
         )}
         {currentStep === 2 && (
-          <StepMilestones
+          <StepTerms formData={formData} setFormData={setFormData} errors={stepErrors} />
+        )}
+        {currentStep === 3 && (
+          <StepAmount
             formData={formData}
+            setFormData={setFormData}
+            errors={stepErrors}
             onAdd={addMilestone}
             onRemove={removeMilestone}
             onUpdate={updateMilestone}
           />
         )}
-        {currentStep === 3 && <StepReview formData={formData} />}
-        {currentStep === 4 && (
-          <StepSign onSubmit={handleSubmit} isSubmitting={isSubmitting} error={error} />
+        {currentStep === 4 && <StepReview formData={formData} buyerAddress={address} />}
+        {currentStep === 5 && (
+          <StepConfirm onSubmit={handleSubmit} isSubmitting={isSubmitting} error={submitError} />
         )}
       </div>
 
@@ -252,17 +268,23 @@ export default function CreateEscrowPage() {
       <div className="flex flex-col sm:flex-row justify-between gap-4">
         <Button
           variant="secondary"
-          onClick={() => setCurrentStep((step) => Math.max(1, step - 1))}
+          onClick={handleBack}
           disabled={currentStep === 1}
+          className="min-h-[44px]"
         >
           Back
         </Button>
-        {currentStep < 4 ? (
-          <Button variant="primary" onClick={() => setCurrentStep((step) => step + 1)}>
+        {currentStep < STEPS.length ? (
+          <Button variant="primary" onClick={handleNext} className="min-h-[44px]">
             Next →
           </Button>
         ) : (
-          <Button variant="primary" onClick={handleSubmit} isLoading={isSubmitting}>
+          <Button
+            variant="primary"
+            onClick={handleSubmit}
+            isLoading={isSubmitting}
+            className="min-h-[44px]"
+          >
             Sign & Create Escrow
           </Button>
         )}
@@ -273,35 +295,118 @@ export default function CreateEscrowPage() {
 
 // ── Step Sub-components ───────────────────────────────────────────────────────
 
+function FieldError({ id, message }) {
+  if (!message) return null;
+  return (
+    <p id={id} className="mt-1 text-xs text-red-500 dark:text-red-400" role="alert">
+      {message}
+    </p>
+  );
+}
+
 /**
- * Step 1: Enter counterparty details.
+ * Step 1: Parties — buyer (auto-filled) + seller address.
  */
-function StepCounterparty({ formData, setFormData, setTouched, amountError, descriptionError }) {
+function StepParties({ formData, setFormData, errors, buyerAddress }) {
   return (
     <div className="space-y-4">
-      <h2 className="text-lg font-semibold text-white">Counterparty & Funds</h2>
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Parties</h2>
+
+      <div>
+        <label className="block text-sm text-gray-600 dark:text-gray-400 mb-1">
+          Buyer Address <span className="text-gray-400 text-xs">(your connected wallet)</span>
+        </label>
+        <input
+          type="text"
+          readOnly
+          value={buyerAddress || 'Not connected'}
+          className="w-full bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-4 py-2.5 text-gray-600 dark:text-gray-400 text-sm font-mono cursor-not-allowed"
+          aria-label="Buyer Stellar Address (read-only)"
+        />
+      </div>
 
       <StellarAddressInput
-        id="freelancer-address"
-        label="Freelancer Stellar Address"
+        id="seller-address"
+        label="Seller Stellar Address"
         placeholder="GABCD1234..."
-        value={formData.freelancerAddress}
-        onChange={(val) => setFormData((data) => ({ ...data, freelancerAddress: val }))}
+        value={formData.sellerAddress}
+        onChange={(val) => setFormData((d) => ({ ...d, sellerAddress: val }))}
         required
+        error={errors.sellerAddress}
+        errorId="seller-address-error"
       />
+      <FieldError id="seller-address-error" message={errors.sellerAddress} />
+    </div>
+  );
+}
+
+/**
+ * Step 2: Terms — description + deadline.
+ */
+function StepTerms({ formData, setFormData, errors }) {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Terms</h2>
+
+      <div>
+        <label htmlFor="brief-description" className="block text-sm text-gray-600 dark:text-gray-400 mb-1">
+          Project Description <span className="text-red-500">*</span>
+        </label>
+        <textarea
+          id="brief-description"
+          rows={4}
+          placeholder="Describe the project scope and deliverables (min 10 characters)…"
+          className={`w-full bg-white dark:bg-gray-800 border rounded-lg px-4 py-2.5
+            text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none resize-none transition-colors
+            ${errors.briefDescription ? 'border-red-500 focus:border-red-400' : 'border-gray-300 dark:border-gray-700 focus:border-indigo-500'}`}
+          value={formData.briefDescription}
+          aria-invalid={!!errors.briefDescription}
+          aria-describedby={errors.briefDescription ? 'brief-description-error' : undefined}
+          onChange={(e) => setFormData((d) => ({ ...d, briefDescription: e.target.value }))}
+        />
+        <FieldError id="brief-description-error" message={errors.briefDescription} />
+      </div>
+
+      <div>
+        <label htmlFor="deadline" className="block text-sm text-gray-600 dark:text-gray-400 mb-1">
+          Deadline <span className="text-red-500">*</span>
+        </label>
+        <input
+          id="deadline"
+          type="date"
+          min={todayIso()}
+          className={`w-full bg-white dark:bg-gray-800 border rounded-lg px-4 py-2.5
+            text-gray-900 dark:text-white focus:outline-none transition-colors
+            ${errors.deadline ? 'border-red-500 focus:border-red-400' : 'border-gray-300 dark:border-gray-700 focus:border-indigo-500'}`}
+          value={formData.deadline}
+          aria-invalid={!!errors.deadline}
+          aria-describedby={errors.deadline ? 'deadline-error' : undefined}
+          onChange={(e) => setFormData((d) => ({ ...d, deadline: e.target.value }))}
+        />
+        <FieldError id="deadline-error" message={errors.deadline} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Step 3: Amount — token, total, milestones.
+ */
+function StepAmount({ formData, setFormData, errors, onAdd, onRemove, onUpdate }) {
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Amount</h2>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div>
-          <label htmlFor="token" className="block text-sm text-gray-400 mb-1">
+          <label htmlFor="token" className="block text-sm text-gray-600 dark:text-gray-400 mb-1">
             Token
           </label>
           <select
             id="token"
-            className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-2.5 text-white"
+            className="w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-4 py-2.5 text-gray-900 dark:text-white"
             value={formData.tokenAddress}
-            onChange={(event) =>
-              setFormData((data) => ({ ...data, tokenAddress: event.target.value }))
-            }
+            onChange={(e) => setFormData((d) => ({ ...d, tokenAddress: e.target.value }))}
           >
             <option value="usdc">USDC</option>
             <option value="xlm">XLM</option>
@@ -309,155 +414,173 @@ function StepCounterparty({ formData, setFormData, setTouched, amountError, desc
           </select>
         </div>
         <div>
-          <label htmlFor="total-amount" className="block text-sm text-gray-400 mb-1">
-            Total Amount
+          <label htmlFor="total-amount" className="block text-sm text-gray-600 dark:text-gray-400 mb-1">
+            Total Amount <span className="text-red-500">*</span>
           </label>
           <XLMAmountInput
             id="total-amount"
             value={formData.totalAmount}
-            onChange={(event) => {
-              setFormData((data) => ({ ...data, totalAmount: event.target.value }));
-              setTouched((t) => ({ ...t, totalAmount: true }));
-            }}
-            onBlur={() => setTouched((t) => ({ ...t, totalAmount: true }))}
-            error={amountError}
+            onChange={(e) => setFormData((d) => ({ ...d, totalAmount: e.target.value }))}
+            error={errors.totalAmount}
             errorId="total-amount-error"
           />
+          <FieldError id="total-amount-error" message={errors.totalAmount} />
         </div>
       </div>
 
-      <div>
-        <label htmlFor="brief-description" className="block text-sm text-gray-400 mb-1">
-          Project Brief <span className="text-gray-600">(optional)</span>
-        </label>
-        <textarea
-          id="brief-description"
-          rows={3}
-          placeholder="Briefly describe the project scope and deliverables…"
-          className={`w-full bg-gray-800 border rounded-lg px-4 py-2.5
-                     text-white placeholder-gray-500 focus:outline-none resize-none transition-colors
-                     ${descriptionError ? 'border-red-500 focus:border-red-400' : 'border-gray-700 focus:border-indigo-500'}`}
-          value={formData.briefDescription}
-          aria-invalid={!!descriptionError}
-          aria-describedby={descriptionError ? 'brief-description-error' : undefined}
-          onChange={(event) => {
-            setFormData((data) => ({ ...data, briefDescription: event.target.value }));
-            setTouched((t) => ({ ...t, briefDescription: true }));
-          }}
-          onBlur={() => setTouched((t) => ({ ...t, briefDescription: true }))}
-        />
-        {descriptionError && (
-          <p id="brief-description-error" className="mt-1 text-xs text-red-400" role="alert">
-            {descriptionError}
-          </p>
-        )}
-        {/* TODO (contributor): upload to IPFS and store hash */}
-      </div>
-    </div>
-  );
-}
-
-/**
- * Step 2: Define milestones.
- */
-function StepMilestones({ formData, onAdd, onRemove, onUpdate }) {
-  return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-white">Milestones</h2>
-        <span className="text-sm text-gray-500">
-          Total:{' '}
-          {formData.milestones.reduce((sum, milestone) => sum + Number(milestone.amount || 0), 0)} /{' '}
-          {formData.totalAmount || '—'} {String(formData.tokenAddress || 'USDC').toUpperCase()}
-        </span>
-      </div>
-
-      {formData.milestones.map((milestone, index) => (
-        <div key={index} className="bg-gray-800 rounded-lg p-4 space-y-3">
-          <div className="flex items-center justify-between">
-            <span className="text-sm font-medium text-gray-300">Milestone {index + 1}</span>
-            {formData.milestones.length > 1 && (
-              <button
-                type="button"
-                onClick={() => onRemove(index)}
-                className="text-red-400 text-sm hover:text-red-300"
-              >
-                Remove
-              </button>
-            )}
-          </div>
-          <input
-            type="text"
-            placeholder="Title (e.g. Initial Design Mockups)"
-            aria-label={`Milestone ${index + 1} title`}
-            className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2
-                       text-white placeholder-gray-500 text-sm focus:outline-none focus:border-indigo-500"
-            value={milestone.title}
-            onChange={(event) => onUpdate(index, 'title', event.target.value)}
-          />
-          <textarea
-            rows={2}
-            placeholder="Milestone description"
-            aria-label={`Milestone ${index + 1} description`}
-            className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-2
-                       text-white placeholder-gray-500 text-sm focus:outline-none focus:border-indigo-500 resize-none"
-            value={milestone.description}
-            onChange={(event) => onUpdate(index, 'description', event.target.value)}
-          />
-          <div className="flex gap-2 items-center">
-            <XLMAmountInput
-              value={milestone.amount}
-              placeholder="Amount"
-              aria-label={`Milestone ${index + 1} amount`}
-              onChange={(event) => onUpdate(index, 'amount', event.target.value)}
-              inputClassName="w-32"
-              className="w-32"
-            />
-            <span className="text-gray-500 text-sm">
-              {String(formData.tokenAddress || 'USDC').toUpperCase()}
-            </span>
-          </div>
-        </div>
-      ))}
-
-      <button
-        type="button"
-        onClick={onAdd}
-        className="w-full border border-dashed border-gray-700 rounded-lg py-3
-                   text-gray-500 hover:text-gray-400 hover:border-gray-600 text-sm transition-colors"
-      >
-        + Add Milestone
-      </button>
-    </div>
-  );
-}
-
-/**
- * Step 3: Review summary before signing.
- */
-function StepReview({ formData }) {
-  const token = String(formData.tokenAddress || 'USDC').toUpperCase();
-
-  return (
-    <div className="space-y-4">
-      <h2 className="text-lg font-semibold text-white">Review Details</h2>
-      <div className="bg-gray-800 rounded-lg p-4 text-sm text-gray-400 space-y-2">
-        <p>
-          Freelancer: <span className="text-white">{formData.freelancerAddress || '—'}</span>
-        </p>
-        <p>
-          Total Amount:{' '}
-          <span className="text-white">
-            {formData.totalAmount || '—'} {token}
+      {/* Milestones */}
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Milestones</h3>
+          <span className="text-sm text-gray-500">
+            Total: {formData.milestones.reduce((s, m) => s + Number(m.amount || 0), 0)} /{' '}
+            {formData.totalAmount || '—'} {String(formData.tokenAddress || 'USDC').toUpperCase()}
           </span>
-        </p>
-        <p>
-          Milestones: <span className="text-white">{formData.milestones.length}</span>
-        </p>
+        </div>
+
+        {formData.milestones.map((milestone, index) => (
+          <div key={index} className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                Milestone {index + 1}
+              </span>
+              {formData.milestones.length > 1 && (
+                <button
+                  type="button"
+                  onClick={() => onRemove(index)}
+                  className="text-red-500 text-sm hover:text-red-400 min-h-[44px] px-2"
+                >
+                  Remove
+                </button>
+              )}
+            </div>
+            <input
+              type="text"
+              placeholder="Title (e.g. Initial Design Mockups)"
+              aria-label={`Milestone ${index + 1} title`}
+              className="w-full bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2
+                text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 text-sm focus:outline-none focus:border-indigo-500"
+              value={milestone.title}
+              onChange={(e) => onUpdate(index, 'title', e.target.value)}
+            />
+            <textarea
+              rows={2}
+              placeholder="Milestone description"
+              aria-label={`Milestone ${index + 1} description`}
+              className="w-full bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2
+                text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 text-sm focus:outline-none focus:border-indigo-500 resize-none"
+              value={milestone.description}
+              onChange={(e) => onUpdate(index, 'description', e.target.value)}
+            />
+            <div className="flex gap-2 items-center">
+              <XLMAmountInput
+                value={milestone.amount}
+                placeholder="Amount"
+                aria-label={`Milestone ${index + 1} amount`}
+                onChange={(e) => onUpdate(index, 'amount', e.target.value)}
+                className="w-32"
+                inputClassName="w-32"
+              />
+              <span className="text-gray-500 text-sm">
+                {String(formData.tokenAddress || 'USDC').toUpperCase()}
+              </span>
+            </div>
+          </div>
+        ))}
+
+        <button
+          type="button"
+          onClick={onAdd}
+          className="w-full border border-dashed border-gray-300 dark:border-gray-700 rounded-lg py-3
+            text-gray-500 hover:text-gray-600 dark:hover:text-gray-400 hover:border-gray-400 dark:hover:border-gray-600 text-sm transition-colors min-h-[44px]"
+        >
+          + Add Milestone
+        </button>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Step 4: Review — full summary before signing.
+ */
+function StepReview({ formData, buyerAddress }) {
+  const token = String(formData.tokenAddress || 'USDC').toUpperCase();
+  const milestoneTotal = formData.milestones.reduce((s, m) => s + Number(m.amount || 0), 0);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Review Details</h2>
+
+      <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 text-sm space-y-3">
+        <section>
+          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+            Parties
+          </p>
+          <p className="text-gray-600 dark:text-gray-400">
+            Buyer: <span className="text-gray-900 dark:text-white font-mono">{buyerAddress || '—'}</span>
+          </p>
+          <p className="text-gray-600 dark:text-gray-400 mt-1">
+            Seller:{' '}
+            <span className="text-gray-900 dark:text-white font-mono">
+              {formData.sellerAddress || '—'}
+            </span>
+          </p>
+        </section>
+
+        <hr className="border-gray-200 dark:border-gray-700" />
+
+        <section>
+          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Terms</p>
+          <p className="text-gray-600 dark:text-gray-400">
+            Description:{' '}
+            <span className="text-gray-900 dark:text-white">
+              {formData.briefDescription || '—'}
+            </span>
+          </p>
+          <p className="text-gray-600 dark:text-gray-400 mt-1">
+            Deadline: <span className="text-gray-900 dark:text-white">{formData.deadline || '—'}</span>
+          </p>
+        </section>
+
+        <hr className="border-gray-200 dark:border-gray-700" />
+
+        <section>
+          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+            Amount
+          </p>
+          <p className="text-gray-600 dark:text-gray-400">
+            Total:{' '}
+            <span className="text-gray-900 dark:text-white font-semibold">
+              {formData.totalAmount || '—'} {token}
+            </span>
+          </p>
+          <p className="text-gray-600 dark:text-gray-400 mt-1">
+            Milestones:{' '}
+            <span className="text-gray-900 dark:text-white">{formData.milestones.length}</span>
+            {milestoneTotal > 0 && (
+              <span className="text-gray-500 ml-1">
+                ({milestoneTotal} {token} allocated)
+              </span>
+            )}
+          </p>
+          {formData.milestones.some((m) => m.title) && (
+            <ul className="mt-2 space-y-1 pl-4">
+              {formData.milestones
+                .filter((m) => m.title)
+                .map((m, i) => (
+                  <li key={i} className="text-gray-500 text-xs">
+                    {m.title} — {m.amount || '0'} {token}
+                  </li>
+                ))}
+            </ul>
+          )}
+        </section>
+      </div>
+
       <p className="text-xs text-gray-500">
         ⚠️ By proceeding, you authorize locking{' '}
-        <strong className="text-white">
+        <strong className="text-gray-900 dark:text-white">
           {formData.totalAmount || '0'} {token}
         </strong>{' '}
         in the escrow contract. This action cannot be undone without mutual agreement.
@@ -467,25 +590,28 @@ function StepReview({ formData }) {
 }
 
 /**
- * Step 4: Sign with Freighter.
- * TODO (contributor — Issue #33): build and sign the Soroban transaction
+ * Step 5: Confirm & Sign with Freighter.
  */
-function StepSign({ error }) {
+function StepConfirm({ error }) {
   return (
     <div className="space-y-4 text-center">
-      <h2 className="text-lg font-semibold text-white">Sign & Submit</h2>
-      <p className="text-gray-400 text-sm">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Confirm & Sign</h2>
+      <p className="text-gray-600 dark:text-gray-400 text-sm">
         Clicking the button below will open your Freighter wallet to sign the transaction. Your
         funds will be locked on-chain once confirmed.
       </p>
       {error && (
-        <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3 text-red-400 text-sm">
+        <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3 text-red-600 dark:text-red-400 text-sm">
           {error}
         </div>
       )}
-      <p className="text-xs text-amber-400">
+      <p className="text-xs text-amber-600 dark:text-amber-400">
         🚧 Freighter integration is not yet implemented — see Issue #33
       </p>
     </div>
   );
+}
+
+function todayIso() {
+  return new Date().toISOString().slice(0, 10);
 }

--- a/frontend/app/explorer/page.jsx
+++ b/frontend/app/explorer/page.jsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { Search, SlidersHorizontal, X, ChevronLeft, ChevronRight } from 'lucide-react';
 import Spinner from '../../components/ui/Spinner';
 import EscrowCard from '../../components/escrow/EscrowCard';
+import EscrowCardSkeleton from '../../components/ui/EscrowCardSkeleton';
 import SearchFilters from '../../components/explorer/SearchFilters';
 import Button from '../../components/ui/Button';
 import EmptyState from '../../components/ui/EmptyState';
@@ -194,9 +195,10 @@ function ExplorerContent() {
 
         <div className="flex-1 min-w-0">
           {loading ? (
-            <div className="flex flex-col items-center justify-center py-24 gap-4 text-gray-400">
-              <Spinner />
-              <p className="text-sm">Loading escrows...</p>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <EscrowCardSkeleton key={i} />
+              ))}
             </div>
           ) : error ? (
             <div className="text-center py-16">

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -14,6 +14,29 @@
   }
 }
 
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+.skeleton-shimmer {
+  background: linear-gradient(90deg, #e5e7eb 25%, #d1d5db 50%, #e5e7eb 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+@media (prefers-color-scheme: dark) {
+  .skeleton-shimmer {
+    background: linear-gradient(90deg, #1f2937 25%, #374151 50%, #1f2937 75%);
+    background-size: 200% 100%;
+  }
+}
+
+:root.dark .skeleton-shimmer,
+[data-theme='dark'] .skeleton-shimmer {
+  background: linear-gradient(90deg, #1f2937 25%, #374151 50%, #1f2937 75%);
+  background-size: 200% 100%;
+}
+
 /* Custom base styles */
 @layer base {
   :root {

--- a/frontend/app/layout.jsx
+++ b/frontend/app/layout.jsx
@@ -36,7 +36,7 @@ export default function RootLayout({ children }) {
         <link rel="dns-prefetch" href={API_ORIGIN} />
         <link rel="preconnect" href={API_ORIGIN} crossOrigin="anonymous" />
       </head>
-      <body className="bg-gray-950 text-gray-100 min-h-screen flex flex-col font-sans">
+      <body className="bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100 min-h-screen flex flex-col font-sans">
         <AppStoreProvider>
           <I18nProvider>
             <ThemeProvider>
@@ -49,7 +49,7 @@ export default function RootLayout({ children }) {
                   <ErrorBoundary>
                     <main
                       id="main-content"
-                      className="flex-1 container mx-auto px-4 py-8 max-w-7xl"
+                      className="flex-1 container mx-auto px-3 sm:px-4 py-8 max-w-7xl"
                     >
                       {children}
                     </main>

--- a/frontend/components/dashboard/StatWidgets.jsx
+++ b/frontend/components/dashboard/StatWidgets.jsx
@@ -21,8 +21,8 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
 function SkeletonCard() {
   return (
     <div className="card animate-pulse">
-      <div className="h-3 w-20 bg-gray-700 rounded mb-3" />
-      <div className="h-8 w-16 bg-gray-700 rounded" />
+      <div className="h-3 w-20 bg-gray-300 dark:bg-gray-700 rounded mb-3" />
+      <div className="h-8 w-16 bg-gray-300 dark:bg-gray-700 rounded" />
     </div>
   );
 }
@@ -54,7 +54,7 @@ function SuccessRateChart({ rate }) {
                 <Tooltip
                   formatter={(v) => [`${v}%`, 'Success']}
                   contentStyle={{
-                    background: '#1f2937',
+                    background: 'var(--color-bg-elevated, #1f2937)',
                     border: 'none',
                     borderRadius: 8,
                     fontSize: 12,

--- a/frontend/components/escrow/EscrowCard.jsx
+++ b/frontend/components/escrow/EscrowCard.jsx
@@ -61,7 +61,7 @@ export default function EscrowCard({ escrow, isLoading = false }) {
       {/* Header Row */}
       <div className="flex items-start justify-between gap-3 mb-3">
         <div className="flex-1 min-w-0">
-          <h3 className="text-white font-semibold truncate group-hover:text-indigo-400 transition-colors">
+          <h3 className="text-gray-900 dark:text-white font-semibold truncate group-hover:text-indigo-400 transition-colors">
             {title}
           </h3>
           <p className="text-xs text-gray-500 mt-0.5">
@@ -85,7 +85,7 @@ export default function EscrowCard({ escrow, isLoading = false }) {
           <span>{t('escrow.fields.milestones')}</span>
           <span>{milestoneProgress}</span>
         </div>
-        <div className="w-full h-2 bg-gray-800 rounded-full overflow-hidden shadow-inner">
+        <div className="w-full h-2 bg-gray-200 dark:bg-gray-800 rounded-full overflow-hidden shadow-inner">
           <div
             className="h-full bg-gradient-to-r from-indigo-500 to-purple-500 rounded-full transition-all duration-500 ease-out"
             style={{ width: `${progressPct}%` }}
@@ -95,7 +95,7 @@ export default function EscrowCard({ escrow, isLoading = false }) {
 
       {/* Transaction Hash */}
       {transactionHash && (
-        <div className="mt-3 pt-3 border-t border-gray-800">
+        <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-800">
           <div className="flex items-center justify-between gap-2">
             <span className="text-xs text-gray-500">TX:</span>
             <span className="text-xs font-mono text-gray-400 truncate">
@@ -109,7 +109,7 @@ export default function EscrowCard({ escrow, isLoading = false }) {
       )}
 
       {/* Footer */}
-      <div className="flex items-center justify-between mt-3 pt-3 border-t border-gray-800">
+      <div className="flex items-center justify-between mt-3 pt-3 border-t border-gray-200 dark:border-gray-800">
         <span className="text-xs text-gray-600">#{id}</span>
         <span
           className={`text-xs font-medium ${

--- a/frontend/components/layout/Header.jsx
+++ b/frontend/components/layout/Header.jsx
@@ -85,7 +85,7 @@ export default function Header() {
 
             {/* Hamburger — mobile only */}
             <button
-              className="md:hidden text-gray-400 hover:text-white p-1 rounded transition-colors"
+              className="md:hidden text-gray-400 hover:text-white p-1 rounded transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
               aria-label="Open navigation menu"
               aria-expanded={isMobileMenuOpen}
               onClick={() => setIsMobileMenuOpen(true)}
@@ -103,27 +103,6 @@ export default function Header() {
             </button>
           </div>
         </div>
-
-        {/* Mobile Nav */}
-        {isMobileMenuOpen && (
-          <nav className="md:hidden py-4 border-t border-gray-200 dark:border-gray-800 flex flex-col gap-4">
-            <Link
-              href="/dashboard"
-              className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors px-2"
-              onClick={() => setIsMobileMenuOpen(false)}
-            >
-              {t('nav.dashboard')}
-            </Link>
-            <Link
-              href="/explorer"
-              className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors px-2"
-              onClick={() => setIsMobileMenuOpen(false)}
-            >
-              {t('nav.explorer')}
-            </Link>
-          </nav>
-        )}
-      </div>
 
       <MobileDrawer isOpen={isMobileMenuOpen} onClose={() => setIsMobileMenuOpen(false)} />
     </header>

--- a/frontend/components/ui/Button.jsx
+++ b/frontend/components/ui/Button.jsx
@@ -11,9 +11,11 @@ import { cn } from '../../lib/utils';
 
 const variantClasses = {
   primary: 'bg-indigo-600 hover:bg-indigo-500 text-white border border-indigo-500',
-  secondary: 'bg-gray-800 hover:bg-gray-700 text-gray-300 border border-gray-700',
-  danger: 'bg-red-900/30 hover:bg-red-900/50 text-red-400 border border-red-800',
-  ghost: 'bg-transparent hover:bg-gray-800 text-gray-400 border border-transparent',
+  secondary:
+    'bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-700',
+  danger: 'bg-red-100 hover:bg-red-200 dark:bg-red-900/30 dark:hover:bg-red-900/50 text-red-600 dark:text-red-400 border border-red-300 dark:border-red-800',
+  ghost:
+    'bg-transparent hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400 border border-transparent',
 };
 
 const sizeClasses = {

--- a/frontend/components/ui/Modal.jsx
+++ b/frontend/components/ui/Modal.jsx
@@ -75,23 +75,23 @@ export default function Modal({
 
       {/* Panel */}
       <div
-        className={`relative w-full ${SIZE_CLASSES[size]} bg-gray-900 border border-gray-800
+        className={`relative w-full ${SIZE_CLASSES[size]} bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800
                     rounded-2xl shadow-2xl p-6 space-y-4`}
       >
         {/* Header */}
         <div className="flex items-start justify-between">
           {title && (
-            <h2 id="modal-title" className="text-lg font-semibold text-white">
+            <h2 id="modal-title" className="text-lg font-semibold text-gray-900 dark:text-white">
               {title}
             </h2>
           )}
           {/* Accessibility: aria-label describes action; focus-visible ring for keyboard users */}
           <button
             onClick={onClose}
-            className="ml-auto text-gray-500 hover:text-white transition-colors p-1 rounded-lg
-                       hover:bg-gray-800 focus:outline-none focus-visible:ring-2
+            className="ml-auto text-gray-500 hover:text-gray-900 dark:hover:text-white transition-colors p-1 rounded-lg
+                       hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus-visible:ring-2
                        focus-visible:ring-indigo-500 focus-visible:ring-offset-2
-                       focus-visible:ring-offset-gray-900"
+                       focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900"
             aria-label="Close modal"
             type="button"
           >
@@ -104,7 +104,7 @@ export default function Modal({
 
         {/* Footer with Confirmation Buttons */}
         {isConfirmation && (
-          <div className="flex flex-col sm:flex-row gap-3 pt-4 border-t border-gray-800">
+          <div className="flex flex-col sm:flex-row gap-3 pt-4 border-t border-gray-200 dark:border-gray-800">
             <Button variant="secondary" className="flex-1" onClick={onClose}>
               {cancelLabel}
             </Button>

--- a/frontend/components/ui/Skeleton.jsx
+++ b/frontend/components/ui/Skeleton.jsx
@@ -1,14 +1,14 @@
 import { clsx } from 'clsx';
 
 const Skeleton = ({ className, variant = 'text', ...props }) => {
-  const base = 'animate-pulse bg-gray-200 dark:bg-gray-700';
+  const base = variant === 'line' ? 'bg-gray-300 dark:bg-gray-600' : 'skeleton-shimmer';
 
   const variants = {
     text: 'h-4 w-[60%] rounded',
     heading: 'h-6 w-[70%] rounded-lg mb-2',
     card: 'h-32 rounded-xl',
     image: 'h-48 w-full rounded-xl',
-    line: 'h-px bg-gray-300 dark:bg-gray-600',
+    line: 'h-px',
     table: 'h-10 rounded',
   };
 

--- a/frontend/components/ui/Toast.jsx
+++ b/frontend/components/ui/Toast.jsx
@@ -30,9 +30,9 @@ export default function Toast({ message, type = 'success', onClose, duration = 4
   };
 
   const bgColors = {
-    success: 'bg-gray-900 border-green-500',
-    error: 'bg-gray-900 border-red-500',
-    info: 'bg-gray-900 border-blue-500',
+    success: 'bg-white dark:bg-gray-900 border-green-500',
+    error: 'bg-white dark:bg-gray-900 border-red-500',
+    info: 'bg-white dark:bg-gray-900 border-blue-500',
   };
 
   return (
@@ -42,10 +42,10 @@ export default function Toast({ message, type = 'success', onClose, duration = 4
       aria-live="assertive"
     >
       {icons[type]}
-      <p className="text-white text-sm font-medium">{message}</p>
+      <p className="text-gray-900 dark:text-white text-sm font-medium">{message}</p>
       <button
         onClick={onClose}
-        className="ml-2 text-gray-400 hover:text-white transition-colors"
+        className="ml-2 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
         aria-label="Close notification"
       >
         <X className="w-4 h-4" />

--- a/frontend/tests/forms/EscrowCreate.test.jsx
+++ b/frontend/tests/forms/EscrowCreate.test.jsx
@@ -1,15 +1,12 @@
 /**
- * Comprehensive form validation tests for the Create Escrow page.
+ * Comprehensive form validation tests for the Create Escrow page (5-step wizard).
  *
- * Covers:
- *  - Step navigation and guard behaviour
- *  - Step 1: Counterparty & Funds field validation
- *  - Step 2: Milestone validation (add / remove / amounts)
- *  - Step 3: Review summary accuracy
- *  - Step 4: Sign & Submit state
- *  - Template pre-fill
- *  - Edge cases (boundary values, special characters, whitespace)
- *  - Accessibility (labels, roles, axe)
+ * Steps:
+ *   1. Parties   — buyer (read-only) + seller address
+ *   2. Terms     — description + deadline
+ *   3. Amount    — token, total, milestones
+ *   4. Review    — summary
+ *   5. Confirm   — sign & submit
  */
 
 import { render, screen, fireEvent, within } from '@testing-library/react';
@@ -18,10 +15,8 @@ import CreateEscrowPage from '../../app/escrow/create/page';
 import { ToastProvider } from '../../contexts/ToastContext';
 import { useSearchParams } from 'next/navigation';
 
-// Extend expect with jest-axe matcher
 expect.extend(toHaveNoViolations);
 
-/** Render CreateEscrowPage wrapped in required providers. */
 function renderPage() {
   return render(
     <ToastProvider>
@@ -30,32 +25,30 @@ function renderPage() {
   );
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-/** Advance the form by `n` steps. */
+/** Advance the wizard by n steps (without validation). */
 function advanceSteps(n) {
   for (let i = 0; i < n; i++) {
     fireEvent.click(screen.getByRole('button', { name: /Next/i }));
   }
 }
 
-/** Fill Step 1 with valid data. */
-function _fillStep1({
-  address = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ',
-  amount = '1000',
-  token = 'usdc',
-} = {}) {
-  fireEvent.change(screen.getByPlaceholderText('GABCD1234...'), {
-    target: { value: address },
-  });
-  fireEvent.change(screen.getByPlaceholderText('0.00'), {
-    target: { value: amount },
-  });
-  const select = screen.getByLabelText(/^Token$/i);
-  fireEvent.change(select, { target: { value: token } });
+/** Fill Step 1 with a valid seller address so Next can advance. */
+const VALID_ADDRESS = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+function fillStep1(address = VALID_ADDRESS) {
+  fireEvent.change(screen.getByPlaceholderText('GABCD1234...'), { target: { value: address } });
 }
 
-// ── Setup ─────────────────────────────────────────────────────────────────────
+/** Fill Step 2 with valid description + deadline. */
+function fillStep2() {
+  fireEvent.change(screen.getByPlaceholderText(/Describe the project/i), {
+    target: { value: 'Build a decentralized escrow platform with milestones.' },
+  });
+  // Set deadline to tomorrow
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const iso = tomorrow.toISOString().slice(0, 10);
+  fireEvent.change(screen.getByLabelText(/Deadline/i), { target: { value: iso } });
+}
 
 beforeEach(() => {
   useSearchParams.mockReturnValue(new URLSearchParams());
@@ -67,7 +60,8 @@ beforeEach(() => {
 describe('Step navigation', () => {
   it('starts on step 1', () => {
     renderPage();
-    expect(screen.getByText('Counterparty & Funds')).toBeInTheDocument();
+    expect(screen.getByText('Parties')).toBeInTheDocument();
+    expect(screen.getByText(/Step 1 of 5/i)).toBeInTheDocument();
   });
 
   it('Back button is disabled on step 1', () => {
@@ -75,188 +69,206 @@ describe('Step navigation', () => {
     expect(screen.getByRole('button', { name: 'Back' })).toBeDisabled();
   });
 
-  it('Next advances through all four steps', () => {
+  it('shows step 2 label in progress indicator', () => {
     renderPage();
+    expect(screen.getByText('Terms')).toBeInTheDocument();
+    expect(screen.getByText('Amount')).toBeInTheDocument();
+    expect(screen.getByText('Review')).toBeInTheDocument();
+    expect(screen.getByText('Confirm')).toBeInTheDocument();
+  });
+
+  it('advancing without seller address shows validation error', () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    expect(screen.getByText(/Seller address is required/i)).toBeInTheDocument();
+    // Still on step 1
+    expect(screen.getByText(/Step 1 of 5/i)).toBeInTheDocument();
+  });
+
+  it('advances to step 2 with valid seller address', () => {
+    renderPage();
+    fillStep1();
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    expect(screen.getByText(/Step 2 of 5/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Project Description/i)).toBeInTheDocument();
+  });
+
+  it('step 2 validates description and deadline', () => {
+    renderPage();
+    fillStep1();
     advanceSteps(1);
-    expect(screen.getByText('Milestone 1')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    expect(screen.getByText(/at least 10 characters/i)).toBeInTheDocument();
+  });
+
+  it('advances through all 5 steps with valid data', () => {
+    renderPage();
+    fillStep1();
     advanceSteps(1);
+    fillStep2();
+    advanceSteps(1);
+    // Step 3: fill amount
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '1000' } });
+    advanceSteps(1);
+    // Step 4: Review
+    expect(screen.getByText(/Step 4 of 5/i)).toBeInTheDocument();
     expect(screen.getByText('Review Details')).toBeInTheDocument();
     advanceSteps(1);
-    expect(screen.getByText('Sign & Submit')).toBeInTheDocument();
+    // Step 5: Confirm
+    expect(screen.getByText(/Step 5 of 5/i)).toBeInTheDocument();
+    expect(screen.getByText('Confirm & Sign')).toBeInTheDocument();
   });
 
   it('Back returns to the previous step', () => {
     renderPage();
-    advanceSteps(2);
+    fillStep1();
+    advanceSteps(1);
+    expect(screen.getByText(/Step 2 of 5/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Back' }));
-    expect(screen.getByText('Milestone 1')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
-    expect(screen.getByText('Counterparty & Funds')).toBeInTheDocument();
+    expect(screen.getByText(/Step 1 of 5/i)).toBeInTheDocument();
   });
 
-  it('shows Sign & Create Escrow button only on step 4', () => {
+  it('shows Sign & Create Escrow button only on step 5', () => {
     renderPage();
     expect(screen.queryByRole('button', { name: /Sign & Create Escrow/i })).not.toBeInTheDocument();
-    advanceSteps(3);
+    // Get to step 5 with valid data
+    fillStep1();
+    advanceSteps(1);
+    fillStep2();
+    advanceSteps(1);
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '500' } });
+    advanceSteps(2);
     expect(screen.getByRole('button', { name: /Sign & Create Escrow/i })).toBeInTheDocument();
   });
 
-  it('step indicator highlights completed steps', () => {
+  it('step indicator shows completed steps', () => {
     renderPage();
-    advanceSteps(2);
-    // Steps 1 and 2 should be visually active (indigo), step 3 is current
-    expect(screen.getByText('Review Details')).toBeInTheDocument();
+    fillStep1();
+    advanceSteps(1);
+    expect(screen.getByText(/Step 2 of 5/i)).toBeInTheDocument();
   });
 });
 
-// ── 2. Step 1 — Counterparty & Funds ─────────────────────────────────────────
+// ── 2. Step 1 — Parties ───────────────────────────────────────────────────────
 
-describe('Step 1 — Counterparty & Funds', () => {
-  describe('Freelancer address field', () => {
-    it('renders the address input with correct placeholder', () => {
-      renderPage();
-      expect(screen.getByPlaceholderText('GABCD1234...')).toBeInTheDocument();
-    });
-
-    it('accepts a valid 56-char Stellar address starting with G', () => {
-      renderPage();
-      const input = screen.getByPlaceholderText('GABCD1234...');
-      const validAddress = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-      fireEvent.change(input, { target: { value: validAddress } });
-      expect(input).toHaveValue(validAddress);
-    });
-
-    it('accepts typed input character by character', () => {
-      renderPage();
-      const input = screen.getByPlaceholderText('GABCD1234...');
-      fireEvent.change(input, { target: { value: 'G' } });
-      expect(input).toHaveValue('G');
-    });
-
-    it('starts empty', () => {
-      renderPage();
-      expect(screen.getByPlaceholderText('GABCD1234...')).toHaveValue('');
-    });
-
-    it('handles whitespace-only input', () => {
-      renderPage();
-      const input = screen.getByPlaceholderText('GABCD1234...');
-      fireEvent.change(input, { target: { value: '   ' } });
-      expect(input).toHaveValue('');
-    });
-
-    it('handles very long input without crashing', () => {
-      renderPage();
-      const input = screen.getByPlaceholderText('GABCD1234...');
-      const longValue = 'G' + 'A'.repeat(200);
-      fireEvent.change(input, { target: { value: longValue } });
-      expect(input).toHaveValue(longValue);
-    });
-
-    it('handles special characters in address field', () => {
-      renderPage();
-      const input = screen.getByPlaceholderText('GABCD1234...');
-      fireEvent.change(input, { target: { value: '<script>alert(1)</script>' } });
-      expect(input).toHaveValue('<script>alert(1)</script>');
-    });
+describe('Step 1 — Parties', () => {
+  it('renders heading', () => {
+    renderPage();
+    expect(screen.getByRole('heading', { level: 2, name: /Parties/i })).toBeInTheDocument();
   });
 
-  describe('Token selector', () => {
-    it('defaults to USDC', () => {
-      renderPage();
-      // The token select is the first combobox in the step 1 form area
-      const selects = screen.getAllByRole('combobox');
-      const tokenSelect = selects.find((s) => s.value === 'usdc' || within(s).queryByText('USDC'));
-      expect(tokenSelect).toHaveValue('usdc');
-    });
-
-    it('can be changed to XLM', () => {
-      renderPage();
-      const selects = screen.getAllByRole('combobox');
-      const tokenSelect = selects.find((s) => within(s).queryByText('USDC'));
-      fireEvent.change(tokenSelect, { target: { value: 'xlm' } });
-      expect(tokenSelect).toHaveValue('xlm');
-    });
-
-    it('can be changed to Custom', () => {
-      renderPage();
-      const selects = screen.getAllByRole('combobox');
-      const tokenSelect = selects.find((s) => within(s).queryByText('USDC'));
-      fireEvent.change(tokenSelect, { target: { value: 'custom' } });
-      expect(tokenSelect).toHaveValue('custom');
-    });
-
-    it('offers USDC, XLM, and Custom options', () => {
-      renderPage();
-      const selects = screen.getAllByRole('combobox');
-      const tokenSelect = selects.find((s) => within(s).queryByText('USDC'));
-      const options = within(tokenSelect).getAllByRole('option');
-      const values = options.map((o) => o.value);
-      expect(values).toContain('usdc');
-      expect(values).toContain('xlm');
-      expect(values).toContain('custom');
-    });
+  it('shows buyer address read-only input', () => {
+    renderPage();
+    expect(screen.getByLabelText(/Buyer Stellar Address/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Buyer Stellar Address/i)).toHaveAttribute('readOnly');
   });
 
-  describe('Total Amount field', () => {
-    it('starts empty', () => {
-      renderPage();
-      expect(screen.getByPlaceholderText('0.00')).toHaveValue(null);
-    });
-
-    it('accepts a positive integer', () => {
-      renderPage();
-      const input = screen.getByPlaceholderText('0.00');
-      fireEvent.change(input, { target: { value: '5000' } });
-      expect(input).toHaveValue(5000);
-    });
-
-    it('accepts a decimal amount', () => {
-      renderPage();
-      const input = screen.getByPlaceholderText('0.00');
-      fireEvent.change(input, { target: { value: '99.99' } });
-      expect(input).toHaveValue(99.99);
-    });
-
-    it('accepts zero', () => {
-      renderPage();
-      const input = screen.getByPlaceholderText('0.00');
-      fireEvent.change(input, { target: { value: '0' } });
-      expect(input).toHaveValue(0);
-    });
-
-    it('is a number input type', () => {
-      renderPage();
-      expect(screen.getByPlaceholderText('0.00')).toHaveAttribute('type', 'number');
-    });
+  it('renders seller address input with placeholder', () => {
+    renderPage();
+    expect(screen.getByPlaceholderText('GABCD1234...')).toBeInTheDocument();
   });
 
-  describe('Project Brief field', () => {
-    it('is optional — renders with optional label', () => {
-      renderPage();
-      expect(screen.getByText(/optional/i)).toBeInTheDocument();
-    });
+  it('accepts a valid Stellar address', () => {
+    renderPage();
+    const input = screen.getByPlaceholderText('GABCD1234...');
+    fireEvent.change(input, { target: { value: VALID_ADDRESS } });
+    expect(input).toHaveValue(VALID_ADDRESS);
+  });
 
-    it('accepts multi-line text', () => {
-      renderPage();
-      const textarea = screen.getByPlaceholderText(/Briefly describe/i);
-      fireEvent.change(textarea, { target: { value: 'Line 1\nLine 2' } });
-      expect(textarea).toHaveValue('Line 1\nLine 2');
-    });
+  it('shows error for empty seller address on Next', () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    expect(screen.getByText(/Seller address is required/i)).toBeInTheDocument();
+  });
 
-    it('starts empty', () => {
-      renderPage();
-      expect(screen.getByPlaceholderText(/Briefly describe/i)).toHaveValue('');
-    });
+  it('clears error when valid address is entered and Next retried', () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    fillStep1();
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    expect(screen.queryByText(/Seller address is required/i)).not.toBeInTheDocument();
+  });
+
+  it('handles whitespace-only input', () => {
+    renderPage();
+    const input = screen.getByPlaceholderText('GABCD1234...');
+    fireEvent.change(input, { target: { value: '   ' } });
+    expect(input).toHaveValue('');
   });
 });
 
-// ── 3. Step 2 — Milestones ────────────────────────────────────────────────────
+// ── 3. Step 2 — Terms ─────────────────────────────────────────────────────────
 
-describe('Step 2 — Milestones', () => {
+describe('Step 2 — Terms', () => {
   beforeEach(() => {
     renderPage();
+    fillStep1();
     advanceSteps(1);
+  });
+
+  it('renders heading', () => {
+    expect(screen.getByRole('heading', { level: 2, name: /Terms/i })).toBeInTheDocument();
+  });
+
+  it('renders description textarea', () => {
+    expect(screen.getByPlaceholderText(/Describe the project/i)).toBeInTheDocument();
+  });
+
+  it('renders deadline input', () => {
+    expect(screen.getByLabelText(/Deadline/i)).toBeInTheDocument();
+  });
+
+  it('shows error when description is too short', () => {
+    fireEvent.change(screen.getByPlaceholderText(/Describe the project/i), {
+      target: { value: 'Short' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    expect(screen.getByText(/at least 10 characters/i)).toBeInTheDocument();
+  });
+
+  it('shows error when deadline is missing', () => {
+    fireEvent.change(screen.getByPlaceholderText(/Describe the project/i), {
+      target: { value: 'Valid description with enough chars.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    expect(screen.getByText(/Deadline is required/i)).toBeInTheDocument();
+  });
+
+  it('advances with valid description and future deadline', () => {
+    fillStep2();
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    expect(screen.getByText(/Step 3 of 5/i)).toBeInTheDocument();
+  });
+});
+
+// ── 4. Step 3 — Amount ────────────────────────────────────────────────────────
+
+describe('Step 3 — Amount', () => {
+  beforeEach(() => {
+    renderPage();
+    fillStep1();
+    advanceSteps(1);
+    fillStep2();
+    advanceSteps(1);
+  });
+
+  it('renders heading', () => {
+    expect(screen.getByRole('heading', { level: 2, name: /Amount/i })).toBeInTheDocument();
+  });
+
+  it('renders token selector defaulting to USDC', () => {
+    const selects = screen.getAllByRole('combobox');
+    const tokenSelect = selects.find((s) => within(s).queryByText('USDC'));
+    expect(tokenSelect).toHaveValue('usdc');
+  });
+
+  it('renders total amount input', () => {
+    expect(screen.getByPlaceholderText('0.00')).toBeInTheDocument();
+  });
+
+  it('shows validation error when amount is empty on Next', () => {
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }));
+    expect(screen.getByText(/Amount must be a positive number/i)).toBeInTheDocument();
   });
 
   it('starts with one milestone', () => {
@@ -268,60 +280,31 @@ describe('Step 2 — Milestones', () => {
     expect(screen.queryByRole('button', { name: /Remove/i })).not.toBeInTheDocument();
   });
 
-  it('adds a second milestone when + Add Milestone is clicked', () => {
+  it('adds a second milestone', () => {
     fireEvent.click(screen.getByRole('button', { name: /\+ Add Milestone/i }));
     expect(screen.getByText('Milestone 2')).toBeInTheDocument();
   });
 
-  it('shows Remove button once multiple milestones exist', () => {
-    fireEvent.click(screen.getByRole('button', { name: /\+ Add Milestone/i }));
-    expect(screen.getAllByRole('button', { name: /Remove/i })).toHaveLength(2);
-  });
-
-  it('removes a milestone when Remove is clicked', () => {
+  it('removes a milestone', () => {
     fireEvent.click(screen.getByRole('button', { name: /\+ Add Milestone/i }));
     fireEvent.click(screen.getAllByRole('button', { name: /Remove/i })[1]);
     expect(screen.queryByText('Milestone 2')).not.toBeInTheDocument();
-    expect(screen.getByText('Milestone 1')).toBeInTheDocument();
   });
 
-  it('never removes the last milestone — Remove disappears at 1', () => {
+  it('never removes the last milestone', () => {
     fireEvent.click(screen.getByRole('button', { name: /\+ Add Milestone/i }));
     fireEvent.click(screen.getAllByRole('button', { name: /Remove/i })[0]);
     expect(screen.queryByRole('button', { name: /Remove/i })).not.toBeInTheDocument();
     expect(screen.getByText('Milestone 1')).toBeInTheDocument();
   });
 
-  it('updates milestone title', () => {
-    const titleInput = screen.getByPlaceholderText(/Title \(e\.g\./i);
-    fireEvent.change(titleInput, { target: { value: 'Design Phase' } });
-    expect(titleInput).toHaveValue('Design Phase');
-  });
-
-  it('updates milestone description', () => {
-    const descInput = screen.getByPlaceholderText('Milestone description');
-    fireEvent.change(descInput, { target: { value: 'Deliver wireframes' } });
-    expect(descInput).toHaveValue('Deliver wireframes');
-  });
-
-  it('updates milestone amount', () => {
-    const amountInput = screen.getByPlaceholderText('Amount');
-    fireEvent.change(amountInput, { target: { value: '500' } });
-    expect(amountInput).toHaveValue(500);
-  });
-
-  it('milestone amount is a number input', () => {
-    expect(screen.getByPlaceholderText('Amount')).toHaveAttribute('type', 'number');
-  });
-
-  it('shows running total of milestone amounts', () => {
+  it('shows running total', () => {
     const amountInput = screen.getByPlaceholderText('Amount');
     fireEvent.change(amountInput, { target: { value: '300' } });
-    // Total display contains "300 / — USDC"
     expect(screen.getByText(/300\s*\/\s*—/)).toBeInTheDocument();
   });
 
-  it('sums multiple milestone amounts correctly', () => {
+  it('sums multiple milestone amounts', () => {
     fireEvent.click(screen.getByRole('button', { name: /\+ Add Milestone/i }));
     const amounts = screen.getAllByPlaceholderText('Amount');
     fireEvent.change(amounts[0], { target: { value: '400' } });
@@ -329,115 +312,92 @@ describe('Step 2 — Milestones', () => {
     expect(screen.getByText(/1000\s*\/\s*—/)).toBeInTheDocument();
   });
 
-  it('can add up to 5 milestones', () => {
-    for (let i = 1; i < 5; i++) {
-      fireEvent.click(screen.getByRole('button', { name: /\+ Add Milestone/i }));
-    }
-    expect(screen.getByText('Milestone 5')).toBeInTheDocument();
-  });
-
-  it('handles zero milestone amount', () => {
-    const amountInput = screen.getByPlaceholderText('Amount');
-    fireEvent.change(amountInput, { target: { value: '0' } });
-    expect(amountInput).toHaveValue(0);
-  });
-
-  it('handles decimal milestone amount', () => {
-    const amountInput = screen.getByPlaceholderText('Amount');
-    fireEvent.change(amountInput, { target: { value: '123.45' } });
-    expect(amountInput).toHaveValue(123.45);
-  });
-
-  it('shows token label next to milestone amount', () => {
-    // Default token is USDC
-    expect(screen.getByText('USDC')).toBeInTheDocument();
+  it('shows USDC token label', () => {
+    expect(screen.getAllByText('USDC').length).toBeGreaterThan(0);
   });
 });
 
-// ── 4. Step 3 — Review ────────────────────────────────────────────────────────
+// ── 5. Step 4 — Review ────────────────────────────────────────────────────────
 
-describe('Step 3 — Review', () => {
-  it('shows freelancer address entered in step 1', () => {
-    renderPage();
-    const address = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-    fireEvent.change(screen.getByPlaceholderText('GABCD1234...'), { target: { value: address } });
-    advanceSteps(2);
-    expect(screen.getByText(address)).toBeInTheDocument();
-  });
+describe('Step 4 — Review', () => {
+  const SELLER = VALID_ADDRESS;
 
-  it('shows total amount entered in step 1', () => {
+  function goToReview() {
     renderPage();
+    fillStep1(SELLER);
+    advanceSteps(1);
+    fillStep2();
+    advanceSteps(1);
     fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '2500' } });
-    advanceSteps(2);
-    // Review shows "Total Amount: 2500 USDC"
-    expect(screen.getByText(/Total Amount:/i).closest('p')).toHaveTextContent('2500');
-  });
-
-  it('shows correct milestone count', () => {
-    renderPage();
     advanceSteps(1);
-    fireEvent.click(screen.getByRole('button', { name: /\+ Add Milestone/i }));
-    advanceSteps(1);
-    // Review shows "Milestones: 2"
-    expect(screen.getByText(/Milestones:/i).closest('p')).toHaveTextContent('2');
+  }
+
+  it('renders Review Details heading', () => {
+    goToReview();
+    expect(screen.getByRole('heading', { level: 2, name: /Review Details/i })).toBeInTheDocument();
   });
 
-  it('shows dash when freelancer address is empty', () => {
-    renderPage();
-    advanceSteps(2);
-    // Empty address renders as "—"
-    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+  it('shows seller address', () => {
+    goToReview();
+    expect(screen.getByText(SELLER)).toBeInTheDocument();
   });
 
-  it('shows dash when total amount is empty', () => {
-    renderPage();
-    advanceSteps(2);
-    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+  it('shows total amount', () => {
+    goToReview();
+    expect(screen.getByText(/2500/)).toBeInTheDocument();
   });
 
-  it('shows the selected token in the warning text', () => {
-    renderPage();
-    const selects = screen.getAllByRole('combobox');
-    const tokenSelect = selects.find((s) => within(s).queryByText('USDC'));
-    fireEvent.change(tokenSelect, { target: { value: 'xlm' } });
-    advanceSteps(2);
-    // The warning text contains the token — check the warning paragraph specifically
-    expect(screen.getByText(/authorize locking/i).closest('p')).toHaveTextContent('XLM');
+  it('shows milestone count', () => {
+    goToReview();
+    expect(screen.getByText(/Milestones:/i).closest('p')).toHaveTextContent('1');
   });
 
-  it('shows the lock-funds warning', () => {
-    renderPage();
-    advanceSteps(2);
+  it('shows lock-funds warning', () => {
+    goToReview();
     expect(screen.getByText(/authorize locking/i)).toBeInTheDocument();
   });
+
+  it('shows token in lock warning', () => {
+    goToReview();
+    expect(screen.getByText(/authorize locking/i).closest('p')).toHaveTextContent('USDC');
+  });
 });
 
-// ── 5. Step 4 — Sign & Submit ─────────────────────────────────────────────────
+// ── 6. Step 5 — Confirm ───────────────────────────────────────────────────────
 
-describe('Step 4 — Sign & Submit', () => {
-  beforeEach(() => {
+describe('Step 5 — Confirm', () => {
+  function goToConfirm() {
     renderPage();
-    advanceSteps(3);
+    fillStep1();
+    advanceSteps(1);
+    fillStep2();
+    advanceSteps(1);
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '500' } });
+    advanceSteps(2);
+  }
+
+  it('renders Confirm & Sign heading', () => {
+    goToConfirm();
+    expect(screen.getByRole('heading', { level: 2, name: /Confirm & Sign/i })).toBeInTheDocument();
   });
 
-  it('renders the Sign & Submit heading', () => {
-    expect(screen.getByText('Sign & Submit')).toBeInTheDocument();
-  });
-
-  it('renders the Freighter wallet description', () => {
+  it('renders Freighter description', () => {
+    goToConfirm();
     expect(screen.getByText(/Freighter wallet/i)).toBeInTheDocument();
   });
 
-  it('renders the not-implemented notice', () => {
+  it('renders not-implemented notice', () => {
+    goToConfirm();
     expect(screen.getByText(/Issue #33/i)).toBeInTheDocument();
   });
 
-  it('Sign & Create Escrow button is enabled by default', () => {
-    expect(screen.getByRole('button', { name: /Sign & Create Escrow/i })).not.toBeDisabled();
+  it('Sign & Create Escrow button is present', () => {
+    goToConfirm();
+    expect(screen.getByRole('button', { name: /Sign & Create Escrow/i })).toBeInTheDocument();
   });
 });
 
-// ── 6. Template pre-fill ──────────────────────────────────────────────────────
+// ── 7. Template pre-fill ──────────────────────────────────────────────────────
 
 describe('Template pre-fill', () => {
   it('pre-fills total amount from a selected template', () => {
@@ -455,8 +415,10 @@ describe('Template pre-fill', () => {
   it('pre-fills milestones from a template', () => {
     renderPage();
     fireEvent.click(screen.getByRole('button', { name: 'Use This Template' }));
+    fillStep1();
     advanceSteps(1);
-    // Freelance Website Launch has 3 milestones
+    fillStep2();
+    advanceSteps(1);
     expect(screen.getByText('Milestone 3')).toBeInTheDocument();
   });
 
@@ -476,131 +438,122 @@ describe('Template pre-fill', () => {
   it('does not re-apply the same query param template on re-render', () => {
     useSearchParams.mockReturnValue(new URLSearchParams('template=retainer-monthly-support'));
     const { rerender } = renderPage();
-    // Manually change the amount to simulate user edit
     fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '9999' } });
     rerender(
       <ToastProvider>
         <CreateEscrowPage />
       </ToastProvider>,
     );
-    // Amount should remain user-edited, not reset to 5000
     expect(screen.getByDisplayValue('9999')).toBeInTheDocument();
   });
 });
 
-// ── 7. Edge cases ─────────────────────────────────────────────────────────────
+// ── 8. State preservation ─────────────────────────────────────────────────────
 
-describe('Edge cases', () => {
-  it('renders without crashing when all fields are empty', () => {
-    renderPage();
-    expect(screen.getByText('Counterparty & Funds')).toBeInTheDocument();
-  });
-
-  it('can navigate all steps with empty fields', () => {
-    renderPage();
-    advanceSteps(3);
-    expect(screen.getByText('Sign & Submit')).toBeInTheDocument();
-  });
-
-  it('milestone total shows 0 when no amounts entered', () => {
-    renderPage();
-    advanceSteps(1);
-    // Total display is split across elements: "0" + " / " + "—" + " USDC"
-    // Check the summary span contains "0"
-    const summary = screen.getByText(/Total:\s*0\s*\/\s*—\s*USDC/i);
-    expect(summary).toBeInTheDocument();
-  });
-
-  it('handles very large total amount', () => {
-    renderPage();
-    const input = screen.getByPlaceholderText('0.00');
-    fireEvent.change(input, { target: { value: '999999999' } });
-    expect(input).toHaveValue(999999999);
-  });
-
-  it('handles negative total amount input', () => {
-    renderPage();
-    const input = screen.getByPlaceholderText('0.00');
-    fireEvent.change(input, { target: { value: '-100' } });
-    expect(input).toHaveValue(-100);
-  });
-
-  it('handles unicode in project brief', () => {
-    renderPage();
-    const textarea = screen.getByPlaceholderText(/Briefly describe/i);
-    fireEvent.change(textarea, { target: { value: '日本語テスト 🚀' } });
-    expect(textarea).toHaveValue('日本語テスト 🚀');
-  });
-
-  it('handles unicode in milestone title', () => {
-    renderPage();
-    advanceSteps(1);
-    const titleInput = screen.getByPlaceholderText(/Title \(e\.g\./i);
-    fireEvent.change(titleInput, { target: { value: 'Étape 1 — Démarrage' } });
-    expect(titleInput).toHaveValue('Étape 1 — Démarrage');
-  });
-
-  it('milestone amount total stays correct after removing a milestone', () => {
-    renderPage();
-    advanceSteps(1);
-    fireEvent.click(screen.getByRole('button', { name: /\+ Add Milestone/i }));
-    const amounts = screen.getAllByPlaceholderText('Amount');
-    fireEvent.change(amounts[0], { target: { value: '300' } });
-    fireEvent.change(amounts[1], { target: { value: '700' } });
-    fireEvent.click(screen.getAllByRole('button', { name: /Remove/i })[1]);
-    // Only first milestone (300) remains — total shows "300 / — USDC"
-    expect(screen.getByText(/300\s*\/\s*—/)).toBeInTheDocument();
-  });
-
+describe('State preservation', () => {
   it('preserves step 1 data when navigating forward and back', () => {
     renderPage();
-    const address = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-    fireEvent.change(screen.getByPlaceholderText('GABCD1234...'), { target: { value: address } });
-    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '1500' } });
+    fillStep1(VALID_ADDRESS);
     advanceSteps(1);
     fireEvent.click(screen.getByRole('button', { name: 'Back' }));
-    expect(screen.getByPlaceholderText('GABCD1234...')).toHaveValue(address);
-    expect(screen.getByPlaceholderText('0.00')).toHaveValue(1500);
+    expect(screen.getByPlaceholderText('GABCD1234...')).toHaveValue(VALID_ADDRESS);
   });
 
-  it('preserves milestone data when navigating forward and back', () => {
+  it('preserves step 2 data when navigating back', () => {
     renderPage();
+    fillStep1();
+    advanceSteps(1);
+    const description = 'This is my project description for the escrow.';
+    fireEvent.change(screen.getByPlaceholderText(/Describe the project/i), {
+      target: { value: description },
+    });
+    fillStep2();
+    advanceSteps(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(screen.getByPlaceholderText(/Describe the project/i)).toHaveValue(description);
+  });
+
+  it('preserves milestone data when navigating back', () => {
+    renderPage();
+    fillStep1();
+    advanceSteps(1);
+    fillStep2();
     advanceSteps(1);
     fireEvent.change(screen.getByPlaceholderText(/Title \(e\.g\./i), {
       target: { value: 'My Milestone' },
     });
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '1000' } });
     advanceSteps(1);
     fireEvent.click(screen.getByRole('button', { name: 'Back' }));
     expect(screen.getByPlaceholderText(/Title \(e\.g\./i)).toHaveValue('My Milestone');
   });
 });
 
-// ── 8. Accessibility ──────────────────────────────────────────────────────────
+// ── 9. Edge cases ─────────────────────────────────────────────────────────────
 
-describe('Accessibility', () => {
-  it('step 1 — all inputs have associated labels', () => {
+describe('Edge cases', () => {
+  it('renders without crashing', () => {
     renderPage();
-    // Project Brief textarea has a label (uses htmlFor via aria)
-    expect(screen.getByPlaceholderText(/Briefly describe/i)).toBeInTheDocument();
-    // Total Amount and Freelancer Address labels are present in the DOM
-    expect(screen.getByText(/Total Amount/i)).toBeInTheDocument();
-    expect(screen.getByText(/Freelancer Stellar Address/i)).toBeInTheDocument();
-    // Token label is present
-    expect(screen.getByText(/^Token$/i)).toBeInTheDocument();
+    expect(screen.getByText(/Create New Escrow/i)).toBeInTheDocument();
   });
 
-  it('step 2 — Add Milestone button is accessible', () => {
+  it('milestone total shows 0 when no amounts entered', () => {
     renderPage();
+    fillStep1();
     advanceSteps(1);
-    expect(screen.getByRole('button', { name: /\+ Add Milestone/i })).toBeInTheDocument();
+    fillStep2();
+    advanceSteps(1);
+    expect(screen.getByText(/Total:\s*0\s*\/\s*—\s*USDC/i)).toBeInTheDocument();
   });
 
-  it('step 2 — Remove button has accessible name', () => {
+  it('handles very large total amount', () => {
     renderPage();
+    fillStep1();
+    advanceSteps(1);
+    fillStep2();
+    advanceSteps(1);
+    const input = screen.getByPlaceholderText('0.00');
+    fireEvent.change(input, { target: { value: '999999999' } });
+    expect(input).toHaveValue(999999999);
+  });
+
+  it('handles unicode in description', () => {
+    renderPage();
+    fillStep1();
+    advanceSteps(1);
+    const textarea = screen.getByPlaceholderText(/Describe the project/i);
+    fireEvent.change(textarea, { target: { value: '日本語テスト 🚀 with enough length here' } });
+    expect(textarea).toHaveValue('日本語テスト 🚀 with enough length here');
+  });
+
+  it('milestone amount total stays correct after removing a milestone', () => {
+    renderPage();
+    fillStep1();
+    advanceSteps(1);
+    fillStep2();
     advanceSteps(1);
     fireEvent.click(screen.getByRole('button', { name: /\+ Add Milestone/i }));
-    const removeButtons = screen.getAllByRole('button', { name: /Remove/i });
-    removeButtons.forEach((btn) => expect(btn).toBeInTheDocument());
+    const amounts = screen.getAllByPlaceholderText('Amount');
+    fireEvent.change(amounts[0], { target: { value: '300' } });
+    fireEvent.change(amounts[1], { target: { value: '700' } });
+    fireEvent.click(screen.getAllByRole('button', { name: /Remove/i })[1]);
+    expect(screen.getByText(/300\s*\/\s*—/)).toBeInTheDocument();
+  });
+});
+
+// ── 10. Accessibility ─────────────────────────────────────────────────────────
+
+describe('Accessibility', () => {
+  it('page heading is an h1', () => {
+    renderPage();
+    expect(
+      screen.getByRole('heading', { level: 1, name: /Create New Escrow/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('step 1 heading is h2', () => {
+    renderPage();
+    expect(screen.getByRole('heading', { level: 2, name: /Parties/i })).toBeInTheDocument();
   });
 
   it('navigation buttons have accessible names', () => {
@@ -609,74 +562,27 @@ describe('Accessibility', () => {
     expect(screen.getByRole('button', { name: /Next/i })).toBeInTheDocument();
   });
 
-  it('page heading is an h1', () => {
-    renderPage();
-    expect(
-      screen.getByRole('heading', { level: 1, name: /Create New Escrow/i }),
-    ).toBeInTheDocument();
-  });
-
-  it('step headings are h2', () => {
-    renderPage();
-    expect(
-      screen.getByRole('heading', { level: 2, name: /Counterparty & Funds/i }),
-    ).toBeInTheDocument();
+  it('step 1 has no axe violations', async () => {
+    const { container } = renderPage();
+    const results = await axe(container, {
+      rules: { 'nested-interactive': { enabled: false } },
+    });
+    expect(results).toHaveNoViolations();
   });
 
   it('step 2 heading is h2', () => {
     renderPage();
+    fillStep1();
     advanceSteps(1);
-    expect(screen.getByRole('heading', { level: 2, name: /Milestones/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /Terms/i })).toBeInTheDocument();
   });
 
   it('step 3 heading is h2', () => {
     renderPage();
-    advanceSteps(2);
-    expect(screen.getByRole('heading', { level: 2, name: /Review Details/i })).toBeInTheDocument();
-  });
-
-  it('step 4 heading is h2', () => {
-    renderPage();
-    advanceSteps(3);
-    expect(screen.getByRole('heading', { level: 2, name: /Sign & Submit/i })).toBeInTheDocument();
-  });
-
-  it('step 1 has no axe violations', async () => {
-    const { container } = renderPage();
-    const results = await axe(container, {
-      rules: {
-        // TemplateSelector has nested interactive controls (div[role=button] > button)
-        // tracked as a separate accessibility issue in TemplateSelector component
-        'nested-interactive': { enabled: false },
-      },
-    });
-    expect(results).toHaveNoViolations();
-  });
-
-  it('step 2 has no axe violations', async () => {
-    const { container } = renderPage();
+    fillStep1();
     advanceSteps(1);
-    const results = await axe(container, {
-      rules: { 'nested-interactive': { enabled: false } },
-    });
-    expect(results).toHaveNoViolations();
-  });
-
-  it('step 3 has no axe violations', async () => {
-    const { container } = renderPage();
-    advanceSteps(2);
-    const results = await axe(container, {
-      rules: { 'nested-interactive': { enabled: false } },
-    });
-    expect(results).toHaveNoViolations();
-  });
-
-  it('step 4 has no axe violations', async () => {
-    const { container } = renderPage();
-    advanceSteps(3);
-    const results = await axe(container, {
-      rules: { 'nested-interactive': { enabled: false } },
-    });
-    expect(results).toHaveNoViolations();
+    fillStep2();
+    advanceSteps(1);
+    expect(screen.getByRole('heading', { level: 2, name: /Amount/i })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
closes
closes
closes


## Escrow Creation Wizard (5 steps)
- Redesign create escrow page as a 5-step wizard: Parties → Terms → Amount → Review → Confirm
- Step 1 (Parties): buyer address auto-filled read-only from wallet, seller Stellar address input with format validation
- Step 2 (Terms): required project description (min 10 chars) and deadline field with past-date guard
- Step 3 (Amount): token selector, total amount, milestone planner (add/remove milestones with running total display)
- Step 4 (Review): full summary of all steps before signing
- Step 5 (Confirm): Freighter signing placeholder (Issue #33)
- Per-step validation blocks Next until errors are resolved; errors shown inline only after progression is attempted
- Progress indicator shows 'Step X of 5' and numbered circles with checkmarks for completed steps
- All form state preserved on Back navigation via React state
- Updated EscrowCreate.test.jsx to cover all 5 steps, validation guards, state preservation, template pre-fill, and accessibility

## Mobile-First Responsive Dashboard
- Dashboard escrow cards grid: md:grid-cols-2 → sm:grid-cols-2 so cards go two-up at 640 px, not only at 768 px
- Explorer escrow list grid updated to sm:grid-cols-2 for consistency
- layout.jsx main container: px-4 → px-3 sm:px-4 for tighter mobile padding at 375/390 px viewports
- Removed duplicate inline mobile nav from Header (MobileDrawer already handles it); hamburger button retains min-h/w-[44px] touch target
- StatWidgets SkeletonCard bg updated to bg-gray-300 dark:bg-gray-700 (was dark-only, broke in light mode)
- Escrow detail InfoCell grid already has sm:grid-cols-2 md:grid-cols-4

## Dark Mode
- Toast: hardcoded bg-gray-900 → bg-white dark:bg-gray-900; message text white → text-gray-900 dark:text-white; close button colour fixed
- Button secondary variant: dark-only bg-gray-800 → bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 with matching text and border for both themes
- Button ghost: bg-transparent hover:bg-gray-800 → hover:bg-gray-100 dark:hover:bg-gray-800 with light-mode text-gray-600
- Button danger: dark-only bg-red-900/30 → bg-red-100 dark:bg-red-900/30 with matching light-mode text and border
- Modal panel already had dark: variants; no changes needed
- EscrowCard borders and backgrounds already had dark: variants; minor light-mode text colour fix on role label

## Skeleton Loading States
- Escrow detail page: replace 'Loading escrow…' text with EscrowDetailSkeleton component that mirrors the real page layout (header, info grid, parties card, milestone list) using Skeleton component; only shown on initial fetch (isLoading && !fetchedEscrow)
- Explorer page: replace Spinner + text with 6× EscrowCardSkeleton cards in a responsive grid; imported EscrowCardSkeleton
- Admin disputes page: replace 'Loading…' text with 4× animated card skeletons that match the real dispute card shape
- Skeleton shimmer animation updated to work in both light and dark themes: light uses gray-200/300 gradient, dark uses gray-700/800; uses CSS class override for .dark and [data-theme='dark']

## Summary

Briefly describe what changed and why.

Closes #

## Changes

-
-
-

## Testing

List the exact commands you ran locally.

```bash
# Examples
cargo test --workspace
npm run test -w backend
npm run test -w frontend
npm run lint
```

## Review Notes

Call out any context reviewers should know:

- areas that need extra attention
- follow-up work or known limitations
- deployment or migration considerations

## Checklist

- [ ] Code compiles, or the updated docs reference working commands
- [ ] Tests were added or updated when behavior changed
- [ ] Linting and formatting were run
- [ ] Documentation was updated when needed
- [ ] No breaking changes, or they are clearly described
- [ ] Screenshots or recordings are included for UI changes
