### PR TITLE
fix(backend): repair adminController.js parse errors and migration subscription_id bug

### DIFF
--- a/backend/api/controllers/adminController.js
+++ b/backend/api/controllers/adminController.js
@@ -11,19 +11,11 @@ import prisma from '../../lib/prisma.js';
 import { TIER_LIMITS } from '../../config/rateLimits.js';
 import { logControllerError, getLogger } from '../../config/logger.js';
 import { getUserUsage } from '../middleware/rateLimiter.js';
+import cache from '../../lib/cache.js';
+import { buildPaginatedResponse, parsePagination } from '../../lib/pagination.js';
+import keyRotationService from '../../services/keyRotationService.js';
 
 const adminLog = getLogger();
-
-// JSON.stringify does not guarantee key order, so two objects with the same
-// contents but different insertion order produce different cache keys.
-// This sorted replacer ensures deterministic serialisation for cache keys.
-function stableStringify(obj) {
-  return JSON.stringify(obj, (_, v) =>
-    v && typeof v === 'object' && !Array.isArray(v)
-      ? Object.fromEntries(Object.entries(v).sort(([a], [b]) => a.localeCompare(b)))
-      : v,
-  );
-}
 
 // Mutable runtime overrides (resets on server restart)
 const runtimeTierLimits = { ...TIER_LIMITS };
@@ -63,10 +55,6 @@ const getUserRateLimitUsage = (req, res) => {
   const usage = getUserUsage(userId);
   res.json({ userId, ...usage });
 };
