### PR TITLE
feat(analytics): add analytics pipeline with Prometheus metrics and snapshot model

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["contracts/escrow_contract", "contracts/governance", "contracts/escrow_extensions", "contracts/shared", "contracts/reputation_staking", "contracts/escrow_ownership"]
+members = ["contracts/escrow_contract", "contracts/governance", "contracts/escrow_extensions", "contracts/shared", "contracts/reputation_staking"]
 resolver = "2"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["contracts/escrow_contract", "contracts/governance", "contracts/escrow_extensions", "contracts/shared", "contracts/reputation_staking"]
+members = ["contracts/escrow_contract", "contracts/governance", "contracts/insurance_contract", "contracts/escrow_extensions", "contracts/shared", "contracts/escrow_ownership"]
 resolver = "2"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
-members = ["contracts/escrow_contract", "contracts/governance", "contracts/escrow_extensions", "contracts/shared", "contracts/reputation_staking"]
-members = ["contracts/escrow_contract", "contracts/governance", "contracts/insurance_contract", "contracts/escrow_extensions", "contracts/shared", "contracts/escrow_ownership"]
+members = ["contracts/escrow_contract", "contracts/governance", "contracts/escrow_extensions", "contracts/shared", "contracts/reputation_staking", "contracts/escrow_ownership"]
 resolver = "2"
 
 [profile.release]

--- a/backend/api/routes/escrowRoutes.js
+++ b/backend/api/routes/escrowRoutes.js
@@ -4,6 +4,7 @@ import escrowController, {
   validateEscrowId,
   validatePagination,
 } from '../controllers/escrowController.js';
+import ownershipRoutes from './ownershipRoutes.js';
 import { cacheResponse, invalidateOn, TTL } from '../middleware/cache.js';
 import authMiddleware from '../middleware/auth.js';
 
@@ -80,10 +81,8 @@ router.get(
  * @route  GET /api/escrows/:id/audit/export
  */
 import { exportBundle } from '../controllers/auditController.js';
-router.get(
-  '/:id/audit/export',
-  validateEscrowId,
-  exportBundle,
-);
+router.get('/:id/audit/export', validateEscrowId, exportBundle);
+// Client-rights ownership transfer
+router.use('/:id/ownership', ownershipRoutes);
 
 export default router;

--- a/backend/database/schema.prisma
+++ b/backend/database/schema.prisma
@@ -872,4 +872,14 @@ model SystemConfig {
 
   @@index([key])
   @@map("system_config")
+model AnalyticsSnapshot {
+  id         String   @id @default(cuid())
+  snapshotAt DateTime @map("snapshot_at")
+  period     String   // '5min' | 'hourly' | 'daily'
+  metric     String
+  value      Float
+  labels     Json?
+
+  @@index([metric, period, snapshotAt])
+  @@map("analytics_snapshots")
 }

--- a/backend/database/schema.prisma
+++ b/backend/database/schema.prisma
@@ -872,6 +872,8 @@ model SystemConfig {
 
   @@index([key])
   @@map("system_config")
+}
+
 model AnalyticsSnapshot {
   id         String   @id @default(cuid())
   snapshotAt DateTime @map("snapshot_at")

--- a/backend/lib/metrics.js
+++ b/backend/lib/metrics.js
@@ -153,6 +153,55 @@ export const activeEscrowsGauge = new client.Gauge({
   registers: [register],
 });
 
+export const escrowsCompletedTotal = new client.Counter({
+  name: 'stellar_trust_escrows_completed_total',
+  help: 'Total number of escrows completed',
+  registers: [register],
+});
+
+export const escrowsCancelledTotal = new client.Counter({
+  name: 'stellar_trust_escrows_cancelled_total',
+  help: 'Total number of escrows cancelled',
+  registers: [register],
+});
+
+export const escrowVolumeUsd = new client.Gauge({
+  name: 'stellar_trust_escrow_volume_usd',
+  help: 'Cumulative escrow volume in USD-equivalent',
+  registers: [register],
+});
+
+export const disputeRateGauge = new client.Gauge({
+  name: 'stellar_trust_dispute_rate',
+  help: 'Rolling 30-day dispute rate (disputes / created)',
+  registers: [register],
+});
+
+export const feeRevenueTotal = new client.Gauge({
+  name: 'stellar_trust_fee_revenue_total',
+  help: 'Cumulative platform fee revenue in USD-equivalent',
+  registers: [register],
+});
+
+export const milestoneApprovalRateGauge = new client.Gauge({
+  name: 'stellar_trust_milestone_approval_rate',
+  help: 'Ratio of approved to submitted milestones',
+  registers: [register],
+});
+
+export const medianResolutionDaysGauge = new client.Gauge({
+  name: 'stellar_trust_median_resolution_days',
+  help: 'Median days from dispute raised to resolved (rolling 30d)',
+  registers: [register],
+});
+
+export const milestoneApprovalLatency = new client.Histogram({
+  name: 'stellar_trust_milestone_approval_seconds',
+  help: 'Time from milestone submission to approval in seconds',
+  buckets: [3_600, 86_400, 259_200, 604_800], // 1h, 1d, 3d, 7d
+  registers: [register],
+});
+
 // ── Circuit Breaker Metrics ───────────────────────────────────────────────────
 
 export const circuitBreakerState = new client.Gauge({

--- a/backend/server.js
+++ b/backend/server.js
@@ -43,6 +43,7 @@ import batchRoutes from './api/routes/batchRoutes.js';
 import webhookRoutes from './api/routes/webhookRoutes.js';
 import wellKnownRoutes from './api/routes/wellKnownRoutes.js';
 import webhooksV1Routes from './api/routes/webhooks.js';
+import metricsRoutes from './api/routes/metricsRoutes.js';
 import tenantMiddleware from './api/middleware/tenant.js';
 import templateRoutes from './api/routes/templateRoutes.js';
 import auditMiddleware from './api/middleware/audit.js';
@@ -73,6 +74,7 @@ import { syncFromPrisma, ensureIndex } from './services/reputationSearchService.
 import { createGateway } from './gateway/index.js';
 import queueDashboardRoutes from './api/routes/queueDashboardRoutes.js';
 import chatRoutes from './api/routes/chatRoutes.js';
+import { startAnalyticsWorker } from './workers/analyticsWorker.js';
 
 // Attach Prisma query instrumentation (metrics + traces)
 attachPrismaMetrics(prisma);
@@ -219,6 +221,8 @@ app.use('/api/batch', batchRoutes);
 app.use('/api/search', searchRoutes);
 app.use('/api/chat', chatRoutes);
 app.use('/api/v1/templates', templateRoutes);
+app.use('/api/analytics', analyticsRoutes);
+app.use('/metrics', metricsRoutes);
 app.use('/admin/queues', queueDashboardRoutes);
 app.use('/.well-known', wellKnownRoutes);
 app.use('/docs', docsRouter);
@@ -337,6 +341,9 @@ async function startServer() {
           Sentry.captureException(err, { tags: { component: 'indexer' } });
         });
         startRpcMonitor();
+
+        startAnalyticsWorker();
+        logger.info('[Analytics] Worker + cron started');
 
         // Reputation ES sync — ensure index + initial sync on startup
         ensureIndex().then(() =>

--- a/contracts/reputation_staking/Cargo.toml
+++ b/contracts/reputation_staking/Cargo.toml
@@ -3,7 +3,7 @@ name = "stellar-trust-reputation-staking"
 version = "0.1.0"
 edition = "2021"
 publish = false
-description = "On-chain reputation staking — bond tokens to qualify as arbiter, slash bond on disputed ruling"
+description = "On-chain reputation staking - bond tokens to qualify as arbiter, slash bond on disputed ruling"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
## Summary
- Adds `AnalyticsSnapshot` Prisma model for storing periodic analytics snapshots
- Introduces Prometheus counters for escrows completed/cancelled, volume (USD), and dispute rate gauge in `backend/lib/metrics.js`
- Wires analytics routes and ownership routes into `backend/api/routes/escrowRoutes.js` and `backend/server.js`

## Test plan
- [ ] `npx prisma db push` applies `AnalyticsSnapshot` model without errors
- [ ] `/api/analytics` routes return expected data shapes
- [ ] Prometheus metrics endpoint exposes the new counters

Closes #1469