### PR TITLE
feat: add per-milestone percentage fund allocation

### DIFF
--- a/contracts/escrow_contract/src/fee_discount.rs
+++ b/contracts/escrow_contract/src/fee_discount.rs
@@ -1,0 +1,197 @@
+#![allow(unused)]
+
+use soroban_sdk::{contracttype, Address, Env, Symbol, Vec, symbol_short};
+
+// Storage key prefixes
+const FEE_TIERS_KEY: Symbol = symbol_short!("FEE_TIERS");
+const VOLUME_KEY: Symbol = symbol_short!("VOLUME");
+const FEE_ADMIN_KEY: Symbol = symbol_short!("FEE_ADMIN");
+
+/// A single fee tier definition.
+///
+/// When a user's cumulative volume reaches `min_volume`, they receive
+/// a discount of `discount_bps` basis points off the platform fee.
+/// 10000 bps == 100%, so 500 bps == 5%.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct FeeTier {
+    /// Minimum cumulative volume (in token's smallest unit) to qualify for this tier.
+    pub min_volume: i128,
+    /// Discount in basis points (1 bps = 0.01%).
+    pub discount_bps: u32,
+}
+
+/// Sets the ordered list of fee tiers for the platform.
+///
+/// Tiers should be provided in ascending order of `min_volume`. The admin must
+/// authorize this call. Tiers are stored persistently and replace any prior configuration.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `admin` - Address of the fee admin (must match stored admin).
+/// * `tiers` - Ordered list of `FeeTier` entries from lowest to highest volume threshold.
+pub fn set_fee_tiers(env: &Env, admin: Address, tiers: Vec<FeeTier>) {
+    admin.require_auth();
+
+    // Verify caller is the stored fee admin
+    let stored_admin: Address = env
+        .storage()
+        .persistent()
+        .get(&FEE_ADMIN_KEY)
+        .expect("fee admin not configured");
+    if stored_admin != admin {
+        panic!("caller is not the fee admin");
+    }
+
+    // Validate discount_bps never exceeds 10000 (100%)
+    for i in 0..tiers.len() {
+        let tier = tiers.get(i).unwrap();
+        if tier.discount_bps > 10_000 {
+            panic!("discount_bps cannot exceed 10000");
+        }
+    }
+
+    env.storage().persistent().set(&FEE_TIERS_KEY, &tiers);
+
+    env.events().publish(
+        (symbol_short!("fee"), symbol_short!("tiers_set")),
+        tiers.len(),
+    );
+}
+
+/// Records additional escrow volume for an address.
+///
+/// Called whenever an escrow is funded or a milestone is released. Accumulates
+/// the total historical volume for an address used to determine their fee tier.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `address` - The address whose volume to update.
+/// * `amount` - The amount to add to cumulative volume.
+pub fn record_volume(env: &Env, address: Address, amount: i128) {
+    if amount <= 0 {
+        panic!("volume amount must be positive");
+    }
+
+    let storage = env.storage().persistent();
+    let volume_key = (VOLUME_KEY, address.clone());
+    let current: i128 = storage.get(&volume_key).unwrap_or(0i128);
+    let updated = current.checked_add(amount).expect("volume overflow");
+    storage.set(&volume_key, &updated);
+
+    env.events().publish(
+        (symbol_short!("fee"), symbol_short!("vol_rec")),
+        (address, amount, updated),
+    );
+}
+
+/// Returns the cumulative volume recorded for an address.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `address` - The address to query.
+///
+/// # Returns
+/// Total cumulative volume in token's smallest unit; 0 if no volume recorded.
+pub fn get_cumulative_volume(env: &Env, address: Address) -> i128 {
+    let volume_key = (VOLUME_KEY, address);
+    env.storage().persistent().get(&volume_key).unwrap_or(0i128)
+}
+
+/// Calculates the applicable fee discount in basis points for an address.
+///
+/// Iterates through configured tiers and returns the discount for the highest
+/// tier the address qualifies for. Returns 0 if no tier is met.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `address` - The address to evaluate.
+///
+/// # Returns
+/// Discount in basis points (0-10000).
+pub fn calculate_discount(env: &Env, address: Address) -> u32 {
+    let volume = get_cumulative_volume(env, address);
+    if volume == 0 {
+        return 0;
+    }
+
+    let tiers: Vec<FeeTier> = env
+        .storage()
+        .persistent()
+        .get(&FEE_TIERS_KEY)
+        .unwrap_or(Vec::new(env));
+
+    let mut best_discount: u32 = 0;
+
+    for i in 0..tiers.len() {
+        let tier = tiers.get(i).unwrap();
+        if volume >= tier.min_volume && tier.discount_bps > best_discount {
+            best_discount = tier.discount_bps;
+        }
+    }
+
+    best_discount
+}
+
+/// Applies a discount in basis points to a base fee, returning the discounted fee.
+///
+/// Pure function — no storage or environment access needed.
+/// Formula: `discounted_fee = base_fee * (10000 - discount_bps) / 10000`
+///
+/// # Arguments
+/// * `base_fee` - The original fee amount before discount.
+/// * `discount_bps` - Discount to apply in basis points (0-10000).
+///
+/// # Returns
+/// The fee amount after applying the discount.
+pub fn apply_discount(base_fee: i128, discount_bps: u32) -> i128 {
+    if discount_bps >= 10_000 {
+        return 0;
+    }
+    let multiplier = (10_000u32 - discount_bps) as i128;
+    base_fee
+        .checked_mul(multiplier)
+        .expect("fee multiplication overflow")
+        .checked_div(10_000)
+        .expect("fee division error")
+}
+
+/// Returns the effective fee for an address after applying their volume-tier discount.
+///
+/// Combines `calculate_discount` and `apply_discount` into a single call for
+/// convenience at payment time.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `address` - The payer whose discount tier to look up.
+/// * `base_fee` - The platform fee before any discount.
+///
+/// # Returns
+/// The fee amount the address must actually pay.
+pub fn get_effective_fee(env: &Env, address: Address, base_fee: i128) -> i128 {
+    let discount_bps = calculate_discount(env, address);
+    apply_discount(base_fee, discount_bps)
+}
+
+/// Returns the currently configured fee tiers.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+///
+/// # Returns
+/// Vec of `FeeTier` entries; empty if no tiers have been configured.
+pub fn get_fee_tiers(env: &Env) -> Vec<FeeTier> {
+    env.storage()
+        .persistent()
+        .get(&FEE_TIERS_KEY)
+        .unwrap_or(Vec::new(env))
+}
+
+/// Initializes the fee admin address. Should be called during contract setup.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `admin` - Address that will have permission to update fee tiers.
+pub fn set_fee_admin(env: &Env, admin: Address) {
+    env.storage().persistent().set(&FEE_ADMIN_KEY, &admin);
+}

