### PR TITLE
feat(contracts+backend): implement escrow tokenization — transferable client-rights token per escrow with on-chain ownership indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,6 +1346,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellar-trust-escrow-ownership"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "stellar-trust-governance"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["contracts/escrow_contract", "contracts/governance", "contracts/escrow_extensions", "contracts/shared", "contracts/reputation_staking"]
+members = ["contracts/escrow_contract", "contracts/governance", "contracts/escrow_extensions", "contracts/shared", "contracts/reputation_staking", "contracts/escrow_ownership"]
 resolver = "2"
 
 [profile.release]

--- a/backend/api/controllers/ownershipController.js
+++ b/backend/api/controllers/ownershipController.js
@@ -1,0 +1,84 @@
+import prisma from '../../lib/prisma.js';
+import { stellarService } from '../../services/stellarService.js';
+import { createModuleLogger } from '../../config/logger.js';
+
+const log = createModuleLogger('ownershipController');
+
+const OWNERSHIP_CONTRACT_ID = process.env.OWNERSHIP_CONTRACT_ID || '';
+
+export async function getOwnership(req, res) {
+  const { id: escrowId } = req.params;
+  try {
+    const ownership = await prisma.escrowOwnership.findUnique({
+      where: { escrowId },
+    });
+    const transferLog = await prisma.ownershipTransferLog.findMany({
+      where: { escrowId },
+      orderBy: { createdAt: 'desc' },
+      take: 50,
+    });
+    res.json({ currentOwner: ownership?.currentOwner ?? null, pendingTransfer: null, transferLog });
+  } catch (err) {
+    log.error({ type: 'ownership_get_error', escrowId, err: err.message });
+    res.status(500).json({ error: 'Failed to fetch ownership' });
+  }
+}
+
+export async function offerTransfer(req, res) {
+  const { id: escrowId } = req.params;
+  const { newOwner } = req.body;
+  const caller = req.user?.address;
+
+  if (!newOwner) return res.status(400).json({ error: 'newOwner is required' });
+  if (!OWNERSHIP_CONTRACT_ID) return res.status(503).json({ error: 'Ownership contract not configured' });
+
+  try {
+    const xdr = await stellarService.buildContractCall({
+      contractId: OWNERSHIP_CONTRACT_ID,
+      method: 'offer_transfer',
+      args: [caller, BigInt(escrowId), newOwner],
+    });
+    res.json({ xdr });
+  } catch (err) {
+    log.error({ type: 'offer_transfer_error', escrowId, err: err.message });
+    res.status(500).json({ error: 'Failed to build offer_transfer XDR' });
+  }
+}
+
+export async function acceptTransfer(req, res) {
+  const { id: escrowId } = req.params;
+  const caller = req.user?.address;
+
+  if (!OWNERSHIP_CONTRACT_ID) return res.status(503).json({ error: 'Ownership contract not configured' });
+
+  try {
+    const xdr = await stellarService.buildContractCall({
+      contractId: OWNERSHIP_CONTRACT_ID,
+      method: 'accept_transfer',
+      args: [caller, BigInt(escrowId)],
+    });
+    res.json({ xdr });
+  } catch (err) {
+    log.error({ type: 'accept_transfer_error', escrowId, err: err.message });
+    res.status(500).json({ error: 'Failed to build accept_transfer XDR' });
+  }
+}
+
+export async function cancelTransfer(req, res) {
+  const { id: escrowId } = req.params;
+  const caller = req.user?.address;
+
+  if (!OWNERSHIP_CONTRACT_ID) return res.status(503).json({ error: 'Ownership contract not configured' });
+
+  try {
+    const xdr = await stellarService.buildContractCall({
+      contractId: OWNERSHIP_CONTRACT_ID,
+      method: 'cancel_transfer',
+      args: [caller, BigInt(escrowId)],
+    });
+    res.json({ xdr });
+  } catch (err) {
+    log.error({ type: 'cancel_transfer_error', escrowId, err: err.message });
+    res.status(500).json({ error: 'Failed to build cancel_transfer XDR' });
+  }
+}

--- a/backend/api/routes/ownershipRoutes.js
+++ b/backend/api/routes/ownershipRoutes.js
@@ -1,0 +1,16 @@
+import express from 'express';
+import {
+  getOwnership,
+  offerTransfer,
+  acceptTransfer,
+  cancelTransfer,
+} from '../controllers/ownershipController.js';
+
+const router = express.Router({ mergeParams: true });
+
+router.get('/', getOwnership);
+router.post('/offer', offerTransfer);
+router.post('/accept', acceptTransfer);
+router.post('/cancel', cancelTransfer);
+
+export default router;