-
-import cache from '../../lib/cache.js';
-import { buildPaginatedResponse, parsePagination } from '../../lib/pagination.js';
-import keyRotationService from '../../services/keyRotationService.js';
 
 /** Deterministic JSON serialiser — sorts object keys recursively. */
 function stableStringify(val) {
@@ -497,12 +485,16 @@ const updateSettings = async (req, res) => {
     });
   } catch (err) {
     logControllerError('admin.updateSettings', err, req);
+    res.status(500).json({ error: err.message });
+  }
+};
+
 // ── Key Management ─────────────────────────────────────────────────────────────
 
 const rotateKeys = async (req, res) => {
   try {
     const newKey = await keyRotationService.rotateKey();
-    
+
     // Log action
     await prisma.adminAuditLog.create({
       data: {
@@ -524,12 +516,12 @@ const rotateKeys = async (req, res) => {
 const listKeys = async (req, res) => {
   try {
     const validKeys = await keyRotationService.getValidPublicKeys();
-    
+
     // Omit any private keys if accidentally passed by service (though service shouldn't return them here)
-    const sanitizedKeys = validKeys.map(k => ({
+    const sanitizedKeys = validKeys.map((k) => ({
       kid: k.kid,
       algorithm: k.algorithm,
-      publicKey: k.publicKey
+      publicKey: k.publicKey,
     }));
 
     res.json({ keys: sanitizedKeys });
@@ -598,7 +590,9 @@ const getMetrics = async (req, res) => {
       const totalResolutionMs = resolvedDisputesThisWeek.reduce((sum, d) => {
         return sum + (new Date(d.resolvedAt) - new Date(d.raisedAt));
       }, 0);
-      avgResolutionTime = Math.round(totalResolutionMs / resolvedDisputesThisWeek.length / (1000 * 60 * 60)); // in hours
+      avgResolutionTime = Math.round(
+        totalResolutionMs / resolvedDisputesThisWeek.length / (1000 * 60 * 60),
+      ); // in hours
     }
 
     // Calculate deltas
@@ -607,10 +601,18 @@ const getMetrics = async (req, res) => {
       return Math.round(((current - previous) / previous) * 100);
     };
 
-    const currentLocked = currentTotalLockedXLM._sum.totalAmount ? parseFloat(currentTotalLockedXLM._sum.totalAmount) : 0;
-    const prevLocked = prevTotalLockedXLM._sum.totalAmount ? parseFloat(prevTotalLockedXLM._sum.totalAmount) : 0;
-    const currentFees = currentPlatformFeesThisMonth._sum.amount ? parseFloat(currentPlatformFeesThisMonth._sum.amount) : 0;
-    const prevFees = prevPlatformFeesThisMonth._sum.amount ? parseFloat(prevPlatformFeesThisMonth._sum.amount) : 0;
+    const currentLocked = currentTotalLockedXLM._sum.totalAmount
+      ? parseFloat(currentTotalLockedXLM._sum.totalAmount)
+      : 0;
+    const prevLocked = prevTotalLockedXLM._sum.totalAmount
+      ? parseFloat(prevTotalLockedXLM._sum.totalAmount)
+      : 0;
+    const currentFees = currentPlatformFeesThisMonth._sum.amount
+      ? parseFloat(currentPlatformFeesThisMonth._sum.amount)
+      : 0;
+    const prevFees = prevPlatformFeesThisMonth._sum.amount
+      ? parseFloat(prevPlatformFeesThisMonth._sum.amount)
+      : 0;
 
     const result = {
       activeEscrows: currentActiveEscrows,

--- a/backend/database/migrations/20260528000000_webhooks.js
+++ b/backend/database/migrations/20260528000000_webhooks.js
@@ -7,27 +7,30 @@
  * @param {import('@prisma/client').PrismaClient} prisma
  */
 export async function up(prisma) {
+  // Guard: if prisma db push already applied the final schema (webhook_endpoints),
+  // skip creating webhook_subscriptions to avoid the rename conflict in the next migration.
   await prisma.$executeRawUnsafe(`
-    CREATE TABLE IF NOT EXISTS webhook_subscriptions (
-      id TEXT PRIMARY KEY,
-      tenant_id TEXT NOT NULL,
-      url TEXT NOT NULL,
-      secret TEXT NOT NULL,
-      event_types TEXT[] NOT NULL DEFAULT '{}',
-      is_active BOOLEAN NOT NULL DEFAULT TRUE,
-      created_by TEXT,
-      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-      CONSTRAINT fk_webhook_subscription_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE
-    )
-  `);
-
-  await prisma.$executeRawUnsafe(`
-    CREATE INDEX IF NOT EXISTS webhook_subscriptions_tenant_id_idx ON webhook_subscriptions(tenant_id)
-  `);
-
-  await prisma.$executeRawUnsafe(`
-    CREATE INDEX IF NOT EXISTS webhook_subscriptions_created_by_idx ON webhook_subscriptions(created_by)
+    DO $$ BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'webhook_endpoints'
+      ) THEN
+        CREATE TABLE IF NOT EXISTS webhook_subscriptions (
+          id TEXT PRIMARY KEY,
+          tenant_id TEXT NOT NULL,
+          url TEXT NOT NULL,
+          secret TEXT NOT NULL,
+          event_types TEXT[] NOT NULL DEFAULT '{}',
+          is_active BOOLEAN NOT NULL DEFAULT TRUE,
+          created_by TEXT,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          CONSTRAINT fk_webhook_subscription_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS webhook_subscriptions_tenant_id_idx ON webhook_subscriptions(tenant_id);
+        CREATE INDEX IF NOT EXISTS webhook_subscriptions_created_by_idx ON webhook_subscriptions(created_by);
+      END IF;
+    END $$
   `);
 
   await prisma.$executeRawUnsafe(`

--- a/backend/database/migrations/20260528000000_webhooks.js
+++ b/backend/database/migrations/20260528000000_webhooks.js
@@ -47,7 +47,15 @@ export async function up(prisma) {
   `);
 
   await prisma.$executeRawUnsafe(`
-    CREATE INDEX IF NOT EXISTS webhook_deliveries_subscription_id_idx ON webhook_deliveries(subscription_id)
+    DO $$ BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'webhook_deliveries' AND column_name = 'subscription_id'
+      ) THEN
+        CREATE INDEX IF NOT EXISTS webhook_deliveries_subscription_id_idx
+          ON webhook_deliveries(subscription_id);
+      END IF;
+    END $$
   `);
 
   await prisma.$executeRawUnsafe(`

--- a/backend/database/migrations/20260717000000_webhook_endpoints.js
+++ b/backend/database/migrations/20260717000000_webhook_endpoints.js
@@ -7,13 +7,32 @@
  * @param {import('@prisma/client').PrismaClient} prisma
  */
 export async function up(prisma) {
+  // Rename table — no-op if webhook_subscriptions doesn't exist (prisma db push
+  // already created webhook_endpoints directly from the final schema).
   await prisma.$executeRawUnsafe(`
-    ALTER TABLE IF EXISTS webhook_subscriptions RENAME TO webhook_endpoints
+    DO $$ BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'webhook_subscriptions'
+      ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'webhook_endpoints'
+      ) THEN
+        ALTER TABLE webhook_subscriptions RENAME TO webhook_endpoints;
+      END IF;
+    END $$
   `);
 
+  // Rename column — no-op if already renamed (prisma db push applied final schema).
   await prisma.$executeRawUnsafe(`
-    ALTER TABLE webhook_deliveries
-      RENAME COLUMN subscription_id TO endpoint_id
+    DO $$ BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'webhook_deliveries' AND column_name = 'subscription_id'
+      ) THEN
+        ALTER TABLE webhook_deliveries RENAME COLUMN subscription_id TO endpoint_id;
+      END IF;
+    END $$
   `);
 
   await prisma.$executeRawUnsafe(`


### PR DESCRIPTION
## Summary

Fixes two pre-existing CI failures that were blocking all migration-touching PRs.

### adminController.js
- Move mid-file `import cache`, `import { buildPaginatedResponse, parsePagination }`, and `import keyRotationService` to top of file (ESM requires all imports at the top level)
- Remove duplicate `stableStringify` declaration (first copy at line ~20, second at ~72)
- Add missing closing braces on `updateSettings` catch block — the unclosed scope made acorn reject the `export default` as not top-level, causing the OpenAPI validation job to fail on every PR

### 20260528000000_webhooks.js
- Guard `subscription_id` index creation with a `DO $$ IF EXISTS` column check
- Root cause: `prisma db push` pushes the current schema (which has `endpoint_id` per `20260717000000_webhook_endpoints`), then `migrate.js up` tries to create an index on the now-missing `subscription_id` column