### PR TITLE
feat: implement streaming payment contract with storage and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,6 +1400,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "streaming_payment"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["contracts/escrow_contract", "contracts/governance", "contracts/escrow_extensions", "contracts/shared", "contracts/reputation_staking", "contracts/escrow_ownership", "contracts/escrow_linking"]
+members = ["contracts/escrow_contract", "contracts/governance", "contracts/escrow_extensions", "contracts/shared", "contracts/reputation_staking", "contracts/escrow_ownership", "contracts/escrow_linking", "contracts/streaming_payment"]
 resolver = "2"
 
 [profile.release]

--- a/backend/api/controllers/streamController.js
+++ b/backend/api/controllers/streamController.js
@@ -1,0 +1,209 @@
+/**
+ * Stream Controller
+ *
+ * REST endpoints for payment stream data. Read endpoints are cached at the
+ * route level. The /accrued endpoint queries the contract live (not cached).
+ */
+
+import prisma from '../../lib/prisma.js';
+import { logControllerError } from '../../config/logger.js';
+import { xdr, scValToNative } from '@stellar/stellar-sdk';
+
+const STREAMING_CONTRACT_ID = process.env.STREAMING_CONTRACT_ID || '';
+
+// ── Read handlers ─────────────────────────────────────────────────────────────
+
+const listStreams = async (req, res) => {
+  try {
+    const limit = Math.min(Math.max(Number(req.query.limit ?? 20), 1), 100);
+    const { status, sender, recipient, cursor } = req.query;
+    const userAddress = req.user?.walletAddress || req.query.address;
+
+    const where = {};
+
+    if (status) {
+      where.status = status;
+    }
+
+    if (sender) {
+      where.senderAddress = sender;
+    } else if (recipient) {
+      where.recipientAddress = recipient;
+    } else if (userAddress) {
+      where.OR = [
+        { senderAddress: userAddress },
+        { recipientAddress: userAddress },
+      ];
+    }
+
+    const take = limit + 1;
+    const rows = await prisma.paymentStream.findMany({
+      where,
+      take,
+      skip: cursor ? 1 : 0,
+      ...(cursor ? { cursor: { streamId: BigInt(cursor) } } : {}),
+      orderBy: [{ createdAt: 'desc' }, { streamId: 'desc' }],
+    });
+
+    const hasMore = rows.length > limit;
+    const data = hasMore ? rows.slice(0, limit) : rows;
+    const nextCursor = hasMore ? String(data[data.length - 1].streamId) : null;
+
+    res.json({ data, pagination: { limit, nextCursor } });
+  } catch (err) {
+    if (err.message?.includes('Cannot convert')) {
+      return res.status(400).json({ error: 'Invalid stream id' });
+    }
+    logControllerError('stream.listStreams', err, req);
+    res.status(500).json({ error: err.message });
+  }
+};
+
+const getStream = async (req, res) => {
+  try {
+    const streamId = BigInt(req.params.streamId);
+
+    const stream = await prisma.paymentStream.findUnique({
+      where: { streamId },
+    });
+
+    if (!stream) return res.status(404).json({ error: 'Stream not found' });
+    res.json(stream);
+  } catch (err) {
+    if (err.message?.includes('Cannot convert')) {
+      return res.status(400).json({ error: 'Invalid stream id' });
+    }
+    logControllerError('stream.getStream', err, req);
+    res.status(500).json({ error: err.message });
+  }
+};
+
+const getAccrued = async (req, res) => {
+  try {
+    const streamId = BigInt(req.params.streamId);
+
+    if (!STREAMING_CONTRACT_ID) {
+      return res.status(503).json({ error: 'Streaming contract not configured' });
+    }
+
+    // Query the contract directly for the live accrued amount
+    const { SorobanRpc, Contract, Address, nativeToScVal, BASE_FEE } = await import(
+      '@stellar/stellar-sdk'
+    );
+
+    const server = new SorobanRpc.Server(
+      process.env.SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org',
+    );
+
+    const contract = new Contract(STREAMING_CONTRACT_ID);
+    const dummyAccount = new (await import('@stellar/stellar-sdk')).Account(
+      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAV',
+      '0',
+    );
+
+    const { TransactionBuilder } = await import('@stellar/stellar-sdk');
+    const networkPassphrase =
+      process.env.STELLAR_NETWORK === 'mainnet'
+        ? 'Public Global Stellar Network ; September 2015'
+        : 'Test SDF Network ; September 2015';
+
+    const tx = new TransactionBuilder(dummyAccount, {
+      fee: BASE_FEE,
+      networkPassphrase,
+    })
+      .addOperation(contract.call('accrued', nativeToScVal(streamId, { type: 'u64' })))
+      .setTimeout(30)
+      .build();
+
+    const simulation = await server.simulateTransaction(tx);
+
+    if (SorobanRpc.isSimulationError(simulation)) {
+      return res.status(502).json({ error: 'Contract simulation failed', detail: simulation.error });
+    }
+
+    let accrued = 0;
+    if (simulation.result?.retval) {
+      const native = scValToNative(simulation.result.retval);
+      accrued = typeof native === 'bigint' ? native : BigInt(String(native));
+    }
+
+    res.json({ streamId: streamId.toString(), accrued: accrued.toString() });
+  } catch (err) {
+    logControllerError('stream.getAccrued', err, req);
+    res.status(500).json({ error: err.message });
+  }
+};
+
+const buildClaimXdr = async (req, res) => {
+  try {
+    const streamId = BigInt(req.params.streamId);
+    const { recipientAddress } = req.body;
+
+    if (!recipientAddress) {
+      return res.status(400).json({ error: 'recipientAddress is required' });
+    }
+
+    if (!STREAMING_CONTRACT_ID) {
+      return res.status(503).json({ error: 'Streaming contract not configured' });
+    }
+
+    const {
+      SorobanRpc,
+      Contract,
+      Address,
+      nativeToScVal,
+      TransactionBuilder,
+      BASE_FEE,
+    } = await import('@stellar/stellar-sdk');
+
+    const server = new SorobanRpc.Server(
+      process.env.SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org',
+    );
+
+    const networkPassphrase =
+      process.env.STELLAR_NETWORK === 'mainnet'
+        ? 'Public Global Stellar Network ; September 2015'
+        : 'Test SDF Network ; September 2015';
+
+    const account = await server.getAccount(recipientAddress);
+    const contract = new Contract(STREAMING_CONTRACT_ID);
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase,
+    })
+      .addOperation(
+        contract.call(
+          'claim',
+          new Address(recipientAddress).toScVal(),
+          nativeToScVal(streamId, { type: 'u64' }),
+        ),
+      )
+      .setTimeout(300)
+      .build();
+
+    const prepared = await server.simulateTransaction(tx);
+
+    if (SorobanRpc.isSimulationError(prepared)) {
+      return res.status(422).json({
+        error: 'Simulation failed',
+        detail: prepared.error,
+      });
+    }
+
+    const assembled = SorobanRpc.assembleTransaction(tx, prepared).build();
+    const unsignedXdr = assembled.toXDR('base64');
+
+    res.json({ unsignedXdr, streamId: streamId.toString() });
+  } catch (err) {
+    logControllerError('stream.buildClaimXdr', err, req);
+    res.status(500).json({ error: err.message });
+  }
+};
+
+export default {
+  listStreams,
+  getStream,
+  getAccrued,
+  buildClaimXdr,
+};

--- a/backend/api/routes/streamRoutes.js
+++ b/backend/api/routes/streamRoutes.js
@@ -1,0 +1,32 @@
+import express from 'express';
+import streamController from '../controllers/streamController.js';
+import authMiddleware from '../middleware/auth.js';
+
+const router = express.Router();
+router.use(authMiddleware);
+
+/**
+ * @route  GET /api/v1/streams
+ * @desc   List streams for authenticated user (sender or recipient)
+ */
+router.get('/', streamController.listStreams);
+
+/**
+ * @route  GET /api/v1/streams/:streamId
+ * @desc   Get single stream details
+ */
+router.get('/:streamId', streamController.getStream);
+
+/**
+ * @route  GET /api/v1/streams/:streamId/accrued
+ * @desc   Query contract for current accrued amount (live, not cached)
+ */
+router.get('/:streamId/accrued', streamController.getAccrued);
+
+/**
+ * @route  POST /api/v1/streams/:streamId/claim
+ * @desc   Build unsigned claim XDR for client to sign and submit
+ */
+router.post('/:streamId/claim', streamController.buildClaimXdr);
+
+export default router;

--- a/backend/database/schema.prisma
+++ b/backend/database/schema.prisma
@@ -990,3 +990,28 @@ model OwnershipTransferLog {
   @@index([toOwner])
   @@map("ownership_transfer_logs")
 }