--- a/backend/database/schema.prisma
+++ b/backend/database/schema.prisma
@@ -962,3 +962,31 @@ model AnalyticsSnapshot {
   @@index([metric, period, snapshotAt])
   @@map("analytics_snapshots")
 }
+
+model EscrowOwnership {
+  id            String    @id @default(cuid())
+  escrowId      String    @unique @map("escrow_id")
+  currentOwner  String    @map("current_owner")
+  previousOwner String?   @map("previous_owner")
+  transferredAt DateTime? @map("transferred_at")
+  txHash        String?   @map("tx_hash")
+  updatedAt     DateTime  @updatedAt @map("updated_at")
+
+  @@index([currentOwner])
+  @@map("escrow_ownership")
+}
+
+model OwnershipTransferLog {
+  id        String   @id @default(cuid())
+  escrowId  String   @map("escrow_id")
+  fromOwner String   @map("from_owner")
+  toOwner   String   @map("to_owner")
+  txHash    String   @map("tx_hash")
+  ledger    Int
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@index([escrowId])
+  @@index([fromOwner])
+  @@index([toOwner])
+  @@map("ownership_transfer_logs")
+}

--- a/backend/tests/ownershipIndexer.test.js
+++ b/backend/tests/ownershipIndexer.test.js
@@ -1,0 +1,74 @@
+import { jest } from '@jest/globals';
+
+const loggerMock = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+jest.unstable_mockModule('../config/logger.js', () => ({
+  createModuleLogger: () => loggerMock,
+}));
+
+const prismaMock = {
+  $transaction: jest.fn(),
+  escrowOwnership: { upsert: jest.fn() },
+  ownershipTransferLog: { create: jest.fn() },
+};
+jest.unstable_mockModule('../lib/prisma.js', () => ({ default: prismaMock }));
+
+const mockGetEvents = jest.fn();
+jest.unstable_mockModule('@stellar/stellar-sdk', () => ({
+  SorobanRpc: {
+    Server: jest.fn(() => ({ getEvents: mockGetEvents })),
+  },
+  scValToNative: jest.fn((v) => v),
+}));
+
+const { applyTransferAccepted, pollOwnershipEvents } = await import('../services/ownershipIndexer.js');
+
+describe('applyTransferAccepted', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('upserts EscrowOwnership and creates transfer log in a transaction', async () => {
+    prismaMock.$transaction.mockResolvedValue([]);
+
+    await applyTransferAccepted({
+      escrowId: 'esc-1',
+      from: 'GFROM',
+      to: 'GTO',
+      txHash: 'abc123',
+      ledger: 100,
+    });
+
+    expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+    const [ops] = prismaMock.$transaction.mock.calls[0];
+    expect(ops).toHaveLength(2);
+  });
+});
+
+describe('pollOwnershipEvents', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('skips polling when OWNERSHIP_CONTRACT_ID is not set', async () => {
+    delete process.env.OWNERSHIP_CONTRACT_ID;
+    await pollOwnershipEvents(1000);
+    expect(mockGetEvents).not.toHaveBeenCalled();
+  });
+
+  it('processes TransferAccepted events and stops when fewer than limit returned', async () => {
+    process.env.OWNERSHIP_CONTRACT_ID = 'CCONTRACT';
+    prismaMock.$transaction.mockResolvedValue([]);
+
+    mockGetEvents.mockResolvedValue({
+      events: [
+        {
+          topic: ['own_acc', '42'],
+          value: ['GFROM', 'GTO'],
+          txHash: 'tx1',
+          ledger: '200',
+        },
+      ],
+      cursor: null,
+    });
+
+    await pollOwnershipEvents(1000);
+
+    expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/contracts/escrow_ownership/Cargo.toml
+++ b/contracts/escrow_ownership/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "stellar-trust-escrow-ownership"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "EscrowOwnership contract - tracks and transfers client-rights for each escrow"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { version = "21.0.0", features = [] }
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/contracts/escrow_ownership/src/errors.rs
+++ b/contracts/escrow_ownership/src/errors.rs
@@ -1,0 +1,19 @@
+use soroban_sdk::contracterror;
+
+#[contracterror(export = false)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum OwnershipError {
+    /// Caller is not the current owner.
+    NotOwner = 1,
+    /// accept_transfer called by an address that is not the pending recipient.
+    NotPendingRecipient = 2,
+    /// accept_transfer called when no transfer offer is pending.
+    NoPendingTransfer = 3,
+    /// register called by an address other than the authorised escrow contract.
+    Unauthorized = 4,
+    /// Escrow has already been registered.
+    AlreadyRegistered = 5,
+    /// Escrow not found.
+    NotFound = 6,
+}

--- a/contracts/escrow_ownership/src/events.rs
+++ b/contracts/escrow_ownership/src/events.rs
@@ -1,0 +1,29 @@
+use soroban_sdk::{symbol_short, Address, Env};
+
+pub fn ownership_registered(env: &Env, escrow_id: u64, owner: &Address) {
+    env.events().publish(
+        (symbol_short!("own_reg"), escrow_id),
+        owner.clone(),
+    );
+}
+
+pub fn transfer_offered(env: &Env, escrow_id: u64, from: &Address, to: &Address) {
+    env.events().publish(
+        (symbol_short!("own_off"), escrow_id),
+        (from.clone(), to.clone()),
+    );
+}
+
+pub fn transfer_accepted(env: &Env, escrow_id: u64, from: &Address, to: &Address) {
+    env.events().publish(
+        (symbol_short!("own_acc"), escrow_id),
+        (from.clone(), to.clone()),
+    );
+}
+
+pub fn transfer_cancelled(env: &Env, escrow_id: u64, by: &Address) {
+    env.events().publish(
+        (symbol_short!("own_can"), escrow_id),
+        by.clone(),
+    );
+}

--- a/contracts/escrow_ownership/src/events.rs
+++ b/contracts/escrow_ownership/src/events.rs
@@ -1,10 +1,8 @@
 use soroban_sdk::{symbol_short, Address, Env};
 
 pub fn ownership_registered(env: &Env, escrow_id: u64, owner: &Address) {
-    env.events().publish(
-        (symbol_short!("own_reg"), escrow_id),
-        owner.clone(),
-    );
+    env.events()
+        .publish((symbol_short!("own_reg"), escrow_id), owner.clone());
 }
 
 pub fn transfer_offered(env: &Env, escrow_id: u64, from: &Address, to: &Address) {
@@ -22,8 +20,6 @@ pub fn transfer_accepted(env: &Env, escrow_id: u64, from: &Address, to: &Address
 }
 
 pub fn transfer_cancelled(env: &Env, escrow_id: u64, by: &Address) {
-    env.events().publish(
-        (symbol_short!("own_can"), escrow_id),
-        by.clone(),
-    );
+    env.events()
+        .publish((symbol_short!("own_can"), escrow_id), by.clone());
 }

--- a/contracts/escrow_ownership/src/lib.rs
+++ b/contracts/escrow_ownership/src/lib.rs
@@ -1,0 +1,115 @@
+#![no_std]
+
+mod errors;
+mod events;
+mod storage;
+
+#[cfg(test)]
+mod tests;
+
+use errors::OwnershipError;
+use soroban_sdk::{contract, contractimpl, Address, Env};
+use storage::{
+    clear_pending, get_escrow_contract, get_owner, get_pending, set_escrow_contract, set_owner,
+    set_pending,
+};
+
+#[contract]
+pub struct EscrowOwnershipContract;
+
+#[contractimpl]
+impl EscrowOwnershipContract {
+    /// One-time initialisation: records which contract address is allowed to call `register`.
+    pub fn init(env: Env, escrow_contract: Address) {
+        if get_escrow_contract(&env).is_some() {
+            panic!("already initialised");
+        }
+        set_escrow_contract(&env, &escrow_contract);
+    }
+
+    /// Register ownership for a newly created escrow.
+    /// Only the authorised escrow_contract may call this.
+    pub fn register(
+        env: Env,
+        escrow_id: u64,
+        initial_owner: Address,
+    ) -> Result<(), OwnershipError> {
+        let allowed = get_escrow_contract(&env).ok_or(OwnershipError::Unauthorized)?;
+        allowed.require_auth();
+
+        if get_owner(&env, escrow_id).is_some() {
+            return Err(OwnershipError::AlreadyRegistered);
+        }
+
+        set_owner(&env, escrow_id, &initial_owner);
+        events::ownership_registered(&env, escrow_id, &initial_owner);
+        Ok(())
+    }
+
+    /// Current owner initiates a transfer to new_owner.
+    pub fn offer_transfer(
+        env: Env,
+        current_owner: Address,
+        escrow_id: u64,
+        new_owner: Address,
+    ) -> Result<(), OwnershipError> {
+        current_owner.require_auth();
+
+        let owner = get_owner(&env, escrow_id).ok_or(OwnershipError::NotFound)?;
+        if owner != current_owner {
+            return Err(OwnershipError::NotOwner);
+        }
+
+        set_pending(&env, escrow_id, &new_owner);
+        events::transfer_offered(&env, escrow_id, &current_owner, &new_owner);
+        Ok(())
+    }
+
+    /// Pending recipient confirms the transfer, completing ownership change.
+    pub fn accept_transfer(
+        env: Env,
+        new_owner: Address,
+        escrow_id: u64,
+    ) -> Result<(), OwnershipError> {
+        new_owner.require_auth();
+
+        let pending = get_pending(&env, escrow_id).ok_or(OwnershipError::NoPendingTransfer)?;
+        if pending != new_owner {
+            return Err(OwnershipError::NotPendingRecipient);
+        }
+
+        let old_owner = get_owner(&env, escrow_id).ok_or(OwnershipError::NotFound)?;
+        set_owner(&env, escrow_id, &new_owner);
+        clear_pending(&env, escrow_id);
+        events::transfer_accepted(&env, escrow_id, &old_owner, &new_owner);
+        Ok(())
+    }
+
+    /// Current owner cancels a pending transfer offer.
+    pub fn cancel_transfer(
+        env: Env,
+        current_owner: Address,
+        escrow_id: u64,
+    ) -> Result<(), OwnershipError> {
+        current_owner.require_auth();
+
+        let owner = get_owner(&env, escrow_id).ok_or(OwnershipError::NotFound)?;
+        if owner != current_owner {
+            return Err(OwnershipError::NotOwner);
+        }
+
+        clear_pending(&env, escrow_id);
+        events::transfer_cancelled(&env, escrow_id, &current_owner);
+        Ok(())
+    }
+
+    /// Returns the current client-rights holder for escrow_id.
+    pub fn get_owner(env: Env, escrow_id: u64) -> Result<Address, OwnershipError> {
+        get_owner(&env, escrow_id).ok_or(OwnershipError::NotFound)
+    }
+
+    /// Returns the pending new owner, or None if no offer is active.
+    pub fn pending_transfer(env: Env, escrow_id: u64) -> Option<Address> {
+        get_pending(&env, escrow_id)
+    }
+}

--- a/contracts/escrow_ownership/src/storage.rs
+++ b/contracts/escrow_ownership/src/storage.rs
@@ -48,13 +48,9 @@ pub fn clear_pending(env: &soroban_sdk::Env, escrow_id: u64) {
 }
 
 pub fn get_escrow_contract(env: &soroban_sdk::Env) -> Option<Address> {
-    env.storage()
-        .instance()
-        .get(&DataKey::EscrowContract)
+    env.storage().instance().get(&DataKey::EscrowContract)
 }
 
 pub fn set_escrow_contract(env: &soroban_sdk::Env, addr: &Address) {
-    env.storage()
-        .instance()
-        .set(&DataKey::EscrowContract, addr);
+    env.storage().instance().set(&DataKey::EscrowContract, addr);
 }

--- a/contracts/escrow_ownership/src/storage.rs
+++ b/contracts/escrow_ownership/src/storage.rs
@@ -1,0 +1,60 @@
+use soroban_sdk::{contracttype, Address};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    /// Authorised escrow contract address (set once at init).
+    EscrowContract,
+    /// Current client-rights holder for the given escrow_id.
+    Owner(u64),
+    /// Address that has accepted (or been offered) a pending transfer.
+    PendingTransfer(u64),
+}
+
+const LEDGERS_TO_LIVE: u32 = 518400; // ~30 days at 5s/ledger
+
+pub fn bump(env: &soroban_sdk::Env, key: &DataKey) {
+    env.storage()
+        .persistent()
+        .extend_ttl(key, LEDGERS_TO_LIVE, LEDGERS_TO_LIVE);
+}
+
+pub fn get_owner(env: &soroban_sdk::Env, escrow_id: u64) -> Option<Address> {
+    env.storage().persistent().get(&DataKey::Owner(escrow_id))
+}
+
+pub fn set_owner(env: &soroban_sdk::Env, escrow_id: u64, owner: &Address) {
+    let key = DataKey::Owner(escrow_id);
+    env.storage().persistent().set(&key, owner);
+    bump(env, &key);
+}
+
+pub fn get_pending(env: &soroban_sdk::Env, escrow_id: u64) -> Option<Address> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::PendingTransfer(escrow_id))
+}
+
+pub fn set_pending(env: &soroban_sdk::Env, escrow_id: u64, addr: &Address) {
+    let key = DataKey::PendingTransfer(escrow_id);
+    env.storage().persistent().set(&key, addr);
+    bump(env, &key);
+}
+
+pub fn clear_pending(env: &soroban_sdk::Env, escrow_id: u64) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::PendingTransfer(escrow_id));
+}
+
+pub fn get_escrow_contract(env: &soroban_sdk::Env) -> Option<Address> {
+    env.storage()
+        .instance()
+        .get(&DataKey::EscrowContract)
+}
+
+pub fn set_escrow_contract(env: &soroban_sdk::Env, addr: &Address) {
+    env.storage()
+        .instance()
+        .set(&DataKey::EscrowContract, addr);
+}

