### PR TITLE
feat(backend): add production readiness middleware

### DIFF
--- a/backend/api/middleware/audit.js
+++ b/backend/api/middleware/audit.js
@@ -120,11 +120,21 @@ const ROUTE_MAP = [
   },
 ];
 
+const ESCROW_STATE_CHANGE = {
+  method: /^(POST|PUT|PATCH|DELETE)$/,
+  pattern: /^\/api\/escrows(\/|$)/,
+  category: AuditCategory.ESCROW,
+  action: AuditAction.ESCROW_STATE_CHANGE,
+};
+
 /**
  * Derive the actor from the request.
  * Extend this when JWT auth is added — read req.user.address instead.
  */
 function resolveActor(req) {
+  if (req.user?.walletAddress) return req.user.walletAddress;
+  if (req.user?.address) return req.user.address;
+  if (req.user?.userId) return String(req.user.userId);
   // Admin routes use the API key header; treat as "admin"
   if (req.headers['x-admin-api-key']) return 'admin';
   // Stellar address passed as a body or param field
@@ -141,7 +151,11 @@ function resolveResourceId(req) {
 }
 
 const auditMiddleware = (req, res, next) => {
-  const match = ROUTE_MAP.find((r) => r.method === req.method && r.pattern.test(req.path));
+  const match =
+    ROUTE_MAP.find((r) => r.method === req.method && r.pattern.test(req.path)) ||
+    (ESCROW_STATE_CHANGE.method.test(req.method) && ESCROW_STATE_CHANGE.pattern.test(req.path)
+      ? ESCROW_STATE_CHANGE
+      : null);
 
   if (!match) return next();
 
@@ -155,7 +169,13 @@ const auditMiddleware = (req, res, next) => {
       action: match.action,
       actor: resolveActor(req),
       resourceId: resolveResourceId(req),
-      metadata: res.statusCode >= 400 ? { error: body?.error } : undefined,
+      metadata: {
+        method: req.method,
+        path: req.originalUrl?.split('?')[0],
+        requestId: req.id || req.requestId,
+        body: req.body,
+        response: res.statusCode >= 400 ? { error: body?.error } : undefined,
+      },
       statusCode: res.statusCode,
       ipAddress: req.ip,
     });

--- a/backend/api/middleware/idempotency.js
+++ b/backend/api/middleware/idempotency.js
@@ -1,0 +1,90 @@
+import crypto from 'crypto';
+import cache from '../../lib/cache.js';
+
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const DEFAULT_TTL_SECONDS = 24 * 60 * 60;
+const IN_FLIGHT = new Set();
+
+function isApiMutation(req) {
+  return req.path.startsWith('/api/') && MUTATING_METHODS.has(req.method);
+}
+
+function isExcluded(req) {
+  return /\/webhooks?\b/.test(req.path) || /\/payments\/webhook$/.test(req.path);
+}
+
+function requestFingerprint(req) {
+  return crypto
+    .createHash('sha256')
+    .update(
+      JSON.stringify({
+        method: req.method,
+        path: req.originalUrl?.split('?')[0] ?? req.path,
+        user: req.user?.userId ?? req.user?.address ?? null,
+        tenant: req.tenant?.id ?? null,
+        body: req.body ?? {},
+      }),
+    )
+    .digest('hex');
+}
+
+function sendError(res, status, code, message) {
+  return res.status(status).json({ error: { code, message } });
+}
+
+export default function idempotencyMiddleware(req, res, next) {
+  if (!isApiMutation(req) || isExcluded(req)) return next();
+
+  const key = req.headers['idempotency-key'];
+  if (!key || Array.isArray(key) || typeof key !== 'string' || key.trim().length < 8) {
+    return sendError(
+      res,
+      400,
+      'IDEMPOTENCY_KEY_REQUIRED',
+      'A valid Idempotency-Key header is required for mutating API requests.',
+    );
+  }
+
+  const cacheKey = `idempotency:${req.method}:${req.originalUrl}:${key.trim()}`;
+  const fingerprint = requestFingerprint(req);
+
+  Promise.resolve(cache.get(cacheKey))
+    .then((stored) => {
+      if (stored) {
+        if (stored.fingerprint !== fingerprint) {
+          return sendError(
+            res,
+            409,
+            'IDEMPOTENCY_KEY_CONFLICT',
+            'Idempotency-Key was already used with a different request.',
+          );
+        }
+        res.setHeader('Idempotency-Replayed', 'true');
+        return res.status(stored.statusCode).json(stored.body);
+      }
+
+      if (IN_FLIGHT.has(cacheKey)) {
+        return sendError(
+          res,
+          409,
+          'IDEMPOTENCY_REQUEST_IN_PROGRESS',
+          'A request with this Idempotency-Key is already in progress.',
+        );
+      }
+
+      IN_FLIGHT.add(cacheKey);
+      const originalJson = res.json.bind(res);
+      res.json = (body) => {
+        if (res.statusCode >= 200 && res.statusCode < 500) {
+          cache
+            .set(cacheKey, { fingerprint, statusCode: res.statusCode, body }, DEFAULT_TTL_SECONDS)
+            .catch(() => null);
+        }
+        IN_FLIGHT.delete(cacheKey);
+        return originalJson(body);
+      };
+      res.on('finish', () => IN_FLIGHT.delete(cacheKey));
+      return next();
+    })
+    .catch(next);
+}

--- a/backend/api/middleware/zodValidation.js
+++ b/backend/api/middleware/zodValidation.js
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+
+const objectBody = z.record(z.unknown());
+const emptyBody = z.union([z.undefined(), z.null()]);
+const signedXdrSchema = z.object({
+  signedXdr: z.string().trim().min(1).max(100_000),
+});
+
+const ROUTE_SCHEMAS = [
+  { method: 'POST', pattern: /^\/api\/escrows\/broadcast$/, schema: signedXdrSchema },
+];
+
+function schemaFor(req) {
+  return ROUTE_SCHEMAS.find((route) => route.method === req.method && route.pattern.test(req.path))
+    ?.schema;
+}
+
+export function validateBody(schema) {
+  return (req, res, next) => {
+    const result = schema.safeParse(req.body);
+    if (result.success) {
+      req.body = result.data;
+      return next();
+    }
+
+    return res.status(400).json({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Request body validation failed.',
+        details: result.error.issues.map((issue) => ({
+          path: issue.path.join('.'),
+          message: issue.message,
+        })),
+      },
+    });
+  };
+}
+
+export default function zodValidationMiddleware(req, res, next) {
+  if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method) || !req.path.startsWith('/api/')) {
+    return next();
+  }
+
+  const schema = schemaFor(req) ?? (req.body == null ? emptyBody : objectBody);
+  return validateBody(schema)(req, res, next);
+}