+
+// ── Payment Streams ──────────────────────────────────────────────────────────
+
+model PaymentStream {
+  id              String   @id @default(cuid())
+  streamId        BigInt   @unique
+  senderAddress   String   @map("sender_address")
+  recipientAddress String  @map("recipient_address")
+  tokenAddress    String   @map("token_address")
+  totalAmount     String   @map("total_amount")
+  ratePerSecond   String   @map("rate_per_second")
+  startAt         DateTime @map("start_at")
+  status          String   @default("Active")
+  claimedTotal    String   @default("0") @map("claimed_total")
+  lastClaimedAt   DateTime? @map("last_claimed_at")
+  cancelledAt     DateTime? @map("cancelled_at")
+  createdAt       DateTime @default(now()) @map("created_at")
+
+  @@index([senderAddress])
+  @@index([recipientAddress])
+  @@index([status])
+  @@index([senderAddress, createdAt(sort: Desc)])
+  @@index([recipientAddress, createdAt(sort: Desc)])
+  @@map("payment_streams")
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -76,6 +76,8 @@ import { syncFromPrisma, ensureIndex } from './services/reputationSearchService.
 import { createGateway } from './gateway/index.js';
 import queueDashboardRoutes from './api/routes/queueDashboardRoutes.js';
 import chatRoutes from './api/routes/chatRoutes.js';
+import streamRoutes from './api/routes/streamRoutes.js';
+import { startIndexer as startStreamingIndexer } from './services/streamingIndexer.js';
 import { startAnalyticsWorker } from './workers/analyticsWorker.js';
 
 // Attach Prisma query instrumentation (metrics + traces)
@@ -225,6 +227,7 @@ app.use('/api/chat', chatRoutes);
 app.use('/api/v1/templates', templateRoutes);
 app.use('/api/insurance', insuranceRoutes);
 app.use('/api/analytics', analyticsRoutes);
+app.use('/api/v1/streams', streamRoutes);
 app.use('/metrics', metricsRoutes);
 app.use('/admin/queues', queueDashboardRoutes);
 app.use('/.well-known', wellKnownRoutes);
@@ -344,6 +347,10 @@ async function startServer() {
         startIndexer().catch((err) => {
           logger.error({ err, component: 'indexer' }, 'Indexer failed to start');
           Sentry.captureException(err, { tags: { component: 'indexer' } });
+        });
+        startStreamingIndexer().catch((err) => {
+          logger.error({ err, component: 'streaming-indexer' }, 'Streaming indexer failed to start');
+          Sentry.captureException(err, { tags: { component: 'streaming-indexer' } });
         });
         startRpcMonitor();
 

--- a/backend/services/streamingIndexer.js
+++ b/backend/services/streamingIndexer.js
@@ -1,0 +1,281 @@
+/**
+ * Payment Streaming Indexer
+ *
+ * Polls the Stellar network for Soroban contract events emitted by the
+ * streaming payment contract and writes them to PostgreSQL, keeping the
+ * database in sync so the REST API can serve historical data.
+ *
+ * ## Event → DB Mapping
+ *
+ * | Contract Event    | event_type   | DB Side-Effect                            |
+ * |-------------------|--------------|-------------------------------------------|
+ * | StreamCreated     | str_crt      | INSERT PaymentStream + ContractEvent      |
+ * | StreamClaimed     | str_clm      | UPDATE claimed_total + last_claimed_at    |
+ * | StreamCancelled   | str_can      | UPDATE status + cancelledAt               |
+ *
+ * @module streamingIndexer
+ */
+
+import { createModuleLogger } from '../config/logger.js';
+import prisma from '../lib/prisma.js';
+import { scValToNative } from '@stellar/stellar-sdk';
+import { getContractEvents, getLatestLedger } from './stellarService.js';
+
+const log = createModuleLogger('streamingIndexer');
+
+const STREAMING_CONTRACT_ID = process.env.STREAMING_CONTRACT_ID || '';
+const POLL_INTERVAL_MS = parseInt(process.env.STREAMING_INDEXER_POLL_INTERVAL_MS || '5000', 10);
+
+// ─── XDR / value helpers ──────────────────────────────────────────────────────
+
+const _scValToJs = (scVal) => {
+  if (scVal == null) return null;
+  try {
+    return scValToNative(scVal);
+  } catch {
+    return String(scVal);
+  }
+};
+
+const toJson = (value) =>
+  JSON.parse(JSON.stringify(value, (_k, v) => (typeof v === 'bigint' ? v.toString() : v)));
+
+const parseEventType = (topic0) => {
+  if (typeof topic0 === 'string') return topic0;
+  if (topic0?.value) return String(topic0.value());
+  return String(topic0);
+};
+
+const parseAddress = (scVal) => {
+  if (typeof scVal === 'string') return scVal;
+  try {
+    return scVal.address().toString();
+  } catch {
+    return String(scVal);
+  }
+};
+
+const parseBigInt = (scVal) => {
+  if (typeof scVal === 'bigint') return scVal;
+  if (typeof scVal === 'number') return BigInt(scVal);
+  try {
+    return BigInt(scVal.value().toString());
+  } catch {
+    return BigInt(String(scVal));
+  }
+};
+
+const parseOptionU64 = (scVal) => {
+  if (scVal == null) return null;
+  try {
+    const val = scVal.value();
+    if (val == null) return null;
+    return BigInt(val.toString());
+  } catch {
+    return null;
+  }
+};
+
+// ─── Event handlers ───────────────────────────────────────────────────────────
+
+/**
+ * Handles str_crt — inserts a new PaymentStream row.
+ * topic: (str_crt, stream_id)
+ * data:  (sender, recipient, token, total_amount, rate_per_second, start_at)
+ */
+const handleStreamCreated = async (event, meta) => {
+  const streamId = parseBigInt(event.topic[1]);
+  const [sender, recipient, token, totalAmount, ratePerSecond, startAt] = event.value;
+
+  await prisma.$transaction([
+    prisma.paymentStream.upsert({
+      where: { streamId },
+      create: {
+        streamId,
+        senderAddress: parseAddress(sender),
+        recipientAddress: parseAddress(recipient),
+        tokenAddress: parseAddress(token),
+        totalAmount: parseBigInt(totalAmount).toString(),
+        ratePerSecond: parseBigInt(ratePerSecond).toString(),
+        startAt: new Date(Number(parseBigInt(startAt)) * 1000),
+        status: 'Active',
+        claimedTotal: '0',
+      },
+      update: {},
+    }),
+    buildEventInsert(event, meta, streamId),
+  ]);
+
+  log.info({ message: 'stream_created_indexed', streamId: streamId.toString() });
+};
+
+/**
+ * Handles str_clm — updates claimed_total and last_claimed_at.
+ * topic: (str_clm, stream_id)
+ * data:  (amount, recipient, remaining)
+ */
+const handleStreamClaimed = async (event, meta) => {
+  const streamId = parseBigInt(event.topic[1]);
+  const [amount] = event.value;
+  const claimedAmount = parseBigInt(amount);
+
+  await prisma.$transaction([
+    prisma.paymentStream.updateMany({
+      where: { streamId },
+      data: {
+        claimedTotal: { increment: claimedAmount.toString() },
+        lastClaimedAt: meta.ledgerAt,
+        status: 'Active',
+      },
+    }),
+    buildEventInsert(event, meta, streamId),
+  ]);
+
+  log.info({ message: 'stream_claimed_indexed', streamId: streamId.toString(), amount: claimedAmount.toString() });
+};
+
+/**
+ * Handles str_can — marks stream as Cancelled.
+ * topic: (str_can, stream_id)
+ * data:  (to_recipient, to_sender)
+ */
+const handleStreamCancelled = async (event, meta) => {
+  const streamId = parseBigInt(event.topic[1]);
+
+  await prisma.$transaction([
+    prisma.paymentStream.updateMany({
+      where: { streamId },
+      data: {
+        status: 'Cancelled',
+        cancelledAt: meta.ledgerAt,
+      },
+    }),
+    buildEventInsert(event, meta, streamId),
+  ]);
+
+  log.info({ message: 'stream_cancelled_indexed', streamId: streamId.toString() });
+};
+
+// ─── Dispatch ─────────────────────────────────────────────────────────────────
+
+const HANDLERS = {
+  str_crt: handleStreamCreated,
+  str_clm: handleStreamClaimed,
+  str_can: handleStreamCancelled,
+};
+
+const dispatchEvent = async (rawEvent) => {
+  const eventType = parseEventType(rawEvent.topic[0]);
+  const handler = HANDLERS[eventType];
+
+  if (!handler) {
+    log.warn({ message: 'streaming_indexer_unknown_event', eventType });
+    return;
+  }
+
+  const meta = {
+    ledger: BigInt(rawEvent.ledger),
+    ledgerAt: new Date(rawEvent.ledgerClosedAt),
+    txHash: rawEvent.txHash,
+    eventIndex: rawEvent.id ? parseInt(rawEvent.id.split('-')[1] ?? '0', 10) : 0,
+    contractId: rawEvent.contractId,
+  };
+
+  try {
+    await handler(rawEvent, meta);
+  } catch (err) {
+    if (err.code === 'P2002') return;
+    log.error({
+      message: 'streaming_indexer_handle_failed',
+      eventType,
+      error: err.message,
+      stack: err.stack,
+    });
+    throw err;
+  }
+};
+
+// ─── Core loop ────────────────────────────────────────────────────────────────
+
+const fetchAndProcessEvents = async (fromLedger) => {
+  if (!STREAMING_CONTRACT_ID) {
+    log.warn({ message: 'streaming_indexer_contract_id_unset' });
+    return fromLedger;
+  }
+
+  const events = await getContractEvents(fromLedger, STREAMING_CONTRACT_ID);
+  const latestLedger = await getLatestLedger();
+
+  for (const event of events) {
+    await dispatchEvent(event);
+  }
+
+  if (events.length > 0) {
+    log.info({
+      message: 'streaming_indexer_events_processed',
+      count: events.length,
+      latestLedger: String(latestLedger),
+    });
+  }
+
+  return latestLedger;
+};
+
+const startIndexer = async () => {
+  const state = await prisma.indexerState.upsert({
+    where: { id: 2 },
+    create: { id: 2, lastProcessedLedger: BigInt(process.env.STREAMING_INDEXER_START_LEDGER || '0') },
+    update: {},
+  });
+
+  let lastProcessedLedger = Number(state.lastProcessedLedger);
+  log.info({ message: 'streaming_indexer_started', lastProcessedLedger });
+
+  const tick = async () => {
+    try {
+      const latest = await fetchAndProcessEvents(lastProcessedLedger);
+      if (latest > lastProcessedLedger) {
+        lastProcessedLedger = latest;
+        await prisma.indexerState.update({
+          where: { id: 2 },
+          data: { lastProcessedLedger: BigInt(lastProcessedLedger) },
+        });
+      }
+    } catch (err) {
+      log.error({
+        message: 'streaming_indexer_polling_error',
+        error: err.message,
+        stack: err.stack,
+      });
+    }
+  };
+
+  await tick();
+  setInterval(tick, POLL_INTERVAL_MS);
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const buildEventInsert = (event, meta, streamId) =>
+  prisma.contractEvent.create({
+    data: {
+      ledger: meta.ledger,
+      ledgerAt: meta.ledgerAt,
+      contractId: meta.contractId ?? STREAMING_CONTRACT_ID,
+      eventType: parseEventType(event.topic[0]),
+      escrowId: null,
+      topics: toJson(event.topic),
+      data: toJson(event.value),
+      txHash: meta.txHash,
+      eventIndex: meta.eventIndex,
+    },
+  });
+
+export {
+  startIndexer,
+  fetchAndProcessEvents,
+  dispatchEvent,
+  handleStreamCreated,
+  handleStreamClaimed,
+  handleStreamCancelled,
+};

--- a/backend/tests/integration/streamLifecycle.test.js
+++ b/backend/tests/integration/streamLifecycle.test.js
@@ -1,0 +1,187 @@
+import { jest } from '@jest/globals';
+import request from 'supertest';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const prismaMock = {
+  paymentStream: {
+    findUnique: jest.fn(),
+    findMany: jest.fn(),
+    upsert: jest.fn(),
+    updateMany: jest.fn(),
+    count: jest.fn(),
+  },
+  $transaction: jest.fn(async (ops) => (Array.isArray(ops) ? Promise.all(ops) : ops)),
+};
+jest.unstable_mockModule('../../lib/prisma.js', () => ({ default: prismaMock }));
+
+const stellarSdkMock = {
+  SorobanRpc: {
+    Server: jest.fn(() => ({
+      getAccount: jest.fn(),
+      simulateTransaction: jest.fn(),
+    })),
+    isSimulationError: jest.fn(() => false),
+  },
+  TransactionBuilder: jest.fn(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn(() => ({
+      toXDR: jest.fn(() => 'mock_xdr_base64'),
+    })),
+  })),
+  Contract: jest.fn(() => ({
+    call: jest.fn(),
+  })),
+  Address: jest.fn(() => ({
+    toScVal: jest.fn(),
+  })),
+  nativeToScVal: jest.fn(),
+  scValToNative: jest.fn(() => BigInt(0)),
+  BASE_FEE: '100',
+  xdr: { ScVal: { fromXDR: jest.fn() } },
+};
+jest.unstable_mockModule('@stellar/stellar-sdk', () => stellarSdkMock);
+
+const loggerMock = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+jest.unstable_mockModule('../../config/logger.js', () => ({
+  createModuleLogger: () => loggerMock,
+  logControllerError: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../middleware/auth.js', () => ({
+  default: (req, res, next) => {
+    req.user = { walletAddress: req.headers['x-wallet-address'] || 'user123' };
+    next();
+  },
+}));
+
+// ── Import ────────────────────────────────────────────────────────────────────
+
+const express = (await import('express')).default;
+const streamRoutes = (await import('../../api/routes/streamRoutes.js')).default;
+const streamController = (await import('../../api/controllers/streamController.js')).default;
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+let app;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  app = express();
+  app.use(express.json());
+  app.use('/api/v1/streams', streamRoutes);
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('streamRoutes — GET /api/v1/streams', () => {
+  it('returns paginated streams for authenticated user', async () => {
+    const mockStreams = [
+      {
+        streamId: BigInt(1),
+        senderAddress: 'user123',
+        recipientAddress: 'recipient_g',
+        tokenAddress: 'token_g',
+        totalAmount: '100000000000',
+        ratePerSecond: '10000000',
+        status: 'Active',
+        claimedTotal: '0',
+        createdAt: new Date(),
+      },
+    ];
+
+    prismaMock.paymentStream.findMany.mockResolvedValue(mockStreams);
+
+    const res = await request(app)
+      .get('/api/v1/streams')
+      .set('x-wallet-address', 'user123');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.pagination).toBeDefined();
+  });
+
+  it('filters by status', async () => {
+    prismaMock.paymentStream.findMany.mockResolvedValue([]);
+
+    const res = await request(app)
+      .get('/api/v1/streams?status=Cancelled')
+      .set('x-wallet-address', 'user123');
+
+    expect(res.status).toBe(200);
+    const whereArg = prismaMock.paymentStream.findMany.mock.calls[0][0].where;
+    expect(whereArg.status).toBe('Cancelled');
+  });
+});
+
+describe('streamRoutes — GET /api/v1/streams/:streamId', () => {
+  it('returns stream details', async () => {
+    const mockStream = {
+      streamId: BigInt(42),
+      senderAddress: 'sender_g',
+      recipientAddress: 'recipient_g',
+      status: 'Active',
+    };
+    prismaMock.paymentStream.findUnique.mockResolvedValue(mockStream);
+
+    const res = await request(app)
+      .get('/api/v1/streams/42')
+      .set('x-wallet-address', 'user123');
+
+    expect(res.status).toBe(200);
+    expect(res.body.streamId).toBeDefined();
+  });
+
+  it('returns 404 for non-existent stream', async () => {
+    prismaMock.paymentStream.findUnique.mockResolvedValue(null);
+
+    const res = await request(app)
+      .get('/api/v1/streams/999')
+      .set('x-wallet-address', 'user123');
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 for invalid stream id', async () => {
+    prismaMock.paymentStream.findUnique.mockRejectedValue(new Error('Cannot convert'));
+
+    const res = await request(app)
+      .get('/api/v1/streams/invalid')
+      .set('x-wallet-address', 'user123');
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('streamRoutes — POST /api/v1/streams/:streamId/claim', () => {
+  it('builds unsigned claim XDR', async () => {
+    const mockAccount = { sequenceNumber: '0' };
+    const mockServer = {
+      getAccount: jest.fn().mockResolvedValue(mockAccount),
+      simulateTransaction: jest.fn().mockResolvedValue({
+        result: { retval: 'mock_retval' },
+      }),
+    };
+    stellarSdkMock.SorobanRpc.Server.mockImplementation(() => mockServer);
+
+    const res = await request(app)
+      .post('/api/v1/streams/42/claim')
+      .set('x-wallet-address', 'user123')
+      .send({ recipientAddress: 'recipient_g' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.unsignedXdr).toBe('mock_xdr_base64');
+    expect(res.body.streamId).toBe('42');
+  });
+
+  it('returns 400 when recipientAddress missing', async () => {
+    const res = await request(app)
+      .post('/api/v1/streams/42/claim')
+      .set('x-wallet-address', 'user123')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('recipientAddress is required');
+  });
+});

--- a/backend/tests/unit/streamingIndexer.test.js
+++ b/backend/tests/unit/streamingIndexer.test.js
@@ -1,0 +1,181 @@
+import { jest } from '@jest/globals';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const loggerMock = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+jest.unstable_mockModule('../config/logger.js', () => ({
+  createModuleLogger: () => loggerMock,
+}));
+
+const prismaMock = {
+  indexerState: {
+    upsert: jest.fn(),
+    update: jest.fn(),
+  },
+  contractEvent: { create: jest.fn() },
+  paymentStream: {
+    upsert: jest.fn(),
+    updateMany: jest.fn(),
+    findUnique: jest.fn(),
+    findMany: jest.fn(),
+  },
+  $transaction: jest.fn(async (ops) => (Array.isArray(ops) ? Promise.all(ops) : ops)),
+};
+jest.unstable_mockModule('../../lib/prisma.js', () => ({ default: prismaMock }));
+
+jest.unstable_mockModule('../../services/stellarService.js', () => ({
+  getContractEvents: jest.fn(),
+  getLatestLedger: jest.fn(),
+}));
+
+// ── Import SUT ────────────────────────────────────────────────────────────────
+
+const { dispatchEvent, handleStreamCreated, handleStreamClaimed, handleStreamCancelled } =
+  await import('../../services/streamingIndexer.js');
+const { getContractEvents, getLatestLedger } = await import('../../services/stellarService.js');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeEvent(overrides = {}) {
+  return {
+    topic: ['str_crt', '1'],
+    value: ['sender_addr', 'recipient_addr', 'token_addr', '100000000000', '10000000', '1000'],
+    txHash: 'tx_hash_1',
+    id: '0-1',
+    ledger: 100,
+    ledgerClosedAt: '2025-01-15T10:00:00Z',
+    contractId: 'CONTRACT123',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  prismaMock.indexerState.upsert.mockResolvedValue({ id: 2, lastProcessedLedger: BigInt(0) });
+  prismaMock.indexerState.update.mockResolvedValue({});
+  prismaMock.contractEvent.create.mockResolvedValue({});
+  prismaMock.paymentStream.upsert.mockResolvedValue({});
+  prismaMock.paymentStream.updateMany.mockResolvedValue({});
+  getLatestLedger.mockResolvedValue(100);
+  getContractEvents.mockResolvedValue([]);
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('streamingIndexer — StreamCreated handler', () => {
+  it('creates a PaymentStream row on str_crt event', async () => {
+    const event = makeEvent({
+      topic: ['str_crt', '42'],
+      value: ['sender_g', 'recipient_g', 'token_g', '5000000000', '20000000', '2000'],
+    });
+
+    await handleStreamCreated(event, {
+      ledger: BigInt(100),
+      ledgerAt: new Date('2025-01-15T10:00:00Z'),
+      txHash: 'tx1',
+      eventIndex: 0,
+      contractId: 'CONTRACT123',
+    });
+
+    expect(prismaMock.paymentStream.upsert).toHaveBeenCalledTimes(1);
+    const args = prismaMock.paymentStream.upsert.mock.calls[0][0];
+    expect(args.where.streamId).toBe(BigInt(42));
+    expect(args.create.senderAddress).toBe('sender_g');
+    expect(args.create.recipientAddress).toBe('recipient_g');
+    expect(args.create.totalAmount).toBe('5000000000');
+    expect(args.create.ratePerSecond).toBe('20000000');
+    expect(args.create.status).toBe('Active');
+  });
+
+  it('is idempotent on duplicate stream ID', async () => {
+    const err = new Error('Unique constraint');
+    err.code = 'P2002';
+    prismaMock.paymentStream.upsert.mockRejectedValue(err);
+
+    const event = makeEvent({ topic: ['str_crt', '1'] });
+
+    // Should not throw
+    await expect(
+      handleStreamCreated(event, {
+        ledger: BigInt(100),
+        ledgerAt: new Date(),
+        txHash: 'tx1',
+        eventIndex: 0,
+        contractId: 'c',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('streamingIndexer — StreamClaimed handler', () => {
+  it('updates claimed_total and last_claimed_at on str_clm event', async () => {
+    const event = makeEvent({
+      topic: ['str_clm', '42'],
+      value: ['5000000', 'recipient_g', '99995000000'],
+    });
+
+    await handleStreamClaimed(event, {
+      ledger: BigInt(200),
+      ledgerAt: new Date('2025-01-15T11:00:00Z'),
+      txHash: 'tx2',
+      eventIndex: 0,
+      contractId: 'CONTRACT123',
+    });
+
+    expect(prismaMock.paymentStream.updateMany).toHaveBeenCalledTimes(1);
+    const args = prismaMock.paymentStream.updateMany.mock.calls[0][0];
+    expect(args.where).toEqual({ streamId: BigInt(42) });
+    expect(args.data.lastClaimedAt).toEqual(new Date('2025-01-15T11:00:00Z'));
+    expect(args.data.status).toBe('Active');
+  });
+});
+
+describe('streamingIndexer — StreamCancelled handler', () => {
+  it('marks stream as Cancelled on str_can event', async () => {
+    const event = makeEvent({
+      topic: ['str_can', '42'],
+      value: ['30000000', '70000000'],
+    });
+
+    await handleStreamCancelled(event, {
+      ledger: BigInt(300),
+      ledgerAt: new Date('2025-01-15T12:00:00Z'),
+      txHash: 'tx3',
+      eventIndex: 0,
+      contractId: 'CONTRACT123',
+    });
+
+    expect(prismaMock.paymentStream.updateMany).toHaveBeenCalledTimes(1);
+    const args = prismaMock.paymentStream.updateMany.mock.calls[0][0];
+    expect(args.where).toEqual({ streamId: BigInt(42) });
+    expect(args.data.status).toBe('Cancelled');
+    expect(args.data.cancelledAt).toEqual(new Date('2025-01-15T12:00:00Z'));
+  });
+});
+
+describe('streamingIndexer — dispatchEvent', () => {
+  it('routes str_crt to handleStreamCreated', async () => {
+    const event = makeEvent({ topic: ['str_crt', '1'] });
+    await dispatchEvent(event);
+    expect(prismaMock.paymentStream.upsert).toHaveBeenCalled();
+  });
+
+  it('routes str_clm to handleStreamClaimed', async () => {
+    const event = makeEvent({ topic: ['str_clm', '1'], value: ['1000', 'addr', '99000'] });
+    await dispatchEvent(event);
+    expect(prismaMock.paymentStream.updateMany).toHaveBeenCalled();
+  });
+
+  it('routes str_can to handleStreamCancelled', async () => {
+    const event = makeEvent({ topic: ['str_can', '1'], value: ['5000', '5000'] });
+    await dispatchEvent(event);
+    expect(prismaMock.paymentStream.updateMany).toHaveBeenCalled();
+  });
+
+  it('ignores unknown event types', async () => {
+    const event = makeEvent({ topic: ['unknown_evt', '1'] });
+    await dispatchEvent(event);
+    expect(prismaMock.paymentStream.upsert).not.toHaveBeenCalled();
+    expect(prismaMock.paymentStream.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/contracts/streaming_payment/Cargo.toml
+++ b/contracts/streaming_payment/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "streaming_payment"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+soroban-sdk = { version = "21.0.0" }
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/contracts/streaming_payment/src/errors.rs
+++ b/contracts/streaming_payment/src/errors.rs
@@ -1,0 +1,16 @@
+use soroban_sdk::contracterror;
+
+#[contracterror(export = false)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum StreamError {
+    StreamNotFound = 1,
+    AlreadyDrained = 2,
+    NotRecipient = 3,
+    NotSender = 4,
+    AlreadyCompleted = 5,
+    NotActive = 6,
+    ZeroAmount = 7,
+    InvalidRate = 8,
+    InvalidStart = 9,
+}

--- a/contracts/streaming_payment/src/events.rs
+++ b/contracts/streaming_payment/src/events.rs
@@ -1,0 +1,71 @@
+use soroban_sdk::{symbol_short, Address, Env, Symbol};
+
+pub const STREAM_CREATED: Symbol = symbol_short!("str_crt");
+pub const STREAM_CLAIMED: Symbol = symbol_short!("str_clm");
+pub const STREAM_PAUSED: Symbol = symbol_short!("str_pau");
+pub const STREAM_RESUMED: Symbol = symbol_short!("str_res");
+pub const STREAM_CANCELLED: Symbol = symbol_short!("str_can");
+pub const STREAM_DRAINED: Symbol = symbol_short!("str_drn");
+
+pub fn emit_stream_created(
+    env: &Env,
+    stream_id: u64,
+    sender: &Address,
+    recipient: &Address,
+    token: &Address,
+    total_amount: i128,
+    rate_per_second: i128,
+    start_at: u64,
+) {
+    env.events().publish(
+        (STREAM_CREATED, stream_id),
+        (
+            sender.clone(),
+            recipient.clone(),
+            token.clone(),
+            total_amount,
+            rate_per_second,
+            start_at,
+        ),
+    );
+}
+
+pub fn emit_stream_claimed(
+    env: &Env,
+    stream_id: u64,
+    amount: i128,
+    recipient: &Address,
+    remaining: i128,
+) {
+    env.events().publish(
+        (STREAM_CLAIMED, stream_id),
+        (amount, recipient.clone(), remaining),
+    );
+}
+
+pub fn emit_stream_paused(env: &Env, stream_id: u64) {
+    env.events()
+        .publish((STREAM_PAUSED, stream_id), ());
+}
+
+pub fn emit_stream_resumed(env: &Env, stream_id: u64) {
+    env.events()
+        .publish((STREAM_RESUMED, stream_id), ());
+}
+
+pub fn emit_stream_cancelled(
+    env: &Env,
+    stream_id: u64,
+    to_recipient: i128,
+    to_sender: i128,
+) {
+    env.events().publish(
+        (STREAM_CANCELLED, stream_id),
+        (to_recipient, to_sender),
+    );
+}
+
+pub fn emit_stream_drained(env: &Env, stream_id: u64) {
+    env.events()
+        .publish((STREAM_DRAINED, stream_id), ());
+}

--- a/contracts/streaming_payment/src/lib.rs
+++ b/contracts/streaming_payment/src/lib.rs
@@ -1,0 +1,304 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, IntoVal, Symbol, Val, Vec};
+
+mod errors;
+mod events;
+mod storage;
+mod tests;
+mod types;
+
+pub use errors::StreamError;
+pub use types::{DataKey, Stream, StreamStatus, RATE_PRECISION};
+
+const TRANSFER: Symbol = symbol_short!("transfer");
+
+#[contract]
+pub struct StreamingPaymentContract;
+
+#[contractimpl]
+impl StreamingPaymentContract {
+    /// Create a new payment stream. Transfers `total_amount` from `sender` to
+    /// this contract as escrow. Returns a monotonically-increasing stream_id.
+    pub fn create_stream(
+        env: Env,
+        sender: Address,
+        recipient: Address,
+        token: Address,
+        total_amount: i128,
+        rate_per_second: i128,
+        start_at: u64,
+    ) -> u64 {
+        sender.require_auth();
+
+        if total_amount <= 0 {
+            panic!("total_amount must be positive");
+        }
+        if rate_per_second <= 0 {
+            panic!("rate_per_second must be positive");
+        }
+
+        let now = env.ledger().timestamp();
+        if start_at < now {
+            panic!("start_at must be in the present or future");
+        }
+
+        // Transfer tokens from sender to this contract (escrow)
+        let args: Vec<Val> = Vec::from_array(
+            &env,
+            [
+                sender.to_val(),
+                env.current_contract_address().to_val(),
+                total_amount.into_val(&env),
+            ],
+        );
+        env.invoke_contract::<i128>(&token, &TRANSFER, args);
+
+        let stream_id = storage::increment_stream_count(&env);
+
+        let stream = Stream {
+            sender: sender.clone(),
+            recipient: recipient.clone(),
+            token: token.clone(),
+            total_amount,
+            remaining_balance: total_amount,
+            rate_per_second,
+            start_at,
+            last_claim_time: start_at,
+            paused: false,
+            paused_at: None,
+            status: StreamStatus::Active,
+        };
+
+        storage::set_stream(&env, stream_id, &stream);
+
+        events::emit_stream_created(
+            &env,
+            stream_id,
+            &sender,
+            &recipient,
+            &token,
+            total_amount,
+            rate_per_second,
+            start_at,
+        );
+
+        stream_id
+    }
+
+    /// Claim all accrued-but-unclaimed tokens. Only callable by the stream
+    /// recipient. Returns the amount transferred.
+    pub fn claim(env: Env, recipient: Address, stream_id: u64) -> i128 {
+        recipient.require_auth();
+
+        let mut stream = storage::get_stream(&env, stream_id);
+
+        if stream.recipient != recipient {
+            panic!("not the stream recipient");
+        }
+        if stream.status == StreamStatus::Completed {
+            panic!("stream already completed");
+        }
+        if stream.status == StreamStatus::Cancelled {
+            panic!("stream already cancelled");
+        }
+        if stream.remaining_balance <= 0 {
+            return 0;
+        }
+
+        let accrued = Self::_accrued_amount(&env, &stream);
+        if accrued <= 0 {
+            return 0;
+        }
+
+        let amount = core::cmp::min(accrued, stream.remaining_balance);
+
+        // Transfer tokens from contract to recipient
+        let args: Vec<Val> = Vec::from_array(
+            &env,
+            [
+                env.current_contract_address().to_val(),
+                recipient.to_val(),
+                amount.into_val(&env),
+            ],
+        );
+        env.invoke_contract::<i128>(&stream.token, &TRANSFER, args);
+
+        stream.remaining_balance -= amount;
+        stream.last_claim_time = env.ledger().timestamp();
+
+        if stream.remaining_balance <= 0 {
+            stream.status = StreamStatus::Completed;
+            events::emit_stream_drained(&env, stream_id);
+        }
+
+        storage::set_stream(&env, stream_id, &stream);
+
+        events::emit_stream_claimed(
+            &env,
+            stream_id,
+            amount,
+            &recipient,
+            stream.remaining_balance,
+        );
+
+        amount
+    }
+
+    /// Pause a stream. Only callable by the sender. Stops the drain. No-op if
+    /// already paused.
+    pub fn pause(env: Env, sender: Address, stream_id: u64) {
+        sender.require_auth();
+
+        let mut stream = storage::get_stream(&env, stream_id);
+
+        if stream.sender != sender {
+            panic!("not the stream sender");
+        }
+        if stream.status != StreamStatus::Active && stream.status != StreamStatus::Paused {
+            panic!("stream not in a pausable state");
+        }
+        if stream.paused {
+            return; // no-op
+        }
+
+        // Accrue up to now before pausing so we don't lose time
+        let accrued = Self::_accrued_amount(&env, &stream);
+        if accrued > 0 {
+            stream.last_claim_time = env.ledger().timestamp();
+            stream.remaining_balance -= core::cmp::min(accrued, stream.remaining_balance);
+        }
+
+        stream.paused = true;
+        stream.paused_at = Some(env.ledger().timestamp());
+        stream.status = StreamStatus::Paused;
+
+        storage::set_stream(&env, stream_id, &stream);
+        events::emit_stream_paused(&env, stream_id);
+    }
+
+    /// Resume a paused stream. Only callable by the sender. Resets start_at to
+    /// the current ledger timestamp.
+    pub fn resume(env: Env, sender: Address, stream_id: u64) {
+        sender.require_auth();
+
+        let mut stream = storage::get_stream(&env, stream_id);
+
+        if stream.sender != sender {
+            panic!("not the stream sender");
+        }
+        if stream.status != StreamStatus::Paused {
+            return; // no-op or error — treat as no-op
+        }
+
+        let now = env.ledger().timestamp();
+        stream.start_at = now;
+        stream.last_claim_time = now;
+        stream.paused = false;
+        stream.paused_at = None;
+        stream.status = StreamStatus::Active;
+
+        storage::set_stream(&env, stream_id, &stream);
+        events::emit_stream_resumed(&env, stream_id);
+    }
+
+    /// Cancel a stream. Only callable by the sender. Claims recipient's accrued
+    /// amount first, then returns the remaining balance to the sender.
+    pub fn cancel(env: Env, sender: Address, stream_id: u64) -> (i128, i128) {
+        sender.require_auth();
+
+        let mut stream = storage::get_stream(&env, stream_id);
+
+        if stream.sender != sender {
+            panic!("not the stream sender");
+        }
+        if stream.status == StreamStatus::Completed {
+            panic!("stream already completed");
+        }
+        if stream.status == StreamStatus::Cancelled {
+            panic!("stream already cancelled");
+        }
+
+        // Calculate accrued for recipient
+        let accrued = Self::_accrued_amount(&env, &stream);
+        let to_recipient = core::cmp::min(accrued, stream.remaining_balance);
+
+        // Transfer accrued to recipient
+        if to_recipient > 0 {
+            let args: Vec<Val> = Vec::from_array(
+                &env,
+                [
+                    env.current_contract_address().to_val(),
+                    stream.recipient.to_val(),
+                    to_recipient.into_val(&env),
+                ],
+            );
+            env.invoke_contract::<i128>(&stream.token, &TRANSFER, args);
+            stream.remaining_balance -= to_recipient;
+        }
+
+        let to_sender = stream.remaining_balance;
+
+        // Return remaining to sender
+        if to_sender > 0 {
+            let args: Vec<Val> = Vec::from_array(
+                &env,
+                [
+                    env.current_contract_address().to_val(),
+                    sender.to_val(),
+                    to_sender.into_val(&env),
+                ],
+            );
+            env.invoke_contract::<i128>(&stream.token, &TRANSFER, args);
+            stream.remaining_balance = 0;
+        }
+
+        stream.status = StreamStatus::Cancelled;
+        storage::set_stream(&env, stream_id, &stream);
+
+        events::emit_stream_cancelled(&env, stream_id, to_recipient, to_sender);
+
+        (to_recipient, to_sender)
+    }
+
+    /// View: how many tokens has the recipient accrued so far (unclaimed)?
+    pub fn accrued(env: Env, stream_id: u64) -> i128 {
+        let stream = storage::get_stream(&env, stream_id);
+        Self::_accrued_amount(&env, &stream)
+    }
+}
+
+/// Internal helpers
+#[contractimpl]
+impl StreamingPaymentContract {
+    /// Pure accrual calculation based on the stream's current state and the
+    /// ledger timestamp.
+    fn _accrued_amount(env: &Env, stream: &Stream) -> i128 {
+        if stream.status == StreamStatus::Completed
+            || stream.status == StreamStatus::Cancelled
+            || stream.paused
+            || stream.remaining_balance <= 0
+        {
+            return 0;
+        }
+
+        let now = env.ledger().timestamp();
+        if now <= stream.start_at {
+            return 0;
+        }
+
+        // Use last_claim_time as the accrual baseline. If last_claim_time is
+        // before start_at (initial state), use start_at instead.
+        let since = if stream.last_claim_time < stream.start_at {
+            now - stream.start_at
+        } else if now > stream.last_claim_time {
+            now - stream.last_claim_time
+        } else {
+            return 0;
+        };
+
+        // accrued = elapsed_seconds * rate_per_second
+        let accrued = (since as i128) * stream.rate_per_second;
+        core::cmp::min(accrued, stream.remaining_balance)
+    }
+}

--- a/contracts/streaming_payment/src/storage.rs
+++ b/contracts/streaming_payment/src/storage.rs
@@ -1,0 +1,31 @@
+use soroban_sdk::{Env};
+
+use crate::types::{DataKey, Stream};
+
+pub fn get_stream(env: &Env, stream_id: u64) -> Stream {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Stream(stream_id))
+        .expect("stream not found")
+}
+
+pub fn set_stream(env: &Env, stream_id: u64, stream: &Stream) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Stream(stream_id), stream);
+}
+
+pub fn get_stream_count(env: &Env) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::StreamCount)
+        .unwrap_or(0)
+}
+
+pub fn increment_stream_count(env: &Env) -> u64 {
+    let count = get_stream_count(env);
+    env.storage()
+        .persistent()
+        .set(&DataKey::StreamCount, &(count + 1));
+    count + 1
+}

--- a/contracts/streaming_payment/src/tests.rs
+++ b/contracts/streaming_payment/src/tests.rs
@@ -1,0 +1,507 @@
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
+
+use crate::types::RATE_PRECISION;
+use crate::{StreamingPaymentContract, StreamingPaymentContractClient};
+
+// ── Minimal mock token ──────────────────────────────────────────────────────
+
+mod mock_token {
+    use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol};
+
+    const _MINT: Symbol = symbol_short!("mint");
+    const _TRANSFER: Symbol = symbol_short!("transfer");
+    const _BALANCE: Symbol = symbol_short!("balance");
+
+    #[contracttype]
+    #[derive(Clone)]
+    pub enum DataKey {
+        Bal(Address),
+    }
+
+    #[contract]
+    pub struct MockToken;
+
+    pub use MockTokenClient as Client;
+
+    #[contractimpl]
+    impl MockToken {
+        pub fn mint(env: Env, to: Address, amount: i128) {
+            let bal: i128 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Bal(to.clone()))
+                .unwrap_or(0);
+            env.storage()
+                .persistent()
+                .set(&DataKey::Bal(to), &(bal + amount));
+        }
+
+        pub fn transfer(env: Env, from: Address, to: Address, amount: i128) -> i128 {
+            let from_bal: i128 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Bal(from.clone()))
+                .unwrap_or(0);
+            assert!(from_bal >= amount, "insufficient balance");
+            env.storage()
+                .persistent()
+                .set(&DataKey::Bal(from), &(from_bal - amount));
+            let to_bal: i128 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Bal(to.clone()))
+                .unwrap_or(0);
+            env.storage()
+                .persistent()
+                .set(&DataKey::Bal(to), &(to_bal + amount));
+            amount
+        }
+
+        pub fn balance(env: Env, account: Address) -> i128 {
+            env.storage()
+                .persistent()
+                .get(&DataKey::Bal(account))
+                .unwrap_or(0)
+        }
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, Address, Address, Address) {
+    let env = Env::default();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    // Deploy mock token
+    let token_id = env.register_contract(None::<&Address>, mock_token::MockToken);
+    let token_client = mock_token::Client::new(&env, &token_id);
+
+    // Mint 1,000,000 tokens to sender (at 1e7 precision)
+    token_client.mint(&sender, &1_000_000_000_000_i128); // 100,000 tokens
+
+    (env, sender, recipient, token_id)
+}
+
+fn create_stream(
+    env: &Env,
+    sender: &Address,
+    recipient: &Address,
+    token: &Address,
+    total_amount: i128,
+    rate: i128,
+    start_at: u64,
+) -> (Address, u64) {
+    let stream_contract = env.register_contract(None::<&Address>, StreamingPaymentContract);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_at;
+    });
+    env.mock_all_auths();
+
+    let client = StreamingPaymentContractClient::new(env, &stream_contract);
+    let stream_id = client.create_stream(
+        sender,
+        recipient,
+        token,
+        &total_amount,
+        &rate,
+        &start_at,
+    );
+
+    (stream_contract, stream_id)
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_create_stream_escrows_tokens() {
+    let (env, sender, recipient, token) = setup();
+    let token_client = mock_token::Client::new(&env, &token);
+
+    let (stream_contract, stream_id) = create_stream(
+        &env,
+        &sender,
+        &recipient,
+        &token,
+        100_000_000_000_i128,
+        RATE_PRECISION * 1,
+        1000,
+    );
+
+    // Sender's balance should decrease
+    let sender_bal = token_client.balance(&sender);
+    assert_eq!(sender_bal, 1_000_000_000_000 - 100_000_000_000);
+
+    // Contract should hold the escrowed tokens
+    let contract_bal = token_client.balance(&stream_contract);
+    assert_eq!(contract_bal, 100_000_000_000);
+
+    assert_eq!(stream_id, 1);
+}
+
+#[test]
+fn test_accrued_returns_zero_before_start_at() {
+    let (env, sender, recipient, token) = setup();
+
+    let stream_contract = env.register_contract(None::<&Address>, StreamingPaymentContract);
+    let client = StreamingPaymentContractClient::new(&env, &stream_contract);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+    env.mock_all_auths();
+
+    let stream_id = client.create_stream(
+        &sender,
+        &recipient,
+        &token,
+        &100_000_000_000_i128,
+        &(RATE_PRECISION * 1),
+        &2000,
+    );
+
+    let accrued = client.accrued(&stream_id);
+    assert_eq!(accrued, 0);
+}
+
+#[test]
+fn test_accrued_after_ten_seconds() {
+    let (env, sender, recipient, token) = setup();
+
+    let stream_contract = env.register_contract(None::<&Address>, StreamingPaymentContract);
+    let client = StreamingPaymentContractClient::new(&env, &stream_contract);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+    env.mock_all_auths();
+
+    let stream_id = client.create_stream(
+        &sender,
+        &recipient,
+        &token,
+        &100_000_000_000_i128,
+        &(RATE_PRECISION * 1),
+        &1000,
+    );
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1010;
+    });
+
+    let accrued = client.accrued(&stream_id);
+    assert_eq!(accrued, 10 * RATE_PRECISION);
+}
+
+#[test]
+fn test_claim_transfers_correct_amount() {
+    let (env, sender, recipient, token) = setup();
+    let token_client = mock_token::Client::new(&env, &token);
+
+    let stream_contract = env.register_contract(None::<&Address>, StreamingPaymentContract);
+    let client = StreamingPaymentContractClient::new(&env, &stream_contract);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+    env.mock_all_auths();
+
+    let stream_id = client.create_stream(
+        &sender,
+        &recipient,
+        &token,
+        &100_000_000_000_i128,
+        &(RATE_PRECISION * 1),
+        &1000,
+    );
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1010;
+    });
+
+    let claimed = client.claim(&recipient, &stream_id);
+    assert_eq!(claimed, 10 * RATE_PRECISION);
+
+    let recipient_bal = token_client.balance(&recipient);
+    assert_eq!(recipient_bal, 10 * RATE_PRECISION);
+}
+
+#[test]
+fn test_cancel_splits_correctly() {
+    let (env, sender, recipient, token) = setup();
+    let token_client = mock_token::Client::new(&env, &token);
+
+    let stream_contract = env.register_contract(None::<&Address>, StreamingPaymentContract);
+    let client = StreamingPaymentContractClient::new(&env, &stream_contract);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+    env.mock_all_auths();
+
+    let total = 100_000_000_000_i128;
+    let stream_id = client.create_stream(
+        &sender,
+        &recipient,
+        &token,
+        &total,
+        &(RATE_PRECISION * 1),
+        &1000,
+    );
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1030;
+    });
+
+    let (to_recipient, to_sender) = client.cancel(&sender, &stream_id);
+
+    assert_eq!(to_recipient, 30 * RATE_PRECISION);
+    assert_eq!(to_sender, total - 30 * RATE_PRECISION);
+    assert_eq!(to_recipient + to_sender, total);
+
+    let recipient_bal = token_client.balance(&recipient);
+    assert_eq!(recipient_bal, 30 * RATE_PRECISION);
+
+    let sender_bal = token_client.balance(&sender);
+    assert_eq!(sender_bal, 1_000_000_000_000 - total + (total - 30 * RATE_PRECISION));
+}
+
+#[test]
+fn test_claim_before_start_returns_zero() {
+    let (env, sender, recipient, token) = setup();
+
+    let stream_contract = env.register_contract(None::<&Address>, StreamingPaymentContract);
+    let client = StreamingPaymentContractClient::new(&env, &stream_contract);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+    env.mock_all_auths();
+
+    let stream_id = client.create_stream(
+        &sender,
+        &recipient,
+        &token,
+        &100_000_000_000_i128,
+        &(RATE_PRECISION * 1),
+        &5000,
+    );
+
+    let claimed = client.claim(&recipient, &stream_id);
+    assert_eq!(claimed, 0);
+}
+
+#[test]
+fn test_pause_stops_accrual() {
+    let (env, sender, recipient, token) = setup();
+
+    let stream_contract = env.register_contract(None::<&Address>, StreamingPaymentContract);
+    let client = StreamingPaymentContractClient::new(&env, &stream_contract);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+    env.mock_all_auths();
+
+    let stream_id = client.create_stream(
+        &sender,
+        &recipient,
+        &token,
+        &100_000_000_000_i128,
+        &(RATE_PRECISION * 1),
+        &1000,
+    );
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1005;
+    });
+    client.pause(&sender, &stream_id);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1020;
+    });
+
+    let accrued = client.accrued(&stream_id);
+    assert_eq!(accrued, 0);
+}
+
+#[test]
+fn test_resume_restarts_accrual() {
+    let (env, sender, recipient, token) = setup();
+
+    let stream_contract = env.register_contract(None::<&Address>, StreamingPaymentContract);
+    let client = StreamingPaymentContractClient::new(&env, &stream_contract);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+    env.mock_all_auths();
+
+    let stream_id = client.create_stream(
+        &sender,
+        &recipient,
+        &token,
+        &100_000_000_000_i128,
+        &(RATE_PRECISION * 1),
+        &1000,
+    );
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1005;
+    });
+    client.pause(&sender, &stream_id);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1007;
+    });
+    client.resume(&sender, &stream_id);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1010;
+    });
+
+    let accrued = client.accrued(&stream_id);
+    assert_eq!(accrued, 3 * RATE_PRECISION);
+}
+
+#[test]
+fn test_cancel_on_completed_stream_is_error() {
+    let (env, sender, recipient, token) = setup();
+
+    let stream_contract = env.register_contract(None::<&Address>, StreamingPaymentContract);
+    let client = StreamingPaymentContractClient::new(&env, &stream_contract);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+    env.mock_all_auths();
+
+    let stream_id = client.create_stream(
+        &sender,
+        &recipient,
+        &token,
+        &100_000_000_i128,
+        &(RATE_PRECISION * 1),
+        &1000,
+    );
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1010;
+    });
+    let _ = client.claim(&recipient, &stream_id);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1020;
+    });
+    let result = client.try_cancel(&sender, &stream_id);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_pause_on_already_paused_is_noop() {
+    let (env, sender, recipient, token) = setup();
+
+    let stream_contract = env.register_contract(None::<&Address>, StreamingPaymentContract);
+    let client = StreamingPaymentContractClient::new(&env, &stream_contract);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+    env.mock_all_auths();
+
+    let stream_id = client.create_stream(
+        &sender,
+        &recipient,
+        &token,
+        &100_000_000_000_i128,
+        &(RATE_PRECISION * 1),
+        &1000,
+    );
+
+    client.pause(&sender, &stream_id);
+    client.pause(&sender, &stream_id);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1010;
+    });
+
+    let accrued = client.accrued(&stream_id);
+    assert_eq!(accrued, 0);
+}
+
+#[test]
+fn test_stream_count_increments() {
+    let (env, sender, recipient, token) = setup();
+
+    let stream_contract = env.register_contract(None::<&Address>, StreamingPaymentContract);
+    let client = StreamingPaymentContractClient::new(&env, &stream_contract);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+    env.mock_all_auths();
+
+    let id1 = client.create_stream(
+        &sender,
+        &recipient,
+        &token,
+        &100_000_000_000_i128,
+        &(RATE_PRECISION * 1),
+        &1000,
+    );
+
+    let id2 = client.create_stream(
+        &sender,
+        &recipient,
+        &token,
+        &100_000_000_000_i128,
+        &(RATE_PRECISION * 1),
+        &1000,
+    );
+
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
+}
+
+#[test]
+fn test_multiple_claims_accumulate() {
+    let (env, sender, recipient, token) = setup();
+    let token_client = mock_token::Client::new(&env, &token);
+
+    let stream_contract = env.register_contract(None::<&Address>, StreamingPaymentContract);
+    let client = StreamingPaymentContractClient::new(&env, &stream_contract);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+    });
+    env.mock_all_auths();
+
+    let stream_id = client.create_stream(
+        &sender,
+        &recipient,
+        &token,
+        &100_000_000_000_i128,
+        &(RATE_PRECISION * 1),
+        &1000,
+    );
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1005;
+    });
+    let c1 = client.claim(&recipient, &stream_id);
+    assert_eq!(c1, 5 * RATE_PRECISION);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1010;
+    });
+    let c2 = client.claim(&recipient, &stream_id);
+    assert_eq!(c2, 5 * RATE_PRECISION);
+
+    assert_eq!(token_client.balance(&recipient), 10 * RATE_PRECISION);
+}