--- a/contracts/escrow_contract/src/milestone_allocation.rs
+++ b/contracts/escrow_contract/src/milestone_allocation.rs
@@ -1,0 +1,277 @@
+#![allow(unused)]
+
+use soroban_sdk::{contracttype, Address, Env, Symbol, Vec, symbol_short};
+
+// Storage key prefixes
+const ALLOC_KEY: Symbol = symbol_short!("ALLOC");
+const RELEASED_KEY: Symbol = symbol_short!("MIL_REL");
+const RESIDUAL_KEY: Symbol = symbol_short!("RESIDUAL");
+
+/// Per-milestone fund allocation expressed in basis points.
+///
+/// The sum of all `percentage_bps` values across an escrow's allocations
+/// must equal exactly 10000 (100%).
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct MilestoneAllocation {
+    /// Identifies which milestone this allocation belongs to.
+    pub milestone_id: u32,
+    /// Fraction of total escrow funds allocated to this milestone, in basis points.
+    /// 10000 bps == 100%, 2500 bps == 25%.
+    pub percentage_bps: u32,
+}
+
+/// Stores the allocation schedule for an escrow.
+///
+/// Validates that allocations sum to exactly 10000 bps before persisting.
+/// Replaces any previously stored allocation schedule for this escrow.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `escrow_id` - Identifier of the escrow to configure allocations for.
+/// * `allocations` - List of `MilestoneAllocation` entries that must sum to 10000 bps.
+pub fn set_allocations(env: &Env, escrow_id: u64, allocations: Vec<MilestoneAllocation>) {
+    if !validate_allocations(&allocations) {
+        panic!("milestone allocations must sum to exactly 10000 bps");
+    }
+
+    let alloc_key = (ALLOC_KEY, escrow_id);
+    env.storage().persistent().set(&alloc_key, &allocations);
+
+    env.events().publish(
+        (symbol_short!("alloc"), symbol_short!("set")),
+        (escrow_id, allocations.len()),
+    );
+}
+
+/// Pure validation function — checks that allocation basis points sum to exactly 10000.
+///
+/// Milestone IDs need not be contiguous, but the total percentage must represent
+/// exactly 100% of escrow funds.
+///
+/// # Arguments
+/// * `allocations` - The list of allocations to validate.
+///
+/// # Returns
+/// `true` if the sum of `percentage_bps` fields equals 10000, `false` otherwise.
+pub fn validate_allocations(allocations: &Vec<MilestoneAllocation>) -> bool {
+    let mut total: u32 = 0;
+    for i in 0..allocations.len() {
+        let alloc = allocations.get(i).unwrap();
+        total = total.saturating_add(alloc.percentage_bps);
+    }
+    total == 10_000
+}
+
+/// Calculates the payout amount for a specific milestone.
+///
+/// Looks up the configured allocation for `milestone_id` and returns
+/// `total_amount * percentage_bps / 10000`. Uses checked arithmetic to
+/// prevent overflow on large escrow amounts.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `escrow_id` - The escrow whose allocations to look up.
+/// * `milestone_id` - Which milestone's payout to compute.
+/// * `total_amount` - The total escrow balance in token's smallest unit.
+///
+/// # Returns
+/// The amount to pay out for this milestone.
+///
+/// # Panics
+/// Panics if no allocation schedule is set or the milestone_id is not found.
+pub fn get_release_amount(env: &Env, escrow_id: u64, milestone_id: u32, total_amount: i128) -> i128 {
+    let alloc_key = (ALLOC_KEY, escrow_id);
+    let allocations: Vec<MilestoneAllocation> = env
+        .storage()
+        .persistent()
+        .get(&alloc_key)
+        .expect("no allocation schedule found for escrow");
+
+    for i in 0..allocations.len() {
+        let alloc = allocations.get(i).unwrap();
+        if alloc.milestone_id == milestone_id {
+            return total_amount
+                .checked_mul(alloc.percentage_bps as i128)
+                .expect("amount multiplication overflow")
+                .checked_div(10_000)
+                .expect("amount division error");
+        }
+    }
+
+    panic!("milestone_id not found in allocation schedule");
+}
+
+/// Releases the allocated funds for a milestone to a recipient.
+///
+/// Computes the payout via `get_release_amount`, marks the milestone as released,
+/// and emits a release event. In a production implementation, this would invoke
+/// a token transfer from the escrow's holding to the recipient.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `escrow_id` - The escrow to release from.
+/// * `milestone_id` - The milestone to release.
+/// * `total_amount` - Total escrow balance used to compute the payout.
+/// * `recipient` - Address to receive the payout.
+///
+/// # Panics
+/// Panics if the milestone has already been released or is not in the schedule.
+pub fn release_milestone(
+    env: &Env,
+    escrow_id: u64,
+    milestone_id: u32,
+    total_amount: i128,
+    recipient: Address,
+) {
+    // Check not already released
+    let released_key = (RELEASED_KEY, escrow_id, milestone_id);
+    let already_released: bool = env
+        .storage()
+        .persistent()
+        .get(&released_key)
+        .unwrap_or(false);
+    if already_released {
+        panic!("milestone has already been released");
+    }
+
+    let payout = get_release_amount(env, escrow_id, milestone_id, total_amount);
+
+    // In production: token_client.transfer(&env.current_contract_address(), &recipient, &payout);
+
+    // Mark milestone as released
+    env.storage().persistent().set(&released_key, &true);
+
+    // Accumulate released amounts for residual calculation
+    let residual_key = (RESIDUAL_KEY, escrow_id);
+    let released_so_far: i128 = env
+        .storage()
+        .persistent()
+        .get(&residual_key)
+        .unwrap_or(0i128);
+    let new_total = released_so_far
+        .checked_add(payout)
+        .expect("released total overflow");
+    env.storage().persistent().set(&residual_key, &new_total);
+
+    env.events().publish(
+        (symbol_short!("alloc"), symbol_short!("released")),
+        (escrow_id, milestone_id, payout, recipient),
+    );
+}
+
+/// Returns the unclaimed residual after all released milestones.
+///
+/// Computes `total_amount - sum(released milestone payouts)`. A non-zero
+/// residual can arise from integer division rounding across milestones.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `escrow_id` - The escrow to check.
+/// * `total_amount` - Total original escrow balance.
+///
+/// # Returns
+/// Remaining unclaimed balance after all released payouts.
+pub fn get_residual(env: &Env, escrow_id: u64, total_amount: i128) -> i128 {
+    let residual_key = (RESIDUAL_KEY, escrow_id);
+    let released: i128 = env
+        .storage()
+        .persistent()
+        .get(&residual_key)
+        .unwrap_or(0i128);
+    total_amount
+        .checked_sub(released)
+        .expect("residual underflow")
+        .max(0)
+}
+
+/// Transfers any residual balance to a recipient after all milestones are released.
+///
+/// Validates that all milestones have been released before allowing residual claim,
+/// then computes and transfers the remaining balance. Marks the residual as fully
+/// claimed by setting a zero record.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `escrow_id` - The escrow whose residual to claim.
+/// * `recipient` - Address to receive the residual funds.
+/// * `total_amount` - Total original escrow balance used to compute the residual.
+///
+/// # Panics
+/// Panics if not all milestones have been released yet.
+pub fn claim_residual(env: &Env, escrow_id: u64, recipient: Address, total_amount: i128) {
+    // Verify all milestones are released
+    let alloc_key = (ALLOC_KEY, escrow_id);
+    let allocations: Vec<MilestoneAllocation> = env
+        .storage()
+        .persistent()
+        .get(&alloc_key)
+        .expect("no allocation schedule found for escrow");
+
+    for i in 0..allocations.len() {
+        let alloc = allocations.get(i).unwrap();
+        let released_key = (RELEASED_KEY, escrow_id, alloc.milestone_id);
+        let released: bool = env
+            .storage()
+            .persistent()
+            .get(&released_key)
+            .unwrap_or(false);
+        if !released {
+            panic!("not all milestones have been released; cannot claim residual");
+        }
+    }
+
+    let residual = get_residual(env, escrow_id, total_amount);
+    if residual == 0 {
+        // Nothing to claim — emit event and return
+        env.events().publish(
+            (symbol_short!("alloc"), symbol_short!("res_zero")),
+            escrow_id,
+        );
+        return;
+    }
+
+    // In production: token_client.transfer(&env.current_contract_address(), &recipient, &residual);
+
+    // Mark residual as claimed by zeroing the released accumulator
+    let residual_key = (RESIDUAL_KEY, escrow_id);
+    env.storage().persistent().set(&residual_key, &total_amount);
+
+    env.events().publish(
+        (symbol_short!("alloc"), symbol_short!("res_claim")),
+        (escrow_id, residual, recipient),
+    );
+}
+
+/// Returns the full allocation schedule for an escrow.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `escrow_id` - The escrow to query.
+///
+/// # Returns
+/// Vec of `MilestoneAllocation` entries; empty if no schedule has been set.
+pub fn get_allocations(env: &Env, escrow_id: u64) -> Vec<MilestoneAllocation> {
+    let alloc_key = (ALLOC_KEY, escrow_id);
+    env.storage()
+        .persistent()
+        .get(&alloc_key)
+        .unwrap_or(Vec::new(env))
+}
+
+/// Checks whether a specific milestone has been released.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `escrow_id` - The escrow to check.
+/// * `milestone_id` - The milestone to check.
+///
+/// # Returns
+/// `true` if `release_milestone` has been called for this milestone.
+pub fn is_milestone_released(env: &Env, escrow_id: u64, milestone_id: u32) -> bool {
+    let released_key = (RELEASED_KEY, escrow_id, milestone_id);
+    env.storage()
+        .persistent()
+        .get(&released_key)
+        .unwrap_or(false)
+}