--- a/backend/lib/pagination.js
+++ b/backend/lib/pagination.js
@@ -7,19 +7,39 @@ function normalizeInteger(value, fallback) {
   return Number.isNaN(parsed) ? fallback : parsed;
 }
 
+function encodeCursor(offset) {
+  return Buffer.from(JSON.stringify({ offset }), 'utf8').toString('base64url');
+}
+
+function decodeCursor(cursor) {
+  if (!cursor) return null;
+  try {
+    const decoded = JSON.parse(Buffer.from(String(cursor), 'base64url').toString('utf8'));
+    return Number.isInteger(decoded.offset) && decoded.offset >= 0 ? decoded.offset : null;
+  } catch {
+    return null;
+  }
+}
+
 export function parsePagination(query = {}) {
   const page = Math.max(DEFAULT_PAGE, normalizeInteger(query.page, DEFAULT_PAGE));
   const limit = Math.min(MAX_LIMIT, Math.max(1, normalizeInteger(query.limit, DEFAULT_LIMIT)));
+  const cursorOffset = decodeCursor(query.cursor);
+  const skip = cursorOffset ?? (page - 1) * limit;
 
   return {
-    page,
+    page: cursorOffset === null ? page : Math.floor(skip / limit) + 1,
     limit,
-    skip: (page - 1) * limit,
+    skip,
+    cursor: query.cursor ?? null,
   };
 }
 
 export function buildPaginatedResponse(data, { page, limit, total }) {
   const totalPages = total === 0 ? 0 : Math.ceil(total / limit);
+  const currentOffset = (page - 1) * limit;
+  const nextOffset = currentOffset + limit;
+  const previousOffset = Math.max(0, currentOffset - limit);
 
   return {
     data,
@@ -29,6 +49,8 @@ export function buildPaginatedResponse(data, { page, limit, total }) {
     totalPages,
     hasNextPage: page < totalPages,
     hasPreviousPage: page > DEFAULT_PAGE,
+    nextCursor: nextOffset < total ? encodeCursor(nextOffset) : null,
+    previousCursor: currentOffset > 0 ? encodeCursor(previousOffset) : null,
   };
 }
 

--- a/backend/middleware/validation.js
+++ b/backend/middleware/validation.js
@@ -116,6 +116,7 @@ export const stellarAddressBody = (field = 'address') =>
 export const paginationQuery = [
   query('page').optional().isInt({ min: 1 }).toInt(),
   query('limit').optional().isInt({ min: 1, max: 100 }).toInt(),
+  query('cursor').optional().isBase64().withMessage('cursor must be a valid cursor token'),
 ];
 
 export const escrowIdParam = param('id')

--- a/backend/package.json
+++ b/backend/package.json
@@ -77,7 +77,8 @@
     "winston": "^3.11.0",
     "winston-daily-rotate-file": "^5.0.0",
     "ws": "^8.20.0",
-    "yaml": "^2.4.2"
+    "yaml": "^2.4.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "cross-env": "^10.1.0",

--- a/backend/server.js
+++ b/backend/server.js
@@ -42,6 +42,8 @@ import batchRoutes from './api/routes/batchRoutes.js';
 import webhookRoutes from './api/routes/webhookRoutes.js';
 import tenantMiddleware from './api/middleware/tenant.js';
 import auditMiddleware from './api/middleware/audit.js';
+import idempotencyMiddleware from './api/middleware/idempotency.js';
+import zodValidationMiddleware from './api/middleware/zodValidation.js';
 import { createWebSocketServer, pool } from './api/websocket/handlers.js';
 import cache from './lib/cache.js';
 import { attachPrismaMetrics } from './lib/prismaMetrics.js';
@@ -111,6 +113,8 @@ app.use(express.urlencoded({ extended: true, limit: REQUEST_SIZE_LIMIT }));
 app.use(cookieParser());
 app.use(sanitizeInputs);
 app.use(csrfProtection);
+app.use(zodValidationMiddleware);
+app.use(idempotencyMiddleware);
 app.use('/uploads', express.static('uploads'));
 app.use(auditMiddleware);
 
@@ -240,7 +244,12 @@ app.use((err, req, res, _next) => {
 
   // Attach Sentry event ID to response so support can correlate reports
   const sentryId = res.sentry;
-  const body = { error: err.message || 'Internal server error' };
+  const body = {
+    error: {
+      code: err.code || (statusCode >= 500 ? 'INTERNAL_SERVER_ERROR' : 'REQUEST_ERROR'),
+      message: err.message || 'Internal server error',
+    },
+  };
   if (sentryId) body.errorId = sentryId;
 
   const log = req?.log || logger;

--- a/backend/services/auditService.js
+++ b/backend/services/auditService.js
@@ -10,7 +10,9 @@
 import { stringify } from 'csv-stringify/sync';
 import { createModuleLogger } from '../config/logger.js';
 import prisma from '../lib/prisma.js';
+import { buildPaginatedResponse, parsePagination } from '../lib/pagination.js';
 import { withSpan } from '../lib/tracing.js';
+import { DEFAULT_TENANT_ID, getCurrentTenantId } from '../lib/tenantContext.js';
 
 const auditLogger = createModuleLogger('auditService');
 
@@ -36,6 +38,7 @@ export const AuditAction = {
   CREATE_ESCROW: 'CREATE_ESCROW',
   CANCEL_ESCROW: 'CANCEL_ESCROW',
   COMPLETE_ESCROW: 'COMPLETE_ESCROW',
+  ESCROW_STATE_CHANGE: 'ESCROW_STATE_CHANGE',
   // Milestone
   ADD_MILESTONE: 'ADD_MILESTONE',
   SUBMIT_MILESTONE: 'SUBMIT_MILESTONE',
@@ -95,6 +98,7 @@ export async function log(entry) {
       async () => {
         await prisma.auditLog.create({
           data: {
+            tenantId: entry.tenantId ?? getCurrentTenantId() ?? DEFAULT_TENANT_ID,
             category: entry.category,
             action: entry.action,
             actor: entry.actor,
@@ -152,9 +156,7 @@ function buildWhereClause({ category, action, actor, resourceId, from, to } = {}
  * @returns {{ data: AuditLog[], total: number, page: number, limit: number, pages: number }}
  */
 export async function search(filters = {}) {
-  const page = Math.max(1, parseInt(filters.page) || 1);
-  const limit = Math.min(200, Math.max(1, parseInt(filters.limit) || 50));
-  const skip = (page - 1) * limit;
+  const { page, limit, skip } = parsePagination({ limit: filters.limit ?? 50, ...filters });
 
   const where = buildWhereClause(filters);
 
@@ -168,7 +170,7 @@ export async function search(filters = {}) {
     prisma.auditLog.count({ where }),
   ]);
 
-  return { data, total, page, limit, pages: Math.ceil(total / limit) };
+  return buildPaginatedResponse(data, { total, page, limit });
 }
 
 // ── Export ────────────────────────────────────────────────────────────────────

--- a/backend/tests/backendReadinessMiddleware.test.js
+++ b/backend/tests/backendReadinessMiddleware.test.js
@@ -1,0 +1,70 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it } from '@jest/globals';
+
+import idempotencyMiddleware from '../api/middleware/idempotency.js';
+import zodValidationMiddleware from '../api/middleware/zodValidation.js';
+import { buildPaginatedResponse, parsePagination } from '../lib/pagination.js';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(zodValidationMiddleware);
+  app.use(idempotencyMiddleware);
+  app.post('/api/escrows/broadcast', (req, res) => {
+    res.status(201).json({ accepted: true, signedXdr: req.body.signedXdr });
+  });
+  return app;
+}
+
+describe('backend production readiness middleware', () => {
+  it('rejects mutating API requests without an idempotency key', async () => {
+    const res = await request(buildApp()).post('/api/escrows/broadcast').send({ signedXdr: 'xdr' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('IDEMPOTENCY_KEY_REQUIRED');
+  });
+
+  it('replays matching requests with the same idempotency key', async () => {
+    const app = buildApp();
+    const first = await request(app)
+      .post('/api/escrows/broadcast')
+      .set('Idempotency-Key', 'idem-key-123')
+      .send({ signedXdr: 'xdr' });
+    const second = await request(app)
+      .post('/api/escrows/broadcast')
+      .set('Idempotency-Key', 'idem-key-123')
+      .send({ signedXdr: 'xdr' });
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+    expect(second.headers['idempotency-replayed']).toBe('true');
+    expect(second.body).toEqual(first.body);
+  });
+
+  it('rejects invalid Zod-validated request bodies', async () => {
+    const res = await request(buildApp())
+      .post('/api/escrows/broadcast')
+      .set('Idempotency-Key', 'idem-key-456')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('cursor pagination compatibility', () => {
+  it('emits a cursor that can request the next page', () => {
+    const first = parsePagination({ limit: '2' });
+    const response = buildPaginatedResponse(['a', 'b'], {
+      total: 5,
+      page: first.page,
+      limit: first.limit,
+    });
+    const second = parsePagination({ limit: '2', cursor: response.nextCursor });
+
+    expect(response.nextCursor).toBeTruthy();
+    expect(second.skip).toBe(2);
+    expect(second.page).toBe(2);
+  });
+});

--- a/backend/tests/escrowController.test.js
+++ b/backend/tests/escrowController.test.js
@@ -59,7 +59,10 @@ jest.unstable_mockModule('@stellar/stellar-sdk', () => ({
   scValToNative: jest.fn(() => 42n),
   SorobanRpc: {},
   Transaction: jest.fn(),
-  Networks: { TESTNET: 'Test SDF Network ; September 2015', PUBLIC: 'Public Global Stellar Network ; September 2015' },
+  Networks: {
+    TESTNET: 'Test SDF Network ; September 2015',
+    PUBLIC: 'Public Global Stellar Network ; September 2015',
+  },
 }));
 
 const { default: escrowController } = await import('../api/controllers/escrowController.js');
@@ -123,6 +126,8 @@ describe('escrowController', () => {
         totalPages: 0,
         hasNextPage: false,
         hasPreviousPage: false,
+        nextCursor: null,
+        previousCursor: null,
       });
     });
 
@@ -230,7 +235,11 @@ describe('escrowController', () => {
     });
 
     it('returns 200 with { hash, escrowId } on SUCCESS', async () => {
-      submitTransactionMock.mockResolvedValue({ hash: 'tx_abc', status: 'SUCCESS', returnValue: null });
+      submitTransactionMock.mockResolvedValue({
+        hash: 'tx_abc',
+        status: 'SUCCESS',
+        returnValue: null,
+      });
       const req = { body: { signedXdr: 'AAAA...' } };
       const res = createMockRes();
 
@@ -241,7 +250,11 @@ describe('escrowController', () => {
     });
 
     it('returns 422 on Soroban FAILED status', async () => {
-      submitTransactionMock.mockResolvedValue({ hash: 'tx_fail', status: 'FAILED', errorResultXdr: 'AAAA' });
+      submitTransactionMock.mockResolvedValue({
+        hash: 'tx_fail',
+        status: 'FAILED',
+        errorResultXdr: 'AAAA',
+      });
       const req = { body: { signedXdr: 'AAAA...' } };
       const res = createMockRes();
 

--- a/backend/tests/pagination.test.js
+++ b/backend/tests/pagination.test.js
@@ -6,6 +6,7 @@ describe('parsePagination', () => {
       page: 1,
       limit: 20,
       skip: 0,
+      cursor: null,
     });
   });
 
@@ -14,6 +15,7 @@ describe('parsePagination', () => {
       page: 1,
       limit: 100,
       skip: 0,
+      cursor: null,
     });
   });
 });
@@ -28,6 +30,8 @@ describe('buildPaginatedResponse', () => {
       totalPages: 3,
       hasNextPage: true,
       hasPreviousPage: true,
+      nextCursor: 'eyJvZmZzZXQiOjR9',
+      previousCursor: 'eyJvZmZzZXQiOjB9',
     });
   });
 
@@ -40,6 +44,8 @@ describe('buildPaginatedResponse', () => {
       totalPages: 0,
       hasNextPage: false,
       hasPreviousPage: false,
+      nextCursor: null,
+      previousCursor: null,
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,8 @@
         "winston": "^3.11.0",
         "winston-daily-rotate-file": "^5.0.0",
         "ws": "^8.20.0",
-        "yaml": "^2.4.2"
+        "yaml": "^2.4.2",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "cross-env": "^10.1.0",
@@ -24749,8 +24750,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
Summary:
- Add Zod-backed request body validation middleware for mutating API requests.
- Add idempotency-key handling for mutating API endpoints with replay/conflict behavior.
- Add cursor tokens to shared pagination responses while preserving page/limit compatibility.
- Extend audit logging for escrow state-change requests and standardize uncaught error envelopes.

Closes #57
Closes #58
Closes #59
Closes #60

Validation:
- npm run lint -w backend
- npm run test -w backend -- backendReadinessMiddleware.test.js pagination.test.js escrowController.test.js
- npx prettier --check changed backend files/package metadata
- npm run test -w backend: 440 assertions passed; suite still exits failed because pre-existing tests import missing modules: backend/api/routes/thresholdRoutes.js and backend/services/reconstructionService.js