--- a/contracts/streaming_payment/src/types.rs
+++ b/contracts/streaming_payment/src/types.rs
@@ -1,0 +1,36 @@
+use soroban_sdk::{contracttype, Address};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StreamStatus {
+    Active,
+    Paused,
+    Completed,
+    Cancelled,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Stream {
+    pub sender: Address,
+    pub recipient: Address,
+    pub token: Address,
+    pub total_amount: i128,
+    pub remaining_balance: i128,
+    pub rate_per_second: i128,
+    pub start_at: u64,
+    pub last_claim_time: u64,
+    pub paused: bool,
+    pub paused_at: Option<u64>,
+    pub status: StreamStatus,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Stream(u64),
+    StreamCount,
+}
+
+/// Precision divisor for rate_per_second (1e7 = Stellar's standard integer precision).
+pub const RATE_PRECISION: i128 = 10_000_000;

--- a/frontend/components/streams/StreamCard.tsx
+++ b/frontend/components/streams/StreamCard.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import { useState } from 'react';
+import { useStreamAccrual } from '../../hooks/useStreamAccrual';
+import { cn } from '../../lib/utils';
+import { truncateAddress } from '../../lib/stellar';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+const RATE_PRECISION = 10_000_000;
+
+function formatTokenAmount(amount, decimals = 7) {
+  const num = Number(amount);
+  if (!num) return '0';
+  const formatted = num / RATE_PRECISION;
+  return formatted.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  });
+}
+
+function formatRate(ratePerSecond) {
+  const num = Number(ratePerSecond);
+  if (!num) return '0';
+  const tokensPerSec = num / RATE_PRECISION;
+  if (tokensPerSec < 0.001) return `${(tokensPerSec * 3600).toFixed(2)} tok/hr`;
+  if (tokensPerSec < 1) return `${tokensPerSec.toFixed(4)} tok/sec`;
+  return `${tokensPerSec.toFixed(2)} tok/sec`;
+}
+
+export default function StreamCard({ stream, role, onAction }) {
+  const { accrued, progress } = useStreamAccrual(stream);
+  const [loading, setLoading] = useState(false);
+  const isSender = role === 'sender';
+  const recipient = stream.recipientAddress;
+  const sender = stream.senderAddress;
+
+  const handleClaim = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_URL}/api/v1/streams/${stream.streamId}/claim`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ recipientAddress: recipient }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error);
+
+      const { signWithFreighter } = await import('../../lib/soroban');
+      const signed = await signWithFreighter(data.unsignedXdr);
+
+      const submitRes = await fetch(`${API_URL}/api/escrows/broadcast`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ signedXdr: signed }),
+      });
+      if (!submitRes.ok) throw new Error('Submission failed');
+
+      onAction?.();
+    } catch (err) {
+      console.error('Claim failed:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handlePause = async () => {
+    setLoading(true);
+    try {
+      const { signWithFreighter } = await import('../../lib/soroban');
+      const { SorobanRpc, TransactionBuilder, Contract, Address, nativeToScVal, BASE_FEE } = await import(
+        '@stellar/stellar-sdk'
+      );
+
+      const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet';
+      const RPC_URL = process.env.NEXT_PUBLIC_SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org';
+      const CONTRACT = process.env.NEXT_PUBLIC_STREAMING_CONTRACT_ADDRESS || '';
+      const PASSPHRASE =
+        NETWORK === 'mainnet'
+          ? 'Public Global Stellar Network ; September 2015'
+          : 'Test SDF Network ; September 2015';
+
+      const server = new SorobanRpc.Server(RPC_URL);
+      const account = await server.getAccount(sender);
+      const contract = new Contract(CONTRACT);
+
+      const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: PASSPHRASE })
+        .addOperation(
+          contract.call(
+            'pause',
+            new Address(sender).toScVal(),
+            nativeToScVal(BigInt(stream.streamId), { type: 'u64' }),
+          ),
+        )
+        .setTimeout(300)
+        .build();
+
+      const prepared = await server.simulateTransaction(tx);
+      if (SorobanRpc.isSimulationError(prepared)) throw new Error(prepared.error);
+      const assembled = SorobanRpc.assembleTransaction(tx, prepared).build();
+      const signed = await signWithFreighter(assembled.toXDR('base64'));
+
+      await fetch(`${API_URL}/api/escrows/broadcast`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ signedXdr: signed }),
+      });
+
+      onAction?.();
+    } catch (err) {
+      console.error('Pause failed:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    setLoading(true);
+    try {
+      const { signWithFreighter } = await import('../../lib/soroban');
+      const { SorobanRpc, TransactionBuilder, Contract, Address, nativeToScVal, BASE_FEE } = await import(
+        '@stellar/stellar-sdk'
+      );
+
+      const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet';
+      const RPC_URL = process.env.NEXT_PUBLIC_SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org';
+      const CONTRACT = process.env.NEXT_PUBLIC_STREAMING_CONTRACT_ADDRESS || '';
+      const PASSPHRASE =
+        NETWORK === 'mainnet'
+          ? 'Public Global Stellar Network ; September 2015'
+          : 'Test SDF Network ; September 2015';
+
+      const server = new SorobanRpc.Server(RPC_URL);
+      const account = await server.getAccount(sender);
+      const contract = new Contract(CONTRACT);
+
+      const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: PASSPHRASE })
+        .addOperation(
+          contract.call(
+            'cancel',
+            new Address(sender).toScVal(),
+            nativeToScVal(BigInt(stream.streamId), { type: 'u64' }),
+          ),
+        )
+        .setTimeout(300)
+        .build();
+
+      const prepared = await server.simulateTransaction(tx);
+      if (SorobanRpc.isSimulationError(prepared)) throw new Error(prepared.error);
+      const assembled = SorobanRpc.assembleTransaction(tx, prepared).build();
+      const signed = await signWithFreighter(assembled.toXDR('base64'));
+
+      await fetch(`${API_URL}/api/escrows/broadcast`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ signedXdr: signed }),
+      });
+
+      onAction?.();
+    } catch (err) {
+      console.error('Cancel failed:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const statusColor = {
+    Active: 'text-emerald-400 bg-emerald-400/10',
+    Paused: 'text-yellow-400 bg-yellow-400/10',
+    Completed: 'text-gray-400 bg-gray-400/10',
+    Cancelled: 'text-red-400 bg-red-400/10',
+  };
+
+  return (
+    <div className="card p-4 mb-3 hover:border-gray-700 transition-colors">
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex-1 min-w-0">
+          <p className="text-xs text-gray-500 mb-1">
+            {isSender ? 'To:' : 'From:'}{' '}
+            <span className="font-mono text-gray-300">
+              {truncateAddress(isSender ? recipient : sender)}
+            </span>
+          </p>
+          <p className="text-xs text-gray-500">
+            Stream #{stream.streamId.toString()}
+          </p>
+        </div>
+        <span className={cn('text-xs font-medium px-2 py-1 rounded-full', statusColor[stream.status] || 'text-gray-400')}>
+          {stream.status}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 mb-3 text-sm">
+        <div>
+          <span className="text-gray-500 text-xs block">Rate</span>
+          <span className="text-white">{formatRate(stream.ratePerSecond)}</span>
+        </div>
+        <div>
+          <span className="text-gray-500 text-xs block">Accrued</span>
+          <span className="text-emerald-400 font-mono">{accrued}</span>
+        </div>
+        <div>
+          <span className="text-gray-500 text-xs block">Total</span>
+          <span className="text-gray-300">{formatTokenAmount(stream.totalAmount)}</span>
+        </div>
+        <div>
+          <span className="text-gray-500 text-xs block">Remaining</span>
+          <span className="text-gray-300">{formatTokenAmount(stream.remainingBalance || stream.totalAmount)}</span>
+        </div>
+      </div>
+
+      <div className="w-full h-1.5 bg-gray-800 rounded-full overflow-hidden mb-3">
+        <div
+          className="h-full bg-gradient-to-r from-indigo-500 to-purple-500 rounded-full transition-all duration-200"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+
+      <div className="flex gap-2">
+        {!isSender && stream.status === 'Active' && (
+          <button
+            onClick={handleClaim}
+            disabled={loading}
+            className="flex-1 px-3 py-2 text-sm font-medium rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white disabled:opacity-50 transition-colors"
+          >
+            {loading ? 'Processing...' : 'Claim now'}
+          </button>
+        )}
+        {isSender && stream.status === 'Active' && (
+          <>
+            <button
+              onClick={handlePause}
+              disabled={loading}
+              className="flex-1 px-3 py-2 text-sm font-medium rounded-lg bg-yellow-600/20 hover:bg-yellow-600/40 text-yellow-400 border border-yellow-600/30 disabled:opacity-50 transition-colors"
+            >
+              Pause
+            </button>
+            <button
+              onClick={handleCancel}
+              disabled={loading}
+              className="flex-1 px-3 py-2 text-sm font-medium rounded-lg bg-red-600/20 hover:bg-red-600/40 text-red-400 border border-red-600/30 disabled:opacity-50 transition-colors"
+            >
+              Cancel
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/streams/StreamCreateForm.tsx
+++ b/frontend/components/streams/StreamCreateForm.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+const RATE_PRECISION = 10_000_000;
+
+const COMMON_TOKENS = [
+  { label: 'USDC', address: 'GA5ZSEJYB37JDD5G4LYQCI7ADR7YLFGRMHEZ2EWWGISFCCBOJH2O2UA7' },
+  { label: 'XLM', address: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVSNYHQ2WTHASPFTKEJ7ICIRXXWJ' },
+];
+
+function formatDuration(totalSeconds) {
+  if (!totalSeconds || totalSeconds <= 0) return 'N/A';
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const parts = [];
+  if (days > 0) parts.push(`${days} day${days !== 1 ? 's' : ''}`);
+  if (hours > 0) parts.push(`${hours} hour${hours !== 1 ? 's' : ''}`);
+  if (parts.length === 0) {
+    const mins = Math.ceil(totalSeconds / 60);
+    parts.push(`${mins} minute${mins !== 1 ? 's' : ''}`);
+  }
+  return parts.join(' ');
+}
+
+export default function StreamCreateForm({ onCreated }) {
+  const [recipient, setRecipient] = useState('');
+  const [tokenAddress, setTokenAddress] = useState(COMMON_TOKENS[0].address);
+  const [totalAmount, setTotalAmount] = useState('');
+  const [ratePerHour, setRatePerHour] = useState('');
+  const [startAt, setStartAt] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const ratePerSecond = useMemo(() => {
+    const perHour = parseFloat(ratePerHour);
+    if (!perHour || perHour <= 0) return null;
+    return Math.round((perHour / 3600) * RATE_PRECISION);
+  }, [ratePerHour]);
+
+  const duration = useMemo(() => {
+    const amount = parseFloat(totalAmount);
+    const rate = parseFloat(ratePerHour);
+    if (!amount || !rate || rate <= 0) return null;
+    return (amount / rate) * 3600;
+  }, [totalAmount, ratePerHour]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+
+    try {
+      const {
+        SorobanRpc,
+        TransactionBuilder,
+        Contract,
+        Address,
+        nativeToScVal,
+        xdr,
+        BASE_FEE,
+      } = await import('@stellar/stellar-sdk');
+      const { signWithFreighter } = await import('../../lib/soroban');
+
+      const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet';
+      const RPC_URL = process.env.NEXT_PUBLIC_SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org';
+      const CONTRACT = process.env.NEXT_PUBLIC_STREAMING_CONTRACT_ADDRESS || '';
+      const PASSPHRASE =
+        NETWORK === 'mainnet'
+          ? 'Public Global Stellar Network ; September 2015'
+          : 'Test SDF Network ; September 2015';
+
+      if (!CONTRACT) throw new Error('Streaming contract address not configured');
+
+      const server = new SorobanRpc.Server(RPC_URL);
+      const { freightsApi } = await import('@stellar/freighter-api');
+      const address = await freightsApi.getAddress();
+      const account = await server.getAccount(address);
+      const contract = new Contract(CONTRACT);
+
+      const bigTotal = BigInt(Math.round(parseFloat(totalAmount) * RATE_PRECISION));
+      const bigRate = BigInt(ratePerSecond);
+      const startTs = startAt
+        ? BigInt(Math.floor(new Date(startAt).getTime() / 1000))
+        : BigInt(Math.floor(Date.now() / 1000));
+
+      const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: PASSPHRASE })
+        .addOperation(
+          contract.call(
+            'create_stream',
+            new Address(address).toScVal(),
+            new Address(recipient).toScVal(),
+            new Address(tokenAddress).toScVal(),
+            nativeToScVal(bigTotal, { type: 'i128' }),
+            nativeToScVal(bigRate, { type: 'i128' }),
+            nativeToScVal(startTs, { type: 'u64' }),
+          ),
+        )
+        .setTimeout(300)
+        .build();
+
+      const prepared = await server.simulateTransaction(tx);
+      if (SorobanRpc.isSimulationError(prepared)) {
+        throw new Error(`Simulation failed: ${prepared.error}`);
+      }
+      const assembled = SorobanRpc.assembleTransaction(tx, prepared).build();
+      const signed = await signWithFreighter(assembled.toXDR('base64'));
+
+      const res = await fetch(`${API_URL}/api/escrows/broadcast`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ signedXdr: signed }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Broadcast failed');
+      }
+
+      setRecipient('');
+      setTotalAmount('');
+      setRatePerHour('');
+      onCreated?.();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="card p-6 space-y-4">
+      <h3 className="text-lg font-semibold text-white">Create Payment Stream</h3>
+
+      {error && (
+        <div className="p-3 bg-red-900/30 border border-red-800 rounded-lg text-red-400 text-sm">
+          {error}
+        </div>
+      )}
+
+      <div>
+        <label className="block text-sm text-gray-400 mb-1">Recipient Address</label>
+        <input
+          type="text"
+          value={recipient}
+          onChange={(e) => setRecipient(e.target.value)}
+          placeholder="G..."
+          required
+          className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded-lg text-white text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm text-gray-400 mb-1">Token</label>
+        <select
+          value={tokenAddress}
+          onChange={(e) => setTokenAddress(e.target.value)}
+          className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        >
+          {COMMON_TOKENS.map((t) => (
+            <option key={t.address} value={t.address}>
+              {t.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">Total Amount</label>
+          <input
+            type="number"
+            step="0.01"
+            min="0.01"
+            value={totalAmount}
+            onChange={(e) => setTotalAmount(e.target.value)}
+            placeholder="10000"
+            required
+            className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">Rate (tokens/hour)</label>
+          <input
+            type="number"
+            step="0.01"
+            min="0.01"
+            value={ratePerHour}
+            onChange={(e) => setRatePerHour(e.target.value)}
+            placeholder="50"
+            required
+            className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm text-gray-400 mb-1">Start Date/Time (optional)</label>
+        <input
+          type="datetime-local"
+          value={startAt}
+          onChange={(e) => setStartAt(e.target.value)}
+          className="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        />
+      </div>
+
+      {duration !== null && (
+        <p className="text-sm text-gray-400">
+          At this rate, funds will run out in{' '}
+          <span className="text-indigo-400 font-medium">{formatDuration(duration)}</span>
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={loading || !recipient || !totalAmount || !ratePerHour}
+        className="w-full px-4 py-2.5 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg disabled:opacity-50 transition-colors"
+      >
+        {loading ? 'Creating stream...' : 'Create Stream'}
+      </button>
+    </form>
+  );
+}

--- a/frontend/components/streams/StreamDashboard.tsx
+++ b/frontend/components/streams/StreamDashboard.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import useSWR from 'swr';
+import StreamCard from './StreamCard';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+const fetcher = (url) => fetch(url).then((r) => r.json());
+
+export default function StreamDashboard({ userAddress }) {
+  const [tab, setTab] = useState('all');
+
+  const { data, error, isLoading, mutate } = useSWR(
+    userAddress ? `${API_URL}/api/v1/streams?address=${userAddress}&limit=50` : null,
+    fetcher,
+    { refreshInterval: 15_000 },
+  );
+
+  const streams = data?.data || [];
+  const sending = streams.filter((s) => s.senderAddress === userAddress);
+  const receiving = streams.filter((s) => s.recipientAddress === userAddress);
+
+  const displayStreams =
+    tab === 'sending' ? sending : tab === 'receiving' ? receiving : streams;
+
+  const handleAction = useCallback(() => {
+    mutate();
+  }, [mutate]);
+
+  if (!userAddress) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-gray-500">Connect your wallet to view payment streams.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-xl font-bold text-white">Payment Streams</h2>
+        <div className="flex gap-1 bg-gray-900 rounded-lg p-1">
+          {['all', 'sending', 'receiving'].map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                tab === t
+                  ? 'bg-gray-700 text-white'
+                  : 'text-gray-400 hover:text-gray-200'
+              }`}
+            >
+              {t.charAt(0).toUpperCase() + t.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isLoading && (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="card p-4 animate-pulse">
+              <div className="h-4 bg-gray-800 rounded w-1/3 mb-3" />
+              <div className="h-3 bg-gray-800 rounded w-1/2 mb-2" />
+              <div className="h-3 bg-gray-800 rounded w-1/4" />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <div className="card p-4 border-red-800">
+          <p className="text-red-400 text-sm">Failed to load streams. Retrying...</p>
+        </div>
+      )}
+
+      {!isLoading && !error && displayStreams.length === 0 && (
+        <div className="text-center py-12">
+          <p className="text-gray-500 mb-2">No payment streams found.</p>
+          <p className="text-gray-600 text-sm">Create a new stream to get started.</p>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {tab === 'all' && (
+          <>
+            <div>
+              <h3 className="text-sm font-medium text-gray-400 mb-3 uppercase tracking-wider">
+                Sending ({sending.length})
+              </h3>
+              {sending.map((s) => (
+                <StreamCard
+                  key={s.streamId.toString()}
+                  stream={s}
+                  role="sender"
+                  onAction={handleAction}
+                />
+              ))}
+              {sending.length === 0 && !isLoading && (
+                <p className="text-gray-600 text-sm py-4">No outgoing streams</p>
+              )}
+            </div>
+            <div>
+              <h3 className="text-sm font-medium text-gray-400 mb-3 uppercase tracking-wider">
+                Receiving ({receiving.length})
+              </h3>
+              {receiving.map((s) => (
+                <StreamCard
+                  key={s.streamId.toString()}
+                  stream={s}
+                  role="recipient"
+                  onAction={handleAction}
+                />
+              ))}
+              {receiving.length === 0 && !isLoading && (
+                <p className="text-gray-600 text-sm py-4">No incoming streams</p>
+              )}
+            </div>
+          </>
+        )}
+
+        {tab !== 'all' && (
+          <div className={tab === 'sending' ? '' : ''}>
+            {displayStreams.map((s) => (
+              <StreamCard
+                key={s.streamId.toString()}
+                stream={s}
+                role={tab === 'sending' ? 'sender' : 'recipient'}
+                onAction={handleAction}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/hooks/useStreamAccrual.ts
+++ b/frontend/hooks/useStreamAccrual.ts
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+const RATE_PRECISION = 10_000_000;
+
+/**
+ * Hook that provides a live-updating accrued balance for a payment stream.
+ * Uses requestAnimationFrame for smooth 60fps animation without polling.
+ *
+ * @param {Object} stream - Stream data with ratePerSecond, lastClaimTime, startAt, remainingBalance, status, paused
+ * @returns {{ accrued: string, progress: number }}
+ */
+export function useStreamAccrual(stream) {
+  const [accrued, setAccrued] = useState('0');
+  const [progress, setProgress] = useState(0);
+  const rafRef = useRef(null);
+  const lastValueRef = useRef(0);
+
+  const computeAccrued = useCallback(() => {
+    if (!stream) return { value: 0, progress: 0 };
+
+    const ratePerSecond = Number(stream.ratePerSecond);
+    const remainingBalance = Number(stream.remainingBalance);
+    const totalAmount = Number(stream.totalAmount);
+    const startAt = Number(stream.startAt) / 1000; // convert ms to seconds
+    const lastClaimTime = Number(stream.lastClaimedAt)
+      ? Number(stream.lastClaimedAt) / 1000
+      : startAt;
+
+    if (
+      stream.status !== 'Active' ||
+      stream.paused ||
+      remainingBalance <= 0
+    ) {
+      return { value: 0, progress: totalAmount > 0 ? ((totalAmount - remainingBalance) / totalAmount) * 100 : 0 };
+    }
+
+    const now = Date.now() / 1000;
+    if (now <= startAt) {
+      return { value: 0, progress: 0 };
+    }
+
+    const baseline = lastClaimTime < startAt ? startAt : lastClaimTime;
+    const elapsed = Math.max(0, now - baseline);
+    const rawAccrued = elapsed * ratePerSecond / RATE_PRECISION;
+    const value = Math.min(rawAccrued, remainingBalance);
+    const drained = totalAmount - remainingBalance + value;
+    const progressPct = totalAmount > 0 ? (drained / totalAmount) * 100 : 0;
+
+    return { value, progress: Math.min(progressPct, 100) };
+  }, [stream]);
+
+  useEffect(() => {
+    if (!stream) return;
+
+    const tick = () => {
+      const { value, progress: pct } = computeAccrued();
+      if (value !== lastValueRef.current) {
+        lastValueRef.current = value;
+        setAccrued(value.toFixed(7));
+        setProgress(pct);
+      }
+      rafRef.current = requestAnimationFrame(tick);
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [computeAccrued, stream]);
+
+  return { accrued, progress };
+}


### PR DESCRIPTION
Closes #1460 

# feat: implement per-second payment streaming (Soroban contract, indexer, frontend)

## Summary

Full-stack implementation of per-second payment streaming, spanning three layers:

- **Soroban contract** (`contracts/streaming_payment`) — escrows tokens on `create_stream`
  and drains them to the recipient at a fixed `rate_per_second`, with pause/resume/cancel
  and a pure, testable accrual calculation.
- **Backend ledger-tick indexer** (`backend/services/streamingIndexer.js`) — polls the
  Stellar RPC for the contract's events and mirrors stream state into Postgres, plus a
  REST API (`streamController.js` / `streamRoutes.js`) for listing streams, reading live
  accrual, and building unsigned claim XDR.
- **Frontend real-time drain visualization** (`frontend/components/streams/*`,
  `useStreamAccrual` hook) — a dashboard of sending/receiving streams with a
  `requestAnimationFrame`-driven live balance, no polling required for the animation
  itself.

Closes #

## Changes

- `contracts/streaming_payment/src/lib.rs` — `create_stream`, `claim`, `pause`, `resume`,
  `cancel`, `accrued` entry points on `StreamingPaymentContract`
- `contracts/streaming_payment/src/{types,storage,events,errors}.rs` — `Stream` /
  `StreamStatus` / `DataKey` types, persistent storage helpers, event emission
  (`str_crt`, `str_clm`, `str_pau`, `str_res`, `str_can`, `str_drn`), error enum
- `contracts/streaming_payment/src/tests.rs` — 12-test suite covering creation, accrual,
  claiming, pause/resume, cancel splits, and completed/cancelled-state guards
- `backend/services/streamingIndexer.js` — event-driven indexer with idempotent upserts
  for `StreamCreated`/`StreamClaimed`/`StreamCancelled`, ledger-cursor persistence via
  `IndexerState` (id `2`, separate cursor slot from the escrow indexer)
- `backend/api/controllers/streamController.js` + `backend/api/routes/streamRoutes.js` —
  `GET /streams`, `GET /streams/:id`, `GET /streams/:id/accrued` (live contract
  simulation, uncached), `POST /streams/:id/claim` (builds unsigned claim XDR for the
  client to sign)
- `backend/database/schema.prisma` — new `PaymentStream` model (`payment_streams` table)
  with sender/recipient/status indexes
- `backend/server.js` — wires the streaming router and starts `streamingIndexer` alongside
  the existing escrow indexer
- `frontend/components/streams/{StreamDashboard,StreamCard,StreamCreateForm}.tsx` —
  sending/receiving tabs, per-stream drain UI, create-stream form
- `frontend/hooks/useStreamAccrual.ts` — client-side accrual mirror of the contract's
  `_accrued_amount` logic, driven by `requestAnimationFrame` for smooth 60fps updates
  between the dashboard's 15s SWR refresh
- `backend/tests/unit/streamingIndexer.test.js`,
  `backend/tests/integration/streamLifecycle.test.js` — indexer unit tests and an
  end-to-end stream lifecycle integration test

## Design notes

- **Accrual baseline is `last_claim_time`, not `start_at`.** Every claim/pause advances
  `last_claim_time` to the current ledger timestamp so accrual always resumes from the
  last settlement point rather than re-accruing from the stream's original start. `resume`
  resets both `start_at` and `last_claim_time` to "now" so a paused stream doesn't
  retroactively accrue for the time it was paused.
- **`accrued` is capped at `remaining_balance`** in every call site (`claim`, `pause`,
  `cancel`, the `accrued` view), so a long-idle claim can never transfer more than what's
  actually escrowed, even if `elapsed * rate_per_second` overshoots.
- **`cancel` settles the recipient before returning funds to the sender** — it claims
  whatever's accrued-but-unclaimed first, then refunds the remainder, so cancelling never
  claws back time the recipient already earned.
- **Frontend accrual math is a client-side mirror of `_accrued_amount`**, not a source of
  truth — `useStreamAccrual` only smooths the visual countdown between real data refreshes;
  the authoritative value is always `GET /streams/:id/accrued`, which simulates the
  contract's `accrued()` view directly against RPC.
- **Indexer uses a separate `IndexerState` row (`id: 2`)** from the existing escrow indexer
  (`id: 1`), so the two pollers track independent cursors and a fault in one never stalls
  the other.

## Testing

```bash
cargo test -p streaming_payment
```

- **12 passed, 0 failed** — `test_create_stream_escrows_tokens`,
  `test_accrued_after_ten_seconds`, `test_accrued_returns_zero_before_start_at`,
  `test_claim_before_start_returns_zero`, `test_claim_transfers_correct_amount`,
  `test_multiple_claims_accumulate`, `test_pause_stops_accrual`,
  `test_pause_on_already_paused_is_noop`, `test_resume_restarts_accrual`,
  `test_cancel_splits_correctly`, `test_cancel_on_completed_stream_is_error`,
  `test_stream_count_increments`

```bash
npm run test -w backend -- tests/unit/streamingIndexer.test.js tests/integration/streamLifecycle.test.js
npm run lint
```

- **Not run in this environment** — `backend/node_modules` is a partial install missing
  transitive deps (e.g. `picomatch`), so `jest` fails to boot here regardless of which
  test file is targeted. Run `npm install` in `backend/` and re-run the command above
  before merging.

## Review Notes

- The `accrued` endpoint and claim-XDR builder both hit Soroban RPC live (uncached) —
  worth a look for rate-limit/timeout handling under load.
- No auth check currently gates `buildClaimXdr` beyond requiring `recipientAddress` in the
  body; the contract's `require_auth()` is the actual enforcement point since the client
  still has to sign the XDR as that recipient, but flagging in case the API is expected to
  pre-validate the caller against `req.user`.
- Follow-up: `streamRoutes.js` / indexer `POLL_INTERVAL_MS` and `STREAMING_CONTRACT_ID` env
  vars aren't yet documented in `.env.example` — should be added before deploy.

### Migration checklist

Required for any PR that changes `backend/database/migrations/**` or `prisma/migrations/**`.

- [ ] Migration is backward-compatible with the previous version of the app code
- [x] New NOT NULL columns have a DEFAULT or are added in a separate migration after backfill
      (`PaymentStream` is a wholly new table — no backfill required)
- [ ] No table locks held for more than 100ms at expected table sizes
- [ ] Rollback plan documented below

#### Rollback plan

`PaymentStream` is a new table with no existing readers; rollback is `DROP TABLE
payment_streams` (or the inverse of whichever migration file adds it — none has been
generated yet in this diff, so run `npx prisma migrate dev` to create one before merging).

## Checklist

- [x] Code compiles (`cargo test -p streaming_payment` passes)
- [x] Tests were added for the new contract, indexer, and stream lifecycle
- [ ] Backend `jest` / `eslint` were not run — incomplete local `node_modules` (see Testing)
- [ ] Documentation (`.env.example`) not yet updated with new env vars
- [ ] No breaking changes — additive only (new table, new routes, new contract)
- [ ] Screenshots not included for the new dashboard/create-form UI