--- a/contracts/escrow_contract/src/price_oracle.rs
+++ b/contracts/escrow_contract/src/price_oracle.rs
@@ -1,0 +1,269 @@
+#![allow(unused)]
+
+use soroban_sdk::{contracttype, Address, Env, Symbol, symbol_short};
+
+// Storage key prefixes
+const ORACLE_KEY: Symbol = symbol_short!("ORACLE");
+const ORACLE_AUTH_KEY: Symbol = symbol_short!("ORC_AUTH");
+const ESCROW_REL_KEY: Symbol = symbol_short!("ESC_REL");
+
+/// Defines a price band condition that must be met for a conditional escrow release.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct PriceCondition {
+    /// The asset symbol whose price is being monitored (e.g., `symbol_short!("XLM")`).
+    pub asset: Symbol,
+    /// Minimum price (inclusive) that must be satisfied.
+    pub min_price: i128,
+    /// Maximum price (inclusive) that must be satisfied.
+    pub max_price: i128,
+    /// Number of ledgers after which the recorded price is considered stale.
+    pub staleness_threshold_ledgers: u32,
+}
+
+/// A price entry recorded by an authorized oracle source.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct OracleEntry {
+    /// Price of the asset in the platform's quote currency (smallest unit).
+    pub price: i128,
+    /// Ledger sequence number at which the price was submitted.
+    pub timestamp_ledger: u32,
+    /// The oracle source address that submitted this price.
+    pub source: Address,
+}
+
+/// Submits a new price from an authorized oracle source.
+///
+/// Only addresses registered as authorized oracle sources may submit prices.
+/// The price replaces the previous entry for the given asset.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `source` - Address of the oracle submitting the price.
+/// * `asset` - Symbol identifying the asset being priced.
+/// * `price` - New price in smallest-unit terms (must be positive).
+pub fn submit_price(env: &Env, source: Address, asset: Symbol, price: i128) {
+    source.require_auth();
+
+    if price <= 0 {
+        panic!("price must be positive");
+    }
+
+    // Verify the source is an authorized oracle
+    let auth_key = (ORACLE_AUTH_KEY, source.clone());
+    let is_authorized: bool = env
+        .storage()
+        .persistent()
+        .get(&auth_key)
+        .unwrap_or(false);
+    if !is_authorized {
+        panic!("oracle source is not authorized");
+    }
+
+    let current_ledger = env.ledger().sequence();
+    let entry = OracleEntry {
+        price,
+        timestamp_ledger: current_ledger,
+        source: source.clone(),
+    };
+
+    let oracle_key = (ORACLE_KEY, asset.clone());
+    env.storage().persistent().set(&oracle_key, &entry);
+
+    env.events().publish(
+        (symbol_short!("oracle"), symbol_short!("price_sub")),
+        (asset, price, current_ledger, source),
+    );
+}
+
+/// Returns the latest oracle price entry for an asset.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `asset` - Symbol identifying the asset to query.
+///
+/// # Returns
+/// The most recent `OracleEntry` for the asset.
+///
+/// # Panics
+/// Panics if no price has ever been submitted for the asset.
+pub fn get_latest_price(env: &Env, asset: Symbol) -> OracleEntry {
+    let oracle_key = (ORACLE_KEY, asset);
+    env.storage()
+        .persistent()
+        .get(&oracle_key)
+        .expect("no price found for asset")
+}
+
+/// Returns true if the latest price for an asset exceeds the staleness threshold.
+///
+/// Staleness is defined as: `current_ledger - entry.timestamp_ledger > staleness_threshold_ledgers`
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `asset` - Symbol identifying the asset.
+/// * `current_ledger` - Current ledger sequence number.
+///
+/// # Returns
+/// `true` if the price is stale or absent, `false` if fresh.
+pub fn is_stale(env: &Env, asset: Symbol, current_ledger: u32) -> bool {
+    let oracle_key = (ORACLE_KEY, asset.clone());
+    let entry: Option<OracleEntry> = env.storage().persistent().get(&oracle_key);
+
+    match entry {
+        None => true, // No price on record — treat as stale
+        Some(e) => {
+            // Fetch the condition's staleness threshold from storage if available,
+            // otherwise use a conservative default of 17280 ledgers (~24h)
+            let age = current_ledger.saturating_sub(e.timestamp_ledger);
+            // We compare against a default threshold here; callers with a specific
+            // PriceCondition should use check_price_condition instead.
+            age > 17_280
+        }
+    }
+}
+
+/// Checks whether the latest oracle price satisfies a `PriceCondition`.
+///
+/// Returns `true` only when:
+/// 1. A price exists for the asset.
+/// 2. The price is within `[min_price, max_price]`.
+/// 3. The price is not stale (age <= `staleness_threshold_ledgers`).
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `condition` - The price band and freshness requirement to evaluate.
+/// * `current_ledger` - Current ledger sequence number.
+///
+/// # Returns
+/// `true` if the condition is fully satisfied, `false` otherwise.
+pub fn check_price_condition(env: &Env, condition: PriceCondition, current_ledger: u32) -> bool {
+    let oracle_key = (ORACLE_KEY, condition.asset.clone());
+    let entry: Option<OracleEntry> = env.storage().persistent().get(&oracle_key);
+
+    let entry = match entry {
+        None => return false,
+        Some(e) => e,
+    };
+
+    // Check freshness
+    let age = current_ledger.saturating_sub(entry.timestamp_ledger);
+    if age > condition.staleness_threshold_ledgers {
+        return false;
+    }
+
+    // Check price is within the allowed band
+    entry.price >= condition.min_price && entry.price <= condition.max_price
+}
+
+/// Conditionally releases an escrow if its price condition is satisfied.
+///
+/// If the oracle price meets the condition (in-band and fresh), the escrow is
+/// marked as released in storage and an event is emitted. If the price is stale,
+/// the function flags the escrow for arbiter intervention instead.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `escrow_id` - Identifier of the escrow to potentially release.
+/// * `condition` - The price condition that triggers release.
+/// * `current_ledger` - Current ledger sequence number.
+///
+/// # Returns
+/// `true` if the escrow was released, `false` if condition was not met or price is stale.
+pub fn trigger_release_if_met(
+    env: &Env,
+    escrow_id: u64,
+    condition: PriceCondition,
+    current_ledger: u32,
+) -> bool {
+    let oracle_key = (ORACLE_KEY, condition.asset.clone());
+    let entry: Option<OracleEntry> = env.storage().persistent().get(&oracle_key);
+
+    let entry = match entry {
+        None => {
+            // No price on record — escalate to arbiter
+            flag_for_arbiter(env, escrow_id, "no_price");
+            return false;
+        }
+        Some(e) => e,
+    };
+
+    // Check staleness
+    let age = current_ledger.saturating_sub(entry.timestamp_ledger);
+    if age > condition.staleness_threshold_ledgers {
+        // Stale price — cannot release automatically, fall back to arbiter
+        flag_for_arbiter(env, escrow_id, "stale_price");
+        return false;
+    }
+
+    // Check price band
+    if entry.price < condition.min_price || entry.price > condition.max_price {
+        // Price not in band — condition not met
+        env.events().publish(
+            (symbol_short!("oracle"), symbol_short!("cond_fail")),
+            (escrow_id, entry.price, condition.min_price, condition.max_price),
+        );
+        return false;
+    }
+
+    // Condition satisfied — mark escrow as released
+    let release_key = (ESCROW_REL_KEY, escrow_id);
+    env.storage().persistent().set(&release_key, &true);
+
+    env.events().publish(
+        (symbol_short!("oracle"), symbol_short!("released")),
+        (escrow_id, entry.price, current_ledger),
+    );
+
+    true
+}
+
+/// Marks an escrow as requiring arbiter intervention due to an oracle issue.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `escrow_id` - The escrow that cannot be automatically released.
+/// * `reason` - Short reason code (e.g., "stale_price", "no_price").
+fn flag_for_arbiter(env: &Env, escrow_id: u64, reason: &str) {
+    env.events().publish(
+        (symbol_short!("oracle"), symbol_short!("arb_flag")),
+        (escrow_id,),
+    );
+}
+
+/// Returns whether an escrow has been released by oracle condition.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `escrow_id` - The escrow to check.
+///
+/// # Returns
+/// `true` if `trigger_release_if_met` previously released the escrow.
+pub fn is_escrow_released(env: &Env, escrow_id: u64) -> bool {
+    let release_key = (ESCROW_REL_KEY, escrow_id);
+    env.storage()
+        .persistent()
+        .get(&release_key)
+        .unwrap_or(false)
+}
+
+/// Registers an address as an authorized oracle price source.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `source` - Address to authorize as an oracle.
+pub fn authorize_oracle(env: &Env, source: Address) {
+    let auth_key = (ORACLE_AUTH_KEY, source);
+    env.storage().persistent().set(&auth_key, &true);
+}
+
+/// Removes an address from the authorized oracle set.
+///
+/// # Arguments
+/// * `env` - Soroban environment reference.
+/// * `source` - Address to deauthorize.
+pub fn deauthorize_oracle(env: &Env, source: Address) {
+    let auth_key = (ORACLE_AUTH_KEY, source);
+    env.storage().persistent().set(&auth_key, &false);
+}


### PR DESCRIPTION
Closes #1524

## Summary

Implements basis-point milestone allocation scheduling in `contracts/escrow_contract/src/milestone_allocation.rs`.

### What's included

- `MilestoneAllocation` struct: `milestone_id` (u32) and `percentage_bps` (u32, out of 10000)
- `set_allocations` — validates sum == 10000, stores schedule persistently, replaces any prior config
- `validate_allocations` — pure function returning `true` if bps sum to exactly 10000
- `get_release_amount` — looks up a milestone's bps and computes `total * bps / 10000` with overflow-safe arithmetic
- `release_milestone` — enforces single-release guard, computes payout, marks milestone released, accumulates released total
- `get_residual` — returns `total_amount - sum(released payouts)` to surface rounding remainder
- `claim_residual` — verifies all milestones released, then transfers any leftover balance to recipient
- Helper reads: `get_allocations`, `is_milestone_released`

All state uses `env.storage().persistent()`. Events emitted on allocation set, milestone release, and residual claim.