--- a/contracts/escrow_ownership/src/tests.rs
+++ b/contracts/escrow_ownership/src/tests.rs
@@ -1,0 +1,94 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation},
+    Address, Env,
+};
+
+fn setup() -> (Env, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, EscrowOwnershipContract);
+    let escrow_contract_addr = Address::generate(&env);
+    let client = EscrowOwnershipContractClient::new(&env, &contract_id);
+    client.init(&escrow_contract_addr);
+    (env, contract_id, escrow_contract_addr)
+}
+
+#[test]
+fn register_and_get_owner() {
+    let (env, contract_id, escrow_contract) = setup();
+    let client = EscrowOwnershipContractClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+
+    client.register(&1u64, &owner);
+    assert_eq!(client.get_owner(&1u64), owner);
+}
+
+#[test]
+fn offer_and_accept_transfer() {
+    let (env, contract_id, _) = setup();
+    let client = EscrowOwnershipContractClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+
+    client.register(&2u64, &owner);
+    client.offer_transfer(&owner, &2u64, &new_owner);
+    assert_eq!(client.pending_transfer(&2u64), Some(new_owner.clone()));
+
+    client.accept_transfer(&new_owner, &2u64);
+    assert_eq!(client.get_owner(&2u64), new_owner);
+    assert_eq!(client.pending_transfer(&2u64), None);
+}
+
+#[test]
+fn cancel_transfer() {
+    let (env, contract_id, _) = setup();
+    let client = EscrowOwnershipContractClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+
+    client.register(&3u64, &owner);
+    client.offer_transfer(&owner, &3u64, &new_owner);
+    client.cancel_transfer(&owner, &3u64);
+    assert_eq!(client.pending_transfer(&3u64), None);
+    assert_eq!(client.get_owner(&3u64), owner);
+}
+
+#[test]
+#[should_panic]
+fn wrong_recipient_cannot_accept() {
+    let (env, contract_id, _) = setup();
+    let client = EscrowOwnershipContractClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    let intended = Address::generate(&env);
+    let interloper = Address::generate(&env);
+
+    client.register(&4u64, &owner);
+    client.offer_transfer(&owner, &4u64, &intended);
+    client.accept_transfer(&interloper, &4u64);
+}
+
+#[test]
+#[should_panic]
+fn non_owner_cannot_offer() {
+    let (env, contract_id, _) = setup();
+    let client = EscrowOwnershipContractClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    client.register(&5u64, &owner);
+    client.offer_transfer(&attacker, &5u64, &attacker);
+}
+
+#[test]
+#[should_panic]
+fn double_register_fails() {
+    let (env, contract_id, _) = setup();
+    let client = EscrowOwnershipContractClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+
+    client.register(&6u64, &owner);
+    client.register(&6u64, &owner);
+}

--- a/contracts/escrow_ownership/src/tests.rs
+++ b/contracts/escrow_ownership/src/tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use soroban_sdk::{
-    testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation},
+    testutils::Address as _,
     Address, Env,
 };
 
@@ -18,7 +18,7 @@ fn setup() -> (Env, Address, Address) {
 
 #[test]
 fn register_and_get_owner() {
-    let (env, contract_id, escrow_contract) = setup();
+    let (env, contract_id, _escrow_contract) = setup();
     let client = EscrowOwnershipContractClient::new(&env, &contract_id);
     let owner = Address::generate(&env);
 

--- a/contracts/escrow_ownership/src/tests.rs
+++ b/contracts/escrow_ownership/src/tests.rs
@@ -1,10 +1,7 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{
-    testutils::Address as _,
-    Address, Env,
-};
+use soroban_sdk::{testutils::Address as _, Address, Env};
 
 fn setup() -> (Env, Address, Address) {
     let env = Env::default();

--- a/frontend/components/escrow/OwnershipPanel.tsx
+++ b/frontend/components/escrow/OwnershipPanel.tsx
@@ -89,7 +89,7 @@ export function OwnershipPanel({
             >
               {truncate(data.currentOwner)}
             </span>
-            <CopyButton value={data.currentOwner} label="address" />
+            <CopyButton text={data.currentOwner} value={data.currentOwner} label="address" />
           </>
         ) : (
           <span className="text-gray-400 italic">Not registered</span>

--- a/frontend/components/escrow/OwnershipPanel.tsx
+++ b/frontend/components/escrow/OwnershipPanel.tsx
@@ -1,0 +1,191 @@
+'use client';
+import { useState } from 'react';
+import { CopyButton } from '../ui/CopyButton';
+
+interface TransferLog {
+  id: string;
+  fromOwner: string;
+  toOwner: string;
+  txHash: string;
+  createdAt: string;
+}
+
+interface OwnershipData {
+  currentOwner: string | null;
+  pendingTransfer: string | null;
+  transferLog: TransferLog[];
+}
+
+interface Props {
+  escrowId: string;
+  data: OwnershipData;
+  currentUserAddress?: string;
+  onOfferTransfer: (newOwner: string) => Promise<void>;
+  onAcceptTransfer: () => Promise<void>;
+  onCancelTransfer: () => Promise<void>;
+}
+
+function truncate(addr: string) {
+  if (addr.length <= 12) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+export function OwnershipPanel({
+  escrowId,
+  data,
+  currentUserAddress,
+  onOfferTransfer,
+  onAcceptTransfer,
+  onCancelTransfer,
+}: Props) {
+  const [showTransferModal, setShowTransferModal] = useState(false);
+  const [newOwnerInput, setNewOwnerInput] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const isOwner = currentUserAddress && data.currentOwner === currentUserAddress;
+  const isPendingRecipient = currentUserAddress && data.pendingTransfer === currentUserAddress;
+
+  async function handleOffer() {
+    if (!newOwnerInput.trim()) return;
+    setBusy(true);
+    try {
+      await onOfferTransfer(newOwnerInput.trim());
+      setShowTransferModal(false);
+      setNewOwnerInput('');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleAccept() {
+    setBusy(true);
+    try {
+      await onAcceptTransfer();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleCancel() {
+    setBusy(true);
+    try {
+      await onCancelTransfer();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="rounded-xl border border-gray-200 dark:border-gray-700 p-4 space-y-3">
+      <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Client Rights</h3>
+
+      <div className="flex items-center gap-2 text-sm">
+        <span className="text-gray-500 dark:text-gray-400">Owner:</span>
+        {data.currentOwner ? (
+          <>
+            <span
+              title={data.currentOwner}
+              className="font-mono text-gray-800 dark:text-gray-200"
+            >
+              {truncate(data.currentOwner)}
+            </span>
+            <CopyButton value={data.currentOwner} label="address" />
+          </>
+        ) : (
+          <span className="text-gray-400 italic">Not registered</span>
+        )}
+      </div>
+
+      {data.pendingTransfer && (
+        <div className="rounded-md bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-300 dark:border-yellow-700 px-3 py-2 text-xs space-y-1">
+          <p className="text-yellow-800 dark:text-yellow-200">
+            Transfer pending — waiting for{' '}
+            <span className="font-mono" title={data.pendingTransfer}>
+              {truncate(data.pendingTransfer)}
+            </span>
+          </p>
+          {isPendingRecipient && (
+            <button
+              onClick={handleAccept}
+              disabled={busy}
+              className="text-xs px-2 py-1 rounded bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
+            >
+              Accept transfer
+            </button>
+          )}
+          {isOwner && (
+            <button
+              onClick={handleCancel}
+              disabled={busy}
+              className="text-xs px-2 py-1 rounded bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 hover:bg-red-200 disabled:opacity-50 ml-2"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+      )}
+
+      {isOwner && !data.pendingTransfer && (
+        <button
+          onClick={() => setShowTransferModal(true)}
+          className="text-xs px-3 py-1 rounded-md border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300"
+        >
+          Transfer rights
+        </button>
+      )}
+
+      {showTransferModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl p-6 w-full max-w-md space-y-4">
+            <h4 className="font-semibold text-gray-800 dark:text-gray-200">Transfer client rights</h4>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Enter the Stellar address that will receive ownership of escrow {escrowId}.
+            </p>
+            <input
+              type="text"
+              value={newOwnerInput}
+              onChange={(e) => setNewOwnerInput(e.target.value)}
+              placeholder="G..."
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => { setShowTransferModal(false); setNewOwnerInput(''); }}
+                className="px-4 py-2 text-sm rounded-md border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleOffer}
+                disabled={busy || !newOwnerInput.trim()}
+                className="px-4 py-2 text-sm rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                {busy ? 'Sending…' : 'Offer transfer'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {data.transferLog.length > 0 && (
+        <details className="text-xs">
+          <summary className="cursor-pointer text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
+            Transfer history ({data.transferLog.length})
+          </summary>
+          <ul className="mt-2 space-y-1">
+            {data.transferLog.map((entry) => (
+              <li key={entry.id} className="flex items-center gap-1 text-gray-600 dark:text-gray-400">
+                <span className="font-mono" title={entry.fromOwner}>{truncate(entry.fromOwner)}</span>
+                <span>→</span>
+                <span className="font-mono" title={entry.toOwner}>{truncate(entry.toOwner)}</span>
+                <span className="text-gray-400 ml-1">{new Date(entry.createdAt).toLocaleDateString()}</span>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </section>
+  );
+}
+
+export default OwnershipPanel;


### PR DESCRIPTION
## Summary

Implements transferable client-rights (escrow ownership token) on Soroban, a backend ownership indexer, and a frontend ownership panel.

- New standalone `escrow_ownership` Soroban contract with register/offer/accept/cancel/view entry points
- Backend REST API for building XDR for ownership transfers (client signs off-chain)
- `EscrowOwnership` and `OwnershipTransferLog` Prisma models
- `OwnershipPanel` React component showing current owner, pending transfers, and transfer history
- Unit tests for `ownershipIndexer` service

## Contracts

- `contracts/escrow_ownership/src/lib.rs` — `register`, `offer_transfer`, `accept_transfer`, `cancel_transfer`, `get_owner`, `pending_transfer`
- Events: `own_reg`, `own_off`, `own_acc`, `own_can`
- Errors: `NotOwner`, `NotPendingRecipient`, `NoPendingTransfer`, `Unauthorized`, `AlreadyRegistered`, `NotFound`
- `contracts/escrow_ownership/src/tests.rs` — happy path, wrong-recipient, non-owner, double-register guards

## Backend

- `backend/api/controllers/ownershipController.js` — builds Soroban XDR for each operation; returns to client for signing
- `backend/api/routes/ownershipRoutes.js` — mounted at `/:id/ownership` via escrowRoutes
- `backend/database/schema.prisma` — `EscrowOwnership` (current owner, previous owner, timestamps) and `OwnershipTransferLog` (per-transfer audit trail)
- `backend/tests/ownershipIndexer.test.js` — unit tests for `applyTransferAccepted` and `pollOwnershipEvents`

## Frontend

- `frontend/components/escrow/OwnershipPanel.tsx` — shows current owner, pending transfer badge with accept/cancel, transfer offer modal, collapsible transfer history

## Test plan

- [ ] `cargo test -p stellar-trust-escrow-ownership` — all 6 unit tests pass
- [ ] Backend: `npm test backend/tests/ownershipIndexer.test.js` passes
- [ ] `OWNERSHIP_CONTRACT_ID` env var controls whether indexer polls; skips gracefully when unset
- [ ] `GET /api/v1/escrows/:id/ownership` returns `{ currentOwner, pendingTransfer, transferLog }`
- [ ] Offer → accept flow changes owner and clears pending
- [ ] Offer → cancel flow clears pending without changing owner

Closes #